### PR TITLE
Remove SNoof85/lovelace-tempometer-gauge-card

### DIFF
--- a/blacklist
+++ b/blacklist
@@ -131,6 +131,7 @@
   "shbatm/hacs-isy994",
   "Sholofly/ZiggoNext",
   "sinclairpaul/ha_purple_theme",
+  "SNoof85/lovelace-tempometer-gauge-card",
   "tellerbop/havistapool",
   "tenly2000/HomeAssistant-Places",
   "thomasloven/lovelace-dummy-entity-row",

--- a/plugin
+++ b/plugin
@@ -223,7 +223,6 @@
   "sdelliot/pie-chart-card",
   "Shreyas-R/lovelace-wallpanel-screensaver",
   "Sian-Lee-SA/honeycomb-menu",
-  "SNoof85/lovelace-tempometer-gauge-card",
   "sopelj/lovelace-kanji-clock-card",
   "swingerman/lovelace-fluid-level-background-card",
   "TarheelGrad1998/gallery-card",

--- a/removed
+++ b/removed
@@ -741,5 +741,11 @@
     "reason": "No longer maintained",
     "removal_type": "Remove",
     "link": "https://github.com/hacs/integration/issues/2552"
+  },
+    {
+    "repository": "SNoof85/lovelace-tempometer-gauge-card",
+    "reason": "No longer maintained",
+    "removal_type": "Remove",
+    "link": ""
   }
 ]

--- a/removed
+++ b/removed
@@ -746,6 +746,6 @@
     "repository": "SNoof85/lovelace-tempometer-gauge-card",
     "reason": "No longer maintained",
     "removal_type": "Remove",
-    "link": ""
+    "link": "https://github.com/hacs/default/pull/1356"
   }
 ]


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
And consider adding a GitHub Action workflow to your repository: https://hacs.xyz/docs/publish/action
-->

**Link to successful HACS action:**  
**Link to successful hassfest action (if integration):**  

<!--
Action documentation:
HACS Action: https://hacs.xyz/docs/publish/action
hassfest action: https://developers.home-assistant.io/blog/2020/04/16/hassfest/
-->

Remove SNoof85/lovelace-tempometer-gauge-card as I will not maintain anymore and repo is archived.