### PR TITLE
Remove plugin [mattieha/slider-button-card]

### DIFF
--- a/blacklist
+++ b/blacklist
@@ -118,6 +118,7 @@
   "mammuth/ha-fritzbox-tools",
   "mampfes/hacs_wiffi",
   "MatthewFlamm/nwsradar",
+  "mattieha/slider-button-card",
   "maykar/compact-custom-header",
   "maykar/custom-header",
   "maykar/kiosk-mode",

--- a/plugin
+++ b/plugin
@@ -178,7 +178,6 @@
   "marrobHD/tv-card",
   "mathoudebine/homeassistant-browser-control-card",
   "mattieha/select-list-card",
-  "mattieha/slider-button-card",
   "maxwroc/battery-state-card",
   "maxwroc/github-flexi-card",
   "MesserschmittX/lovelace-nicehash-excavator-monitor-card",

--- a/removed
+++ b/removed
@@ -879,5 +879,11 @@
     "reason": "Added to Home Assistant core",
     "removal_type": "replaced",
     "link": "https://www.home-assistant.io/integrations/homewizard/"
+  },
+  {
+    "repository": "mattieha/slider-button-card",
+    "reason": "Abandoned, community fork maintained at custom-cards/slider-button-card",
+    "removal_type": "replaced",
+    "link": "https://github.com/custom-cards/slider-button-card"
   }
 ]


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
And consider adding a GitHub Action workflow to your repository: https://hacs.xyz/docs/publish/action
-->
"mattieha/slider-button-card" has become abandoned and there have been no responses from the maintainer for the past several months. @lizsugar and I are now maintaining a new fork at "custom-cards/slider-button-card" with bug fixes (done) and new features to come shortly.


**Link to successful HACS action: N/A
**Link to successful hassfest action (if integration): N/A

<!--
Action documentation:
HACS Action: https://hacs.xyz/docs/publish/action
hassfest action: https://developers.home-assistant.io/blog/2020/04/16/hassfest/
-->
