### PR TITLE
Adds new plugin [reptilex/tesla-style-solar-power-card]

### DIFF
--- a/plugin
+++ b/plugin
@@ -151,6 +151,7 @@
   "postlund/search-card",
   "r-renato/ha-card-waze-travel-time",
   "r-renato/ha-card-weather-conditions",
+  "reptilex/tesla-style-solar-power-card",
   "RodBr/miflora-card",
   "royto/logbook-card",
   "rsnodgrass/water-heater-card",


### PR DESCRIPTION
it's a visualisation for solar power systems the tesla powerwall style

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
-->
