### PR TITLE
Re-add xirixiz / homeassistant-afvalwijzer (fixed bug)

### DIFF
--- a/blacklist
+++ b/blacklist
@@ -73,6 +73,5 @@
   "shaonianzhentan/ha-cloud-music",
   "sinclairpaul/ha_purple_theme",
   "tenly2000/HomeAssistant-Places",
-  "xaviml/z2m_ikea_controller",
-  "xirixiz/Home-Assistant-Sensor-Afvalwijzer"
+  "xaviml/z2m_ikea_controller"
 ]

--- a/integration
+++ b/integration
@@ -389,6 +389,7 @@
   "vlumikero/home-assistant-securitas",
   "walthowd/ha-automower",
   "websylv/homeassistant-meteoswiss",
+  "xirixiz/homeassistant-afvalwijzer",
   "xMrVizzy/Minecraft-Version",
   "xMrVizzy/Philips-AirPurifier",
   "youdroid/home-assistant-couchpotato",

--- a/removed
+++ b/removed
@@ -332,12 +332,6 @@
     "link": "https://github.com/hacs/default/pull/577"
   },
   {
-    "repository": "xirixiz/Home-Assistant-Sensor-Afvalwijzer",
-    "reason": "Breaks HA startup",
-    "removal_type": "broken",
-    "link": "https://github.com/xirixiz/Home-Assistant-Sensor-Afvalwijzer/issues/68"
-  },
-  {
     "repository": "cbulock/lovelace-battery-entity",
     "reason": "Abandoned, not working properly",
     "removal_type": "remove",


### PR DESCRIPTION
Fixed bugs:
- systemexit causing a full exit/lock of hass