### PR TITLE
Adds new appdaemon [Petro31/ad_monitor_events]

### DIFF
--- a/appdaemon
+++ b/appdaemon
@@ -17,5 +17,6 @@
   "UbhiTS/ad-alexatalkingclock",
   "Burningstone91/Hue_Dimmer_Deconz",
   "jmarsik/ad-eurotronic-trv-valvepos",
-  "Petro31/IlluminateDoor"
+  "Petro31/IlluminateDoor",
+  "Petro31/ad_monitor_events"
 ]


### PR DESCRIPTION
Add a new event monitor that places events in specified log locations.