### PR TITLE
Remove plugin gap-card - Deprecated

### DIFF
--- a/plugin
+++ b/plugin
@@ -213,7 +213,6 @@
   "thomasloven/lovelace-card-tools",
   "thomasloven/lovelace-dummy-entity-row",
   "thomasloven/lovelace-fold-entity-row",
-  "thomasloven/lovelace-gap-card",
   "thomasloven/lovelace-gui-sandbox",
   "thomasloven/lovelace-hui-element",
   "thomasloven/lovelace-layout-card",


### PR DESCRIPTION
Functionality is included in layout-card since 2.3.0
