### PR TITLE
Adds new appdaemon [wernerhp/appdaemon_aqara_motion_sensors]

### DIFF
--- a/appdaemon
+++ b/appdaemon
@@ -52,6 +52,7 @@
   "UbhiTS/ad-autofanspeed",
   "UbhiTS/ad-autointernetrebooter",
   "vash3d/nethassmo",
+  "wernerhp/appdaemon_aqara_motion_sensors",
   "wernerhp/appdaemon_wasp",
   "xaviml/controllerx"
 ]


### PR DESCRIPTION
An AppDaemon app to reset Xiaomi Aqara motion sensors after a given timeout.

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
-->
