### PR TITLE
Adds new integration [raman325/ha-zoom-automation]

### DIFF
--- a/integration
+++ b/integration
@@ -295,6 +295,7 @@
   "Pyhive/HA-Hive-Custom-Component",
   "r-renato/ha-climacell-weather",
   "r-renato/hass-xiaomi-mi-flora-and-flower-care",
+  "raman325/ha-zoom-automation",
   "rdehuyss/homeassistant-custom_components-denkovi",
   "reharmsen/hass-youless-component",
   "remco770/garbage-bar-homeassistant",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
-->
Hi,

I created a new integration that will allow users to set up webhook automations on events that occur in a user's Zoom account. As an example, I am currently using this integration to enable/disable a `do not disturb` signal for my wife when I enter and exit a Zoom meeting.

I submitted a PR to home-assistant/brands (home-assistant/brands#1804) but it has not been approved yet so that check my fail.

Cheers!