### PR TITLE
Adds new integration [J-Lindvig/Flagdays_DK]

### DIFF
--- a/integration
+++ b/integration
@@ -304,6 +304,7 @@
   "itchannel/fordpass-ha",
   "itchannel/optus-ha",
   "ITTV-tools/homeassistant-kostalplenticore",
+  "J-Lindvig/Flagdays_DK",
   "JAAlperin/hass-bardolph",
   "jadson179/consul",
   "jadson179/controlid",


### PR DESCRIPTION
Flagdays_dk is a integration which is scraping the official flagsdays.

It is possible to add your own flagdays, ex. birthdays or other signifacant events.
You can also specify which flags you own and wish to use.
Furthermore it uses a online API to calculate sunrise and sunset to be use in the flag_up and flag_down times.
If given an offset, it will create some extra attributes with the offset subtracted from the flag_up and flag_down times.

There are boolean switches stating if it is a memorial with special orders regarding the event.
![image](https://user-images.githubusercontent.com/54498188/151345649-0a123af4-2958-46de-8491-5ea4da2152f6.png)


<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
And consider adding a GitHub Action workflow to your repository: https://hacs.xyz/docs/publish/action
-->
