### PR TITLE
Adds new integration [deblockt/hass-proscenic-790T-vacuum]

### DIFF
--- a/integration
+++ b/integration
@@ -77,6 +77,7 @@
   "dave-code-ruiz/uhomeuponor",
   "DavidFW1960/bom_forecast",
   "DavidMStraub/homeassistant-homeconnect",
+  "deblockt/hass-proscenic-790T-vacuum",
   "dgomes/ha_erse",
   "djbulsink/panasonic_ac",
   "dlarrick/hass-kumo",


### PR DESCRIPTION
- [x] You are submitting only 1 repository.
- [x] You repository is compliant with https://hacs.xyz/docs/publish/start
- [x] You have tested it with HACS by adding it as a custom repository.
- [x] The list are still alphabetical after my change.
