### PR TITLE
Adds new integration [jcwillox/hass-auto-backup]

### DIFF
--- a/integration
+++ b/integration
@@ -139,5 +139,6 @@
   "fineemb/Yeelink-ven-fan",
   "gcobb321/icloud3",
   "remco770/garbage-bar-homeassistant",
-  "tomaae/homeassistant-mikrotik_router"
+  "tomaae/homeassistant-mikrotik_router",
+  "jcwillox/hass-auto-backup"
 ]


### PR DESCRIPTION
Improved backup service for Hass.io that can automatically remove snapshots and supports generational backup schemes.

Before you submit a pull request, please make sure you have the following:

- [x] You are submitting only 1 repository.
- [x] You repository is compliant with https://hacs.xyz/docs/publish/start
- [x] You have tested it with HACS by adding it as a custom repository
