### PR TITLE
Revert "Adds new integration [fred-oranje/rituals-genie]"

### DIFF
--- a/integration
+++ b/integration
@@ -258,7 +258,6 @@
   "fondberg/easee_hass",
   "fondberg/spotcast",
   "freakshock88/hass-populartimes",
-  "fred-oranje/rituals-genie",
   "freol35241/ltss",
   "frimtec/hass-compal-wifi",
   "fsaris/home-assistant-awox",


### PR DESCRIPTION
Reverts hacs/default#809

Looks like the integration is removed:
```txt
<Integration fred-oranje/rituals-genie> GitHub returned 404 for https://api.github.com/repos/fred-oranje/rituals-genie
```

https://github.com/fred-oranje/rituals-genie
https://github.com/fred-oranje