### PR TITLE
Remove plugin dummy-entity-row - deprecated

### DIFF
--- a/plugin
+++ b/plugin
@@ -211,7 +211,6 @@
   "thomasloven/lovelace-badge-card",
   "thomasloven/lovelace-card-mod",
   "thomasloven/lovelace-card-tools",
-  "thomasloven/lovelace-dummy-entity-row",
   "thomasloven/lovelace-fold-entity-row",
   "thomasloven/lovelace-gap-card",
   "thomasloven/lovelace-gui-sandbox",


### PR DESCRIPTION
Functionality is covered by template-entity-row.

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
And consider adding a GitHub Action workflow to your repository: https://hacs.xyz/docs/publish/action
-->
