### PR TITLE
Remove integration [echoromeo/hanobo]

### DIFF
--- a/integration
+++ b/integration
@@ -196,7 +196,6 @@
   "dynasticorpheus/gigasetelements-ha",
   "eavanvalkenburg/sia",
   "ec-blaster/magicswitchbot-homeassistant",
-  "echoromeo/hanobo",
   "edekeijzer/osrm_travel_time",
   "eifinger/hass-foldingathomecontrol",
   "eifinger/hass-here-weather",


### PR DESCRIPTION
Remove echoromeo/hanobo from HACS to allow for integration directly in Home Assistant

https://github.com/home-assistant/core/pull/50913