### PR TITLE
Remove retired integration amelchio/logbook_cache

### DIFF
--- a/integration
+++ b/integration
@@ -12,7 +12,6 @@
   "alryaz/hass-mosenergosbyt",
   "amaximus/bkk_stop",
   "amaximus/fkf-garbage-collection",
-  "amelchio/logbook_cache",
   "And3rsL/Deebot-for-hassio",
   "And3rsL/VisonicAlarm-for-Hassio",
   "andersonshatch/midea-ac-py",


### PR DESCRIPTION
This is no longer needed with current Home Assistant versions.

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
-->
