### PR TITLE
Add rpi_gpio integration

### DIFF
--- a/integration
+++ b/integration
@@ -648,5 +648,6 @@
   "youdroid/home-assistant-gitea",
   "youdroid/home-assistant-sickchill",
   "zachowj/hass-node-red",
-  "zigul/HomeAssistant-CEZdistribuce"
+  "zigul/HomeAssistant-CEZdistribuce"  
+  "Sholofly/rpi-gpio",
 ]


### PR DESCRIPTION
As of version 2022.6.0 the core rpi_gpio integration will be removed from the core of Home Assistant. it's deprecated as of version 2022.2.0. This integration is en exact copy of the current core integration. Should we keep this one open until then or should I request an add then?

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
And consider adding a GitHub Action workflow to your repository: https://hacs.xyz/docs/publish/action
-->
