### PR TITLE
Adds new appdaemon [UbhiTS/ad-alexatalkingclock]

### DIFF
--- a/appdaemon
+++ b/appdaemon
@@ -11,5 +11,6 @@
   "bieniu/ha-ad-thermostats-update",
   "ludeeus/ad-watchdog",
   "eifinger/appdaemon-deconz-xiaomi-button",
-  "xaviml/z2m_ikea_controller"
+  "xaviml/z2m_ikea_controller",
+  "UbhiTS/ad-alexatalkingclock"
 ]


### PR DESCRIPTION
This app allows you to make Amazon Alexa speak the time at specified intervals of hourly, half hourly or quarter hourly.

Before you submit a pull request, please make sure you have the following:

- [x] You are submitting only 1 repository.
- [x] You repository is compliant with https://hacs.xyz/docs/publish/start
- [x] You have tested it with HACS by adding it as a custom repository
