### PR TITLE
Adds new integration [PTST/O365-HomeAssistant]

### DIFF
--- a/blacklist
+++ b/blacklist
@@ -50,6 +50,7 @@
   "maykar/compact-custom-header",
   "Michsior14/ha-kaiterra",
   "Michsior14/ha-laser-egg",
+  "PTST/O365Calendar-HomeAssistant",
   "Rocka84/dual-gauge-card",
   "shaonianzhentan/ha-cloud-music",
   "tenly2000/HomeAssistant-Places",

--- a/integration
+++ b/integration
@@ -140,7 +140,7 @@
   "pippyn/Home-Assistant-Sensor-Groningen-Afvalwijzer",
   "pippyn/Home-Assistant-Sensor-Ophaalkalender",
   "ptimatth/GeorideHA",
-  "PTST/O365Calendar-HomeAssistant",
+  "PTST/O365-HomeAssistant",
   "r-renato/hass-xiaomi-mi-flora-and-flower-care",
   "rdehuyss/homeassistant-custom_components-denkovi",
   "reharmsen/hass-youless-component",


### PR DESCRIPTION
PTST/O365Calendar-HomeAssistant has been renamed to PTST/O365-HomeAssistant due to upcoming changes to this integration enabling wider O365 use than just calendars

Before you submit a pull request, please make sure you have done the following:

- [x] You are submitting only 1 repository.
- [x] You repository is compliant with https://hacs.xyz/docs/publish/start
- [x] You have tested it with HACS by adding it as a custom repository.
- [x] The list are still alphabetical after my change.

<!-- You as the submitter need to check all these boxes before it's mergable -->