### PR TITLE
Adds new integration [Cyr-ius/hass-cozytouch]

### DIFF
--- a/integration
+++ b/integration
@@ -160,5 +160,5 @@
   "cyberjunky/home-assistant-toon_climate",
   "rsnodgrass/hass-adtpulse",
   "rsnodgrass/hass-flo-water",
-  "cyr-ius/hass-cozytouch"
+  "Cyr-ius/hass-cozytouch"
 ]

--- a/integration
+++ b/integration
@@ -160,5 +160,5 @@
   "cyberjunky/home-assistant-toon_climate",
   "rsnodgrass/hass-adtpulse",
   "rsnodgrass/hass-flo-water",
-  "Cyr-ius/hass-cozytouch"
+  "cyr-ius/hass-cozytouch"
 ]

--- a/integration
+++ b/integration
@@ -159,5 +159,6 @@
   "cyberjunky/home-assistant-toon_smartmeter",
   "cyberjunky/home-assistant-toon_climate",
   "rsnodgrass/hass-adtpulse",
-  "rsnodgrass/hass-flo-water"
+  "rsnodgrass/hass-flo-water",
+  "Cyr-ius/hass-cozytouch"
 ]


### PR DESCRIPTION
Added Cyr-ius/hass-cozytouch for Cozytouch devices
 
- Sensor with temperature, occupancy, electricalpower metrics, ...
- Climate sensor with preset mode
- Water Heater sensor with hvac mode , boost mode , wway

Before you submit a pull request, please make sure you have the following:

- [X] You are submitting only 1 repository.
- [X] You repository is compliant with https://hacs.xyz/docs/publish/start
- [X] You have tested it with HACS by adding it as a custom repository
