### PR TITLE
Remove HomeWizard Energy integration

### DIFF
--- a/blacklist
+++ b/blacklist
@@ -88,6 +88,7 @@
   "custom-components/unsplash",
   "custom-components/usps_mail",
   "DavidFW1960/bom_forecast",
+  "DCSBL/ha-homewizard-energy",
   "doudz/homeassistant-zigate",
   "dr1rrb/ha-twinkly",
   "DSorlov/hasl-platform",

--- a/integration
+++ b/integration
@@ -187,7 +187,6 @@
   "davesmeghead/visonic",
   "DavidMStraub/homeassistant-homeconnect",
   "dckiller51/bodymiscale",
-  "DCSBL/ha-homewizard-energy",
   "ddanssaert/home-assistant-ipcamlive",
   "deblockt/hass-proscenic-790T-vacuum",
   "DeebotUniverse/Deebot-4-Home-Assistant",

--- a/removed
+++ b/removed
@@ -879,5 +879,5 @@
     "reason": "Added to Home Assistant core",
     "removal_type": "replaced",
     "link": "https://www.home-assistant.io/integrations/homewizard/"
-  },
+  }
 ]

--- a/removed
+++ b/removed
@@ -873,5 +873,11 @@
     "reason": "Repository not available",
     "removal_type": "remove",
     "link": "https://github.com/hacs/default/pull/1402"
-  }
+  },
+  {
+    "repository": "DCSBL/ha-homewizard-energy",
+    "reason": "Added to Home Assistant core",
+    "removal_type": "replaced",
+    "link": "https://www.home-assistant.io/integrations/homewizard/"
+  },
 ]


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start

Do not open a PR without passing actions in your repository that you link to in this PR template.
-->

**Link to successful HACS action:** NA  
**Link to successful hassfest action (if integration):** NA

HomeWizard has been added to core since 2022.2. This custom integration was kept alive to make migrations possible but is currently only causing confusion. Let's remove it. 

https://github.com/DCSBL/ha-homewizard-energy
https://www.home-assistant.io/integrations/homewizard/
