### PR TITLE
Adds new integration [abacao/hass_wibeee]

### DIFF
--- a/integration
+++ b/integration
@@ -2,6 +2,7 @@
   "5high/konke",
   "5high/phicomm-dc1-homeassistant",
   "AaronDavidSchneider/SonosAlarm",
+  "abacao/hass_wibeee",
   "AdamNaj/linksys_velop",
   "AkA57/liveboxtvuhd",
   "akasma74/Hass-Custom-Alarm",


### PR DESCRIPTION
This PR adds the Wibeee component as a default component in HACS

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
-->
