### PR TITLE
Adds new integration [ryannazaretian/hacs-nexia-climate-integration]

### DIFF
--- a/integration
+++ b/integration
@@ -66,6 +66,8 @@
   "edenhaus/ha-prosenic",
   "eifinger/open_route_service",
   "elad-bar/ha-blueiris",
+  "elad-bar/ha-dahuavto",
+  "elad-bar/ha-hpprinter",
   "exKAjFASH/media_player.elkoep_lara",
   "fineemb/Xiaomi-Smart-Multipurpose-Kettle",
   "fineemb/Yeelink-ven-fan",
@@ -165,6 +167,7 @@
   "rsnodgrass/hass-sensorpush",
   "rt400/School-Vacation",
   "ryanmac8/Home-Assistant-Marta",
+  "ryannazaretian/hacs-nexia-climate-integration",
   "safepay/cover.hd_powerview",
   "safepay/sensor.fronius",
   "safepay/sensor.willyweather",
@@ -200,8 +203,5 @@
   "xirixiz/Home-Assistant-Sensor-Afvalwijzer",
   "xMrVizzy/Minecraft-Version",
   "xMrVizzy/Philips-AirPurifier",
-  "zachowj/hass-node-red",
-  "elad-bar/ha-hpprinter",
-  "elad-bar/ha-dahuavto",
-  "ryannazaretian/hacs-nexia-climate-integration"
+  "zachowj/hass-node-red"
 ]

--- a/integration
+++ b/integration
@@ -202,5 +202,6 @@
   "xMrVizzy/Philips-AirPurifier",
   "zachowj/hass-node-red",
   "elad-bar/ha-hpprinter",
-  "elad-bar/ha-dahuavto"
+  "elad-bar/ha-dahuavto",
+  "ryannazaretian/hacs-nexia-climate-integration"
 ]


### PR DESCRIPTION
Integrates Trane and American Standard thermostats connected to Nexia. 

See thread: https://community.home-assistant.io/t/nexia-and-trane-xl1050-xl850-thermostat/48673

Before you submit a pull request, please make sure you have done the following:

- [X] You are submitting only 1 repository.
- [X] You repository is compliant with https://hacs.xyz/docs/publish/start
- [X] You have tested it with HACS by adding it as a custom repository.
- [X] The list are still alphabetical after my change.

<!-- You as the submitter need to check all these boxes before it's mergable -->