### PR TITLE
Adds new plugin [custom-cards/slider-button-card]

### DIFF
--- a/plugin
+++ b/plugin
@@ -55,6 +55,7 @@
   "custom-cards/plan-coordinates",
   "custom-cards/rmv-card",
   "custom-cards/secondaryinfo-entity-row",
+  "custom-cards/slider-button-card",
   "custom-cards/spotify-card",
   "custom-cards/stack-in-card",
   "custom-cards/surveillance-card",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
And consider adding a GitHub Action workflow to your repository: https://hacs.xyz/docs/publish/action
-->
"mattieha/slider-button-card" has become abandoned and there have been no responses from the maintainer for the past several months. @lizsugar and I are now maintaining a new fork at "custom-cards/slider-button-card" with bug fixes (done) and new features to come shortly.

https://github.com/hacs/default/pull/1388 removes the original version of the card.


**Link to successful HACS action: https://github.com/custom-cards/slider-button-card/runs/6714759995?check_suite_focus=true  
**Link to successful hassfest action (if integration): N/A

<!--
Action documentation:
HACS Action: https://hacs.xyz/docs/publish/action
hassfest action: https://developers.home-assistant.io/blog/2020/04/16/hassfest/
-->
