### PR TITLE
Adds new plugin [DarkFox/rejseplanen-stog-card]

### DIFF
--- a/plugin
+++ b/plugin
@@ -57,6 +57,7 @@
   "CyrisXD/love-lock-card",
   "danimart1991/pvpc-hourly-pricing-card",
   "DarkFox/rejseplanen-card",
+  "DarkFox/rejseplanen-stog-card",
   "DavidFW1960/bom-weather-card",
   "DBa2016/power-usage-card-regex",
   "dcramer/lovelace-nextbus-card",


### PR DESCRIPTION
New card which displays Rejseplanen departures in the style of S-Tog departure boards.

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
-->
