### PR TITLE
Adding Calendar TV Reminders AppDaemon App

### DIFF
--- a/appdaemon
+++ b/appdaemon
@@ -51,6 +51,7 @@
   "UbhiTS/ad-alexatalkingclock",
   "UbhiTS/ad-autofanspeed",
   "UbhiTS/ad-autointernetrebooter",
+  "UbhiTS/ad-calendartvreminders",
   "vash3d/nethassmo",
   "wernerhp/appdaemon_aqara_motion_sensors",
   "wernerhp/appdaemon_wasp",


### PR DESCRIPTION
Your TV notifies you of the next upcoming event from you calendar every time it turns on

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
-->
