### PR TITLE
Adds new integration [9a4gl/hass-centrometal-boiler]

### DIFF
--- a/integration
+++ b/integration
@@ -1,7 +1,7 @@
 [
   "5high/konke",
   "5high/phicomm-dc1-homeassistant",
-  "9a4gl/hass-peltec",
+  "9a4gl/hass-centrometal-boiler",
   "9rpp/securifi",
   "AaronDavidSchneider/SonosAlarm",
   "abacao/hass_wibeee",


### PR DESCRIPTION
Peltec is just one boiler produced by centrometal. Support for other boilers has been added. So it makes sense to rename it from peltec to centrometal-boiler now.

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
And consider adding a GitHub Action workflow to your repository: https://hacs.xyz/docs/publish/action
-->
