### PR TITLE
Adds new integration [hellqvio86/home_assistant_casambi]

### DIFF
--- a/integration
+++ b/integration
@@ -208,6 +208,7 @@
   "hcoohb/hass-yeelightbt",
   "heinoldenhuis/home_assistant_omnik_solar",
   "Hellowlol/ha-tide",
+  "hellqvio86/home_assistant_casambi",
   "herikw/home-assistant-custom-components",
   "heyajohnny/afvalinfo",
   "heyajohnny/cryptoinfo",


### PR DESCRIPTION
I would like my Casambi integration to be apart of the HACS store

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
And consider adding a GitHub Action workflow to your repository: https://hacs.xyz/docs/publish/action
-->
