### PR TITLE
Adds new integration [jobvk/Home-Assistant-Windcentrale]

### DIFF
--- a/integration
+++ b/integration
@@ -297,6 +297,7 @@
   "jihao/rokid-webhook-hass",
   "jihao/traccar-cn-hass",
   "jm-73/Indego",
+  "jobvk/Home-Assistant-Windcentrale",
   "joggs/home_assistant_ebeco",
   "Johnwulp/rad-afval",
   "jomwells/ambilight-yeelight",


### PR DESCRIPTION
Add Windcentrale integration

Windcentrale provide an API to get realtime winturbine sensors and news messages.