### PR TITLE
Adds new plugin [benct/lovelace-battery-entity-row]

### DIFF
--- a/plugin
+++ b/plugin
@@ -12,6 +12,7 @@
   "badguy99/PlantPictureCard",
   "bbbenji/synthwave-hass-extras",
   "ben8p/lovelace-tab-redirect-card",
+  "benct/lovelace-battery-entity-row",
   "benct/lovelace-github-entity-row",
   "benct/lovelace-multiple-entity-row",
   "benct/lovelace-xiaomi-vacuum-card",


### PR DESCRIPTION
Intended to replace [cbulock/lovelace-battery-entity](https://github.com/cbulock/lovelace-battery-entity), which has been removed from HACS due to lack of maintenance. Rewritten and added a few improvements on this card as well.

Many similarities with [maxwroc/battery-state-card](https://github.com/maxwroc/battery-state-card) (which is also derived from cbulock's card), but this card is *a lot* simpler and has a much smaller footprint than maxwroc's, for those who just need a simple battery row in the default entities card.