### PR TITLE
pawkakol/worlds-air-quality-index integration added

### DIFF
--- a/integration
+++ b/integration
@@ -511,6 +511,7 @@
   "PaulAnnekov/home-assistant-padavan-tracker",
   "pawelhulek/kontomierz-sensor",
   "pawelhulek/pgnig-sensor",
+  "pawkakol1/worlds-air-quality-index",
   "pcourbin/ecodevices_rt2",
   "pcourbin/imaprotect",
   "peetereczek/ztm",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
And consider adding a GitHub Action workflow to your repository: https://hacs.xyz/docs/publish/action
-->

**Link to successful HACS action:**  
**Link to successful hassfest action (if integration):**  

<!--
Action documentation:
HACS Action: https://hacs.xyz/docs/publish/action
hassfest action: https://developers.home-assistant.io/blog/2020/04/16/hassfest/
-->
