### PR TITLE
Adds new integration [dvd-dev/hilo]

### DIFF
--- a/integration
+++ b/integration
@@ -204,6 +204,7 @@
   "dreed47/redfin",
   "DSorlov/hasl-platform",
   "DurgNomis-drol/ha_toyota",
+  "dvd-dev/hilo",
   "dwainscheeren/dwains-lovelace-dashboard",
   "dylandoamaral/trakt-integration",
   "dynasticorpheus/gigasetelements-ha",


### PR DESCRIPTION
Submitting the integration for Hilo smart home product from Hydro-Quebec. We already have a good userbase, it would be easier for everyone if we can include this in HACS default.
