### PR TITLE
removed SIA

### DIFF
--- a/blacklist
+++ b/blacklist
@@ -92,6 +92,7 @@
   "doudz/homeassistant-zigate",
   "dr1rrb/ha-twinkly",
   "DSorlov/hasl-platform",
+  "eavanvalkenburg/sia",
   "edenhaus/ha-prosenic",
   "eifinger/here_travel_time",
   "enriqg9/dual-thermostat",

--- a/integration
+++ b/integration
@@ -222,7 +222,6 @@
   "dwainscheeren/dwains-lovelace-dashboard",
   "dylandoamaral/trakt-integration",
   "dynasticorpheus/gigasetelements-ha",
-  "eavanvalkenburg/sia",
   "ec-blaster/magicswitchbot-homeassistant",
   "echoromeo/hanobo",
   "edekeijzer/osrm_travel_time",

--- a/removed
+++ b/removed
@@ -885,5 +885,11 @@
     "reason": "Abandoned, community fork maintained at custom-cards/slider-button-card",
     "removal_type": "replaced",
     "link": "https://github.com/custom-cards/slider-button-card"
+  },
+  {
+    "repository": "eavanvalkenburg/sia",
+    "reason": "moved to official integration",
+    "removal_type": "delete",
+    "link": ""
   }
 ]


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start

Do not open a PR without passing actions in your repository that you link to in this PR template.
-->

Removing SIA as it is now a official integration (replaces #1436).

**Link to successful HACS action:**  
**Link to successful hassfest action (if integration):**  

<!--
Action documentation:
HACS Action: https://hacs.xyz/docs/publish/action
hassfest action: https://developers.home-assistant.io/blog/2020/04/16/hassfest/
-->
