### PR TITLE
xMrVizzy/button-toolbar not available any longer

### DIFF
--- a/plugin
+++ b/plugin
@@ -191,6 +191,5 @@
   "Villhellm/custom-sidebar",
   "Villhellm/lovelace-animated-background",
   "Villhellm/lovelace-clock-card",
-  "Voxxie/lovelace-jumbo-card",
-  "xMrVizzy/button-toolbar"
+  "Voxxie/lovelace-jumbo-card"
 ]


### PR DESCRIPTION
Removed xMrVizzy/button-toolbar since the repository is not available any longer on github. Not sure if this is a breaking change and if other changes are needed somewhere else in the code.

This repo leads to the following error in home assistant:

```
Logger: custom_components.hacs.repository.plugin.xMrVizzy.button-toolbar
Source: custom_components/hacs/helpers/functions/validate_repository.py:40
Integration: HACS (documentation, issues)
First occurred: 7:09:29 AM (1 occurrences)
Last logged: 7:09:29 AM
GitHub returned 404 for https://api.github.com/repos/xMrVizzy/button-toolbar 
```

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
And consider adding a GitHub Action workflow to your repository: https://hacs.xyz/docs/publish/action
-->
