### PR TITLE
Remove 'shbatm/hacs-isy994' from Integrations

### DIFF
--- a/blacklist
+++ b/blacklist
@@ -102,6 +102,7 @@
   "Rocka84/dual-gauge-card",
   "SebuZet/samsungrac",
   "shaonianzhentan/ha-cloud-music",
+  "shbatm/hacs-isy994",
   "sinclairpaul/ha_purple_theme",
   "tenly2000/HomeAssistant-Places",
   "thomasloven/lovelace-dummy-entity-row",

--- a/integration
+++ b/integration
@@ -466,7 +466,6 @@
   "sermayoral/ha-samsungtv-encrypted",
   "Sha-Darim/brandriskute",
   "shaiu/technicolor",
-  "shbatm/hacs-isy994",
   "shogunxam/Home-Assistant-custom-components-cfr-toscana",
   "Sholofly/ZiggoNext",
   "shutupflanders/sensor.moneydashboard",

--- a/removed
+++ b/removed
@@ -567,5 +567,11 @@
     "reason": "Repository is archived",
     "removal_type": "remove",
     "link": "https://github.com/hacs/integration/issues/2121"
+  },
+  {
+    "repository": "shbatm/hacs-isy994",
+    "reason": "Repository was used as a beta test for core ISY994 and is no longer required.",
+    "removal_type": "remove",
+    "link": "https://github.com/shbatm/hacs-isy994"
   }
 ]


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
And consider adding a GitHub Action workflow to your repository: https://hacs.xyz/docs/publish/action
-->
Remove shbatm/hacs-isy994 integration from default.

This integration was used for beta testing changes to the core integration up until HA 2021.6.0; there are breaking changes in 2021.6.8 which will cause issues if people continue to use this branch.

See https://github.com/home-assistant/core/issues/53969 and https://github.com/home-assistant/core/issues/53984