### PR TITLE
Adds new integration [krahabb/meross_lan]

### DIFF
--- a/integration
+++ b/integration
@@ -299,6 +299,7 @@
   "KoljaWindeler/ytube_music_player",
   "konnected-io/noonlight-hass",
   "koying/openrgb_ha",
+  "krahabb/meross_lan",
   "kuchel77/diskspace",
   "kukulich/home-assistant-jablotron100",
   "LaggAt/hacs-govee",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
And consider adding a GitHub Action workflow to your repository: https://hacs.xyz/docs/publish/action
-->
Hello,
 I would like this to be added to deafult repo. 
This is an integration for integrating meross devices in HA without going through their own cloud service (there is already an integration for the latter)
It is already used by a 'bunch' of early adopters and should work just fine
Thank you for your work!
Davide
