### PR TITLE
Adds new appdaemon [Petro31/ad_group_all]

### DIFF
--- a/appdaemon
+++ b/appdaemon
@@ -22,5 +22,6 @@
   "simonhq/Clean-GTFS",
   "so3n/Bring-Back-group.all_x",
   "AaronDavidSchneider/SonosAlarmAutomation",
-  "Petro31/ad_people_tracker"
+  "Petro31/ad_people_tracker",
+  "Petro31/ad_group_all"
 ]


### PR DESCRIPTION
Adds appdaemon app that creates group.all_* and keeps them up to date with the current integrations and entities.

Before you submit a pull request, please make sure you have the following:

- [x ] You are submitting only 1 repository.
- [x ] You repository is compliant with https://hacs.xyz/docs/publish/start
- [x ] You have tested it with HACS by adding it as a custom repository
