### PR TITLE
Adds new integration [kotborealis/home-assistant-custom-components-cover-time-based-synced]

### DIFF
--- a/integration
+++ b/integration
@@ -319,6 +319,7 @@
   "KoljaWindeler/kaco",
   "KoljaWindeler/ytube_music_player",
   "konnected-io/noonlight-hass",
+  "kotborealis/home-assistant-custom-components-cover-time-based-synced",
   "koying/jellyfin_ha",
   "koying/openrgb_ha",
   "krahabb/meross_lan",


### PR DESCRIPTION
Adds [kotborealis/home-assistant-custom-components-cover-time-based-synced](https://github.com/kotborealis/home-assistant-custom-components-cover-time-based-synced) to HACS default repos.