### PR TITLE
Remove HACS support from Oura Component

### DIFF
--- a/blacklist
+++ b/blacklist
@@ -54,6 +54,7 @@
   "maykar/compact-custom-header",
   "Michsior14/ha-kaiterra",
   "Michsior14/ha-laser-egg",
+  "nitobuendia/oura-custom-component",
   "pippyn/Home-Assistant-Sensor-Ophaalkalender",
   "PTST/O365Calendar-HomeAssistant",
   "robmarkcole/HASS-Sighthound",

--- a/integration
+++ b/integration
@@ -193,7 +193,6 @@
   "nagyrobi/home-assistant-custom-components-cover-rf-time-based",
   "nickneos/HA_harmony_climate_component",
   "nikrolls/homeassistant-goldair-climate",
-  "nitobuendia/oura-custom-component",
   "nstrelow/ha_philips_android_tv",
   "ntilley905/faastatus",
   "ollo69/ha-samsungtv-smart",


### PR DESCRIPTION
Oura Component is removing HACS support as a protest to the decision of deprecating YAML.

You can read more on the [component issue #1](https://github.com/nitobuendia/oura-custom-component/issues/1).

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
-->

Before you submit a pull request, please make sure you have done the following:

- [x] You are submitting only 1 repository.
- [x] You repository is compliant with https://hacs.xyz/docs/publish/start
- [x] You have tested it with HACS by adding it as a custom repository.
- [x] The list are still alphabetical after my change.

<!-- 
You as the submitter need to check all these boxes before it's mergable 
-->
