### PR TITLE
Adds new theme [JuanMTech/google_dark_theme]

### DIFF
--- a/theme
+++ b/theme
@@ -10,5 +10,6 @@
   "aFFekopp/dark_teal",
   "arsaboo/oxford_blue_theme",
   "aFFekopp/noctis", 
-  "am80l/sundown"
+  "am80l/sundown",
+  "JuanMTech/google_dark_theme"
 ]


### PR DESCRIPTION
Adding a Home Assistant theme inspired on Google app dark mode to the default repository.

Before you submit a pull request, please make sure you have the following:

- [x] You are submitting only 1 repository.
- [x] You repository is compliant with https://hacs.xyz/docs/publish/start
- [x] You have tested it with HACS by adding it as a custom repository
