### PR TITLE
Remove brefra/home-assistant-plugwise-stick integration from default.

### DIFF
--- a/blacklist
+++ b/blacklist
@@ -19,6 +19,7 @@
   "bramkragten/lyric",
   "bratanon/lovelace-conditional-entity-row",
   "Bre77/myair",
+  "brefra/home-assistant-plugwise-stick",
   "briis/mbweather",
   "burnnat/ha-polar",
   "cbulock/lovelace-battery-entity",

--- a/integration
+++ b/integration
@@ -58,7 +58,6 @@
   "bouwew/sems2mqtt",
   "bramkragten/mind",
   "bramstroker/homeassistant-powercalc",
-  "brefra/home-assistant-plugwise-stick",
   "bremor/bonaire_myclimate",
   "bremor/bureau_of_meteorology",
   "bremor/public_transport_victoria",

--- a/removed
+++ b/removed
@@ -573,5 +573,11 @@
     "reason": "Repository was used as a beta test for core ISY994 and is no longer required.",
     "removal_type": "remove",
     "link": "https://github.com/shbatm/hacs-isy994"
+  },
+  {
+    "repository": "brefra/home-assistant-plugwise-stick",
+    "reason": "Replaced by alternative custom integration",
+    "removal_type": "remove",
+    "link": "https://github.com/plugwise/plugwise-beta"
   }
 ]


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
And consider adding a GitHub Action workflow to your repository: https://hacs.xyz/docs/publish/action
-->
Remove `brefra/home-assistant-plugwise-stick` integration from default.

I do not maintain this integration anymore. I've joined the [plugwise team](https://github.com/plugwise) (no affiliation with Plugwise BV) and actively maintain the [Plugwise BETA](https://github.com/plugwise/plugwise-beta) custom integration over there. It has more and better support for the plugwise USB stick.
It's also the beta integration for the official `plugwise` integration in Home Assistant.

