### PR TITLE
Adds new integration [Cyr-ius/hass-livebox-component]

### DIFF
--- a/integration
+++ b/integration
@@ -159,5 +159,6 @@
   "cyberjunky/home-assistant-toon_smartmeter",
   "cyberjunky/home-assistant-toon_climate",
   "rsnodgrass/hass-adtpulse",
-  "rsnodgrass/hass-flo-water"
+  "rsnodgrass/hass-flo-water",
+  "Cyr-ius/hass-livebox-component"
 ]


### PR DESCRIPTION
This a custom component for Home Assistant. The livebox integration allows you to observe and control Livebox router.

There is currently support for the following device types within Home Assistant:

    Sensor with traffic metrics
    Binary Sensor with wan status , public ip , private ip
    Device tracker for connected devices (via option add wired devices)
    Switch for enable/disable Wireless
    Service for restart the router

Before you submit a pull request, please make sure you have the following:

- [X] You are submitting only 1 repository.
- [X] You repository is compliant with https://hacs.xyz/docs/publish/start
- [X] You have tested it with HACS by adding it as a custom repository
