### PR TITLE
Adds new theme [JuanMTech/google_light_theme]

### DIFF
--- a/theme
+++ b/theme
@@ -11,5 +11,6 @@
   "arsaboo/oxford_blue_theme",
   "aFFekopp/noctis", 
   "am80l/sundown",
-  "JuanMTech/google_dark_theme"
+  "JuanMTech/google_dark_theme",
+  "JuanMTech/google_light_theme"
 ]


### PR DESCRIPTION
Adding a Home Assistant theme inspired on Google app light mode to the default repository.

Before you submit a pull request, please make sure you have the following:

- [x] You are submitting only 1 repository.
- [x] You repository is compliant with https://hacs.xyz/docs/publish/start
- [x] You have tested it with HACS by adding it as a custom repository
