### PR TITLE
Adds new repository r-renato/ha-card-waze-travel-time

### DIFF
--- a/plugin
+++ b/plugin
@@ -60,5 +60,6 @@
   "amaximus/garbage-collection-card",
   "AmoebeLabs/flex-horseshoe-card",
   "r-renato/hass-xiaomi-mi-flora-and-flower-care",
+  "r-renato/ha-card-waze-travel-time",
   "azuwis/zigbee2mqtt-networkmap"
 ]


### PR DESCRIPTION
Added a new plugin repository containing a waze lovelace card.

Before you submit a pull request, please make sure you have to following:

- [x] You are submitting only 1 repository.
- [x] You repository is compliant with https://hacs.xyz/docs/publish/start
- [x] You have tested it with HACS by adding it as a custom repository
