### PR TITLE
Adds new integration [dvd-dev/hilo]

### DIFF
--- a/integration
+++ b/integration
@@ -204,6 +204,7 @@
   "dreed47/redfin",
   "DSorlov/hasl-platform",
   "DurgNomis-drol/ha_toyota",
+  "dvd-dev/hilo",
   "dwainscheeren/dwains-lovelace-dashboard",
   "dylandoamaral/trakt-integration",
   "dynasticorpheus/gigasetelements-ha",


### PR DESCRIPTION
This integration allows configuration of various Hilo smart home devices. Hilo is a subsidiary of Hydro Quebec. There's already a small community using this integration, it would make the life easier for everyone if we could include it in the default HACS repositories.