### PR TITLE
Adds new plugin [deblockt/hass-proscenic-790T-vacuum]

### DIFF
--- a/plugin
+++ b/plugin
@@ -24,6 +24,7 @@
   "DarkFox/rejseplanen-card",
   "DavidFW1960/bom-weather-card",
   "dcramer/lovelace-nextbus-card",
+  "deblockt/hass-proscenic-790T-vacuum",
   "denysdovhan/vacuum-card",
   "dimagoltsman/content-card-remote-control",
   "dimagoltsman/generic-remote-control-card",


### PR DESCRIPTION
- [x] You are submitting only 1 repository.
- [x] You repository is compliant with https://hacs.xyz/docs/publish/start
- [x] You have tested it with HACS by adding it as a custom repository.
- [x] The list are still alphabetical after my change.
