### PR TITLE
Adds new appdaemon [UbhiTS/ad-alexadoorbell]

### DIFF
--- a/appdaemon
+++ b/appdaemon
@@ -37,6 +37,7 @@
   "so3n/Appdaemon-Xiaomi-Doorbell",
   "so3n/Appdaemon-Xiaomi-Smart-Button",
   "so3n/Bring-Back-group.all_x",
+  "UbhiTS/ad-alexadoorbell",
   "UbhiTS/ad-alexatalkingclock",
   "vash3d/nethassmo",
   "xaviml/controllerx"


### PR DESCRIPTION
You can also :-

add a door sensor (like the Ecolink Door Sensor or any other) to the setup to only ring the bell if the door is currently closed, and has been closed for the last 30 seconds or more. This is so that the bell only rings when someone arrives at your door and not when you step out.
add an outdoor Alexa to greet your guest with a pleasant message based on the time of day
add a doorbell (like the Aeotec Doorbell or any other) to ring when a guest arrives outside your door

Before you submit a pull request, please make sure you have done the following:

- [X] You are submitting only 1 repository.
- [X] You repository is compliant with https://hacs.xyz/docs/publish/start
- [X] You have tested it with HACS by adding it as a custom repository.
- [X] The list are still alphabetical after my change.

<!-- You as the submitter need to check all these boxes before it's mergable -->