### PR TITLE
Add battery_sim to HACS

### DIFF
--- a/integration
+++ b/integration
@@ -267,6 +267,7 @@
   "herikw/home-assistant-custom-components",
   "heyajohnny/afvalinfo",
   "heyajohnny/cryptoinfo",
+  "hif2k1/battery_sim",
   "Home-Is-Where-You-Hang-Your-Hack/sensor.goveetemp_bt_hci",
   "HomeAssistant-Mods/home-assistant-miele",
   "hwmland/homeassistant-xmrpool_stat",


### PR DESCRIPTION
Battery_sim simulates a home battery so users can evaluate how much energy it would save them.

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
And consider adding a GitHub Action workflow to your repository: https://hacs.xyz/docs/publish/action
-->
