### PR TITLE
Remove FAA Status

### DIFF
--- a/blacklist
+++ b/blacklist
@@ -80,6 +80,7 @@
   "Michsior14/ha-kaiterra",
   "Michsior14/ha-laser-egg",
   "nitobuendia/oura-custom-component",
+  "ntilley905/faastatus",
   "OpenXbox/xboxone-home-assistant",
   "peternijssen/lovelace-postnl-card",
   "pippyn/Home-Assistant-Sensor-Ophaalkalender",

--- a/integration
+++ b/integration
@@ -330,7 +330,6 @@
   "nielsfaber/scheduler-component",
   "nikrolls/homeassistant-goldair-climate",
   "nstrelow/ha_philips_android_tv",
-  "ntilley905/faastatus",
   "ollo69/ha-samsungtv-smart",
   "ollo69/ha-smartthinq-sensors",
   "opravdin/weback-hass",

--- a/removed
+++ b/removed
@@ -454,4 +454,10 @@
     "removal_type": "removal",
     "link": "https://github.com/hacs/default/pull/841"
   }
+  {
+    "repository": "ntilley905/faastatus",
+    "reason": "Added to Home Assistant Core",
+    "removal_type": "removal",
+    "link: "https://www.home-assistant.io/integrations/faadelays/"
+  }
 ]


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
And consider adding a GitHub Action workflow to your repository: https://hacs.xyz/docs/publish/action
-->
I've gotten my FAA Status integration merged into Home Assistant Core and will be archiving the custom component repo, so this is to remove it from HACS.