### PR TITLE
Adds new integration [mullerdavid/hass_GreeExt]

### DIFF
--- a/integration
+++ b/integration
@@ -381,6 +381,7 @@
   "MTrab/landroid_cloud",
   "mudape/iphonedetect",
   "muhlba91/onyx-homeassistant-integration",
+  "mullerdavid/hass_GreeExt",
   "muxa/home-assistant-niwa-tides",
   "mvdwetering/huesyncbox",
   "myhomeiot/DahuaVTO",


### PR DESCRIPTION
Please add my custom component for extending gree climate components with swing mode service.
As it is using the builtin gree integration, wheel and brands tests were disabled in the automatic workflow checks.