### PR TITLE
Adds new appdaemon [UbhiTS/ad-autointernetrebooter]

### DIFF
--- a/appdaemon
+++ b/appdaemon
@@ -40,6 +40,7 @@
   "UbhiTS/ad-alexadoorbell",
   "UbhiTS/ad-alexadoorwindowannounce",
   "UbhiTS/ad-alexatalkingclock",
+  "UbhiTS/ad-autointernetrebooter",
   "vash3d/nethassmo",
   "xaviml/controllerx"
 ]


### PR DESCRIPTION
Automatically reboot your internet if you use a Zwave, Zigbee, or Bluetooth switch/socket on your internet modem. This app WILL NOT WORK with WiFi Switches/Sockets

Before you submit a pull request, please make sure you have done the following:

- [X] You are submitting only 1 repository.
- [X] You repository is compliant with https://hacs.xyz/docs/publish/start
- [X] You have tested it with HACS by adding it as a custom repository.
- [X] The list are still alphabetical after my change.

<!-- You as the submitter need to check all these boxes before it's mergable -->