### PR TITLE
Adds new plugin [bokub/rgb-light-card]

### DIFF
--- a/plugin
+++ b/plugin
@@ -61,5 +61,6 @@
   "AmoebeLabs/flex-horseshoe-card",
   "r-renato/hass-xiaomi-mi-flora-and-flower-care",
   "r-renato/ha-card-waze-travel-time",
-  "azuwis/zigbee2mqtt-networkmap"
+  "azuwis/zigbee2mqtt-networkmap",
+  "bokub/rgb-light-card"
 ]


### PR DESCRIPTION
I'm adding [RGB Light Card](https://github.com/bokub/rgb-light-card) as a default repository

- [x] You are submitting only 1 repository.
- [x] You repository is compliant with https://hacs.xyz/docs/publish/start
- [x] You have tested it with HACS by adding it as a custom repository
