### PR TITLE
Adds new appdaemon [Petro31/ad_people_tracker]

### DIFF
--- a/appdaemon
+++ b/appdaemon
@@ -19,5 +19,6 @@
   "jmarsik/ad-eurotronic-trv-valvepos",
   "Petro31/IlluminateDoor",
   "Petro31/ad_monitor_events",
-  "simonhq/Clean-GTFS" 
+  "simonhq/Clean-GTFS",
+  "Petro31/ad_people_tracker"
 ]


### PR DESCRIPTION
Adds new people tracking sensor.

Before you submit a pull request, please make sure you have the following:

- [ x] You are submitting only 1 repository.
- [x ] You repository is compliant with https://hacs.xyz/docs/publish/start
- [ x] You have tested it with HACS by adding it as a custom repository
