### PR TITLE
Remove cgarwood/homeassistant-zwave_mqtt as it is deprecated

### DIFF
--- a/integration
+++ b/integration
@@ -55,7 +55,6 @@
   "cagnulein/switchbot_press",
   "caiosweet/Home-Assistant-custom-components-DPC-Alert",
   "Ceerbeerus/beerbolaget",
-  "cgarwood/homeassistant-zwave_mqtt",
   "claudegel/sinope-1",
   "claudegel/sinope-130",
   "claudegel/sinope-gt125",


### PR DESCRIPTION
Remove the cgarwood/homeassistant-zwave_mqtt repo from the default HACS repos as it has been merged into HA core.

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
-->

Before you submit a pull request, please make sure you have done the following:

- [x] You are submitting only 1 repository.
- [x] You repository is compliant with https://hacs.xyz/docs/publish/start
- [x] You have tested it with HACS by adding it as a custom repository.
- [x] The list are still alphabetical after my change.

<!-- 
You as the submitter need to check all these boxes before it's mergable 
-->
