### PR TITLE
Adds new integration [jnxxx/homeassistant-dabblerdk_powermeterreader]

### DIFF
--- a/integration
+++ b/integration
@@ -337,6 +337,7 @@
   "jihao/traccar-cn-hass",
   "jjlawren/sonos_cloud",
   "jm-73/Indego",
+  "jnxxx/homeassistant-dabblerdk_powermeterreader",
   "jobvk/Home-Assistant-Windcentrale",
   "joggs/home_assistant_ebeco",
   "Johnwulp/rad-afval",


### PR DESCRIPTION
Adding an integration to read power consumption from Echelon/NES power meters through a Dabbler.dk MEP module.

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
And consider adding a GitHub Action workflow to your repository: https://hacs.xyz/docs/publish/action
-->
