### PR TITLE
Remove fred-oranje/rituals-genie

### DIFF
--- a/blacklist
+++ b/blacklist
@@ -97,6 +97,7 @@
   "ericpignet/home-assistant-tplink_router",
   "estevez-dev/extended-banner-card",
   "fineemb/lynk-co",
+  "fred-oranje/rituals-genie",
   "futuretense/lock-manager",
   "heinoldenhuis/home_assistant_area_waste",
   "heinoldenhuis/home_assistant_omnik_solar",

--- a/integration
+++ b/integration
@@ -258,7 +258,6 @@
   "fondberg/easee_hass",
   "fondberg/spotcast",
   "freakshock88/hass-populartimes",
-  "fred-oranje/rituals-genie",
   "freol35241/ltss",
   "frimtec/hass-compal-wifi",
   "fsaris/home-assistant-awox",

--- a/removed
+++ b/removed
@@ -872,6 +872,6 @@
     "repository": "fred-oranje/rituals-genie",
     "reason": "Repository not available",
     "removal_type": "remove",
-    "link": ""
+    "link": "https://github.com/hacs/default/pull/1402"
   }
 ]

--- a/removed
+++ b/removed
@@ -867,5 +867,11 @@
     "reason": "Repository is archived",
     "removal_type": "remove",
     "link": "https://github.com/hacs/default/pull/1375"
+  },
+  {
+    "repository": "fred-oranje/rituals-genie",
+    "reason": "Repository not available",
+    "removal_type": "remove",
+    "link": ""
   }
 ]


### PR DESCRIPTION
Looks like the integration is removed by it's author and no longer accessible:
```txt
<Integration fred-oranje/rituals-genie> GitHub returned 404 for https://api.github.com/repos/fred-oranje/rituals-genie
```

https://github.com/fred-oranje/rituals-genie
https://github.com/fred-oranje

Closes hacs/integration#2748