### PR TITLE
Adds new integration [swartjean/ha-eskom-loadshedding]

### DIFF
--- a/integration
+++ b/integration
@@ -340,6 +340,7 @@
   "sockless-coding/garo_wallbox",
   "sockless-coding/panasonic_cc",
   "StyraHem/ShellyForHASS",
+  "swartjean/ha-eskom-loadshedding",
   "tefinger/hass-brematic",
   "tellerbop/havistapool",
   "ThermIQ/thermiq_mqtt-ha",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
-->
Added a new integration, `eskom_loadshedding`. This integration provides loadshedding-related information pulled from the South African state electricity provider, Eskom.