### PR TITLE
Removes obsolete integration [Limych/media_player.linkplay]

### DIFF
--- a/integration
+++ b/integration
@@ -231,7 +231,6 @@
   "Limych/ha-gismeteo",
   "Limych/ha-iaquk",
   "Limych/ha-jq300",
-  "Limych/media_player.linkplay",
   "lindell/home-assistant-svt-play",
   "lindell/home-assistant-tv4-play",
   "ljmerza/ha-email-sensor",


### PR DESCRIPTION
use `nagyrobi/home-assistant-custom-components-linkplay` instead

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
-->
