### PR TITLE
Adds new integration [ppanagiotis/pymusiccast]

### DIFF
--- a/integration
+++ b/integration
@@ -224,6 +224,7 @@
   "pippyn/Home-Assistant-Sensor-Groningen-Afvalwijzer",
   "Poeschl/Remote-PicoTTS",
   "Pouzor/freebox_player",
+  "ppanagiotis/pymusiccast",
   "ptimatth/GeorideHA",
   "PTST/O365-HomeAssistant",
   "py-smart-gardena/hass-gardena-smart-system",


### PR DESCRIPTION
Group MusicCast Yamaha Speakers with Home Assistant

Overwrite existing pymusiccast module to be able to group musiccast
yamaha speakers.

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
-->

Before you submit a pull request, please make sure you have done the following:

- [x] You are submitting only 1 repository.
- [x] You repository is compliant with https://hacs.xyz/docs/publish/start
- [x] You have tested it with HACS by adding it as a custom repository.
- [x] The list are still alphabetical after my change.

<!-- 
You as the submitter need to check all these boxes before it's mergable 
-->
