### PR TITLE
Adds new appdaemon [ubhits/ad-alexatalkingclock]

### DIFF
--- a/appdaemon
+++ b/appdaemon
@@ -11,5 +11,6 @@
   "bieniu/ha-ad-thermostats-update",
   "ludeeus/ad-watchdog",
   "eifinger/appdaemon-deconz-xiaomi-button",
-  "xaviml/z2m_ikea_controller"
+  "xaviml/z2m_ikea_controller",
+  "ubhits/ad-alexatalkingclock"
 ]


### PR DESCRIPTION
This allows users to make their amazon alexa speak out the time at specified intervals of hourly, half hourly or quarter hourly

Before you submit a pull request, please make sure you have the following:

- [ ] You are submitting only 1 repository.
- [ ] You repository is compliant with https://hacs.xyz/docs/publish/start
- [ ] You have tested it with HACS by adding it as a custom repository
