### PR TITLE
Remove Cozytouch and Hue service integrations

### DIFF
--- a/integration
+++ b/integration
@@ -169,7 +169,6 @@
   "cyberjunky/home-assistant-toon_climate",
   "cyberjunky/home-assistant-toon_smartmeter",
   "cyberjunky/home-assistant-ttn_gateway",
-  "Cyr-ius/hass-cozytouch",
   "Cyr-ius/hass-heatzy",
   "Cyr-ius/hass-hue-service-advanced",
   "Cyr-ius/hass-livebox-component",

--- a/integration
+++ b/integration
@@ -170,7 +170,6 @@
   "cyberjunky/home-assistant-toon_smartmeter",
   "cyberjunky/home-assistant-ttn_gateway",
   "Cyr-ius/hass-heatzy",
-  "Cyr-ius/hass-hue-service-advanced",
   "Cyr-ius/hass-livebox-component",
   "daenny/climate_group",
   "dahlb/ha_blueair",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start

Do not open a PR without passing actions in your repository that you link to in this PR template.
-->

**Link to successful HACS action:**  
**Link to successful hassfest action (if integration):**  

<!--
Action documentation:
HACS Action: https://hacs.xyz/docs/publish/action
hassfest action: https://developers.home-assistant.io/blog/2020/04/16/hassfest/
-->
