### PR TITLE
Adds new appdaemon [Mohlsson/ReplyLightsHistory]

### DIFF
--- a/appdaemon
+++ b/appdaemon
@@ -20,6 +20,7 @@
   "haberda/update_lights",
   "jmarsik/ad-eurotronic-trv-valvepos",
   "ludeeus/ad-watchdog",
+  "Mohlsson/ReplyLightsHistory",
   "Odianosen25/Monitor-App",
   "Petro31/ad_convert_media_volume",
   "Petro31/ad_group_all",


### PR DESCRIPTION
This is an AppDaemon App for Home Assistant that is designed to replays your lights behavior when no one is home. There are multiple other approaches out there that try to simulate behavior, which is hard. This approach simply uses your smart devices previous behavior to control their pending behavior.

Before you submit a pull request, please make sure you have done the following:

- [ ] You are submitting only 1 repository.
- [ ] You repository is compliant with https://hacs.xyz/docs/publish/start
- [ ] You have tested it with HACS by adding it as a custom repository.
- [ ] The list are still alphabetical after my change.

<!-- You as the submitter need to check all these boxes before it's mergable -->