### PR TITLE
Remove surveillance-card from blacklist

### DIFF
--- a/blacklist
+++ b/blacklist
@@ -17,7 +17,6 @@
   "custom-cards/marquee-state-element",
   "custom-cards/monster-card",
   "custom-cards/muuri-grid",
-  "custom-cards/surveillance-card",
   "custom-cards/timer-card",
   "custom-cards/tracker-card",
   "custom-components/binary_sensor.hadockermon",


### PR DESCRIPTION
I've updated the repository (https://github.com/custom-cards/surveillance-card) with the hacs.json file and I've been using this card for a long while and it works on `0.110`.

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
-->

Before you submit a pull request, please make sure you have done the following:

- [x] You are submitting only 1 repository.
- [x] You repository is compliant with https://hacs.xyz/docs/publish/start
- [x] You have tested it with HACS by adding it as a custom repository.
- [x] The list are still alphabetical after my change.

<!-- 
You as the submitter need to check all these boxes before it's mergable 
-->
