### PR TITLE
Adds new integration [ryannazaretian/hacs-nexia-climate-integration]

### DIFF
--- a/integration
+++ b/integration
@@ -136,5 +136,6 @@
   "freakshock88/hass-populartimes",
   "shogunxam/Home-Assistant-custom-components-cfr-toscana",
   "fineemb/Yeelink-ven-fan",
-  "gcobb321/icloud3"
+  "gcobb321/icloud3",
+  "ryannazaretian/hacs-nexia-climate-integration"
 ]


### PR DESCRIPTION
The Nexia Climate integration supports Trane and American Standard thermostats connected to the Nexia service.

Before you submit a pull request, please make sure you have the following:

- [X] You are submitting only 1 repository.
- [X] You repository is compliant with https://hacs.xyz/docs/publish/start
- [X] You have tested it with HACS by adding it as a custom repository
