### PR TITLE
Adds new integration [vanstinator/hass-raincloud]

### DIFF
--- a/integration
+++ b/integration
@@ -275,6 +275,7 @@
   "twrecked/hass-momentary",
   "twrecked/hass-virtual",
   "tybritten/ical-sensor-homeassistant",
+  "vanstinator/hass-raincloud",
   "Verbalinsurection/next_rocket_launch",
   "vigonotion/hass-simpleicons",
   "vinteo/hass-opensprinkler",


### PR DESCRIPTION
This is currently an official HA integration. But it's a web scraper. I'm in the process of publishing to HACS _before_ issuing deprecation PRs to HA-core.

Before you submit a pull request, please make sure you have done the following:

- [x] You are submitting only 1 repository.
- [x] You repository is compliant with https://hacs.xyz/docs/publish/start
- [x] You have tested it with HACS by adding it as a custom repository.
- [x] The list are still alphabetical after my change.