### PR TITLE
Rename appdaemon repository z2m_ikea_controller -> controllerx

### DIFF
--- a/appdaemon
+++ b/appdaemon
@@ -13,7 +13,7 @@
   "bieniu/ha-ad-thermostats-update",
   "ludeeus/ad-watchdog",
   "eifinger/appdaemon-deconz-xiaomi-button",
-  "xaviml/z2m_ikea_controller",
+  "xaviml/controllerx",
   "UbhiTS/ad-alexatalkingclock",
   "Burningstone91/Hue_Dimmer_Deconz",
   "jmarsik/ad-eurotronic-trv-valvepos",


### PR DESCRIPTION
`z2m_ikea_controller` repository has been renamed to `controllerx`

Before you submit a pull request, please make sure you have the following:

- [X] You are submitting only 1 repository.
- [X] You repository is compliant with https://hacs.xyz/docs/publish/start
- [X] You have tested it with HACS by adding it as a custom repository
