### PR TITLE
Specify to use python3 in remove script

### DIFF
--- a/scripts/remove
+++ b/scripts/remove
@@ -10,4 +10,4 @@ echo $reason
 echo $removal_type
 echo $link
 
-python scripts/remove_repo.py "$repository" "$removal_type" "$reason" "$link" || exit 0
+python3 scripts/remove_repo.py "$repository" "$removal_type" "$reason" "$link" || exit 0


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
And consider adding a GitHub Action workflow to your repository: https://hacs.xyz/docs/publish/action
-->
Ran into an issue when using the `make remove` command to [remove a repo](https://github.com/hacs/default/pull/753). It appears that this is the only mention of `python` (instead of `python3`) left in the scripts.