### PR TITLE
Adds new integration [amosyuen/ha-eight-sleep-climate]

### DIFF
--- a/integration
+++ b/integration
@@ -38,6 +38,7 @@
   "amaximus/radioactivity_hu",
   "amaximus/water_quality_fvm",
   "amitfin/daily_schedule",
+  "amosyuen/ha-eight-sleep-climate",
   "amosyuen/ha-tplink-deco",
   "anarion80/sodexo_dla_ciebie",
   "And3rsL/VisonicAlarm-for-Hassio",


### PR DESCRIPTION
Add Eight Sleep Climate to default HACS integrations

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start

Do not open a PR without passing actions in your repository that you link to in this PR template.
-->

**Link to successful HACS action:**  https://github.com/amosyuen/ha-eight-sleep-climate/runs/8127696015?check_suite_focus=true
**Link to successful hassfest action (if integration):**  https://github.com/amosyuen/ha-eight-sleep-climate/runs/8127695824?check_suite_focus=true

<!--
Action documentation:
HACS Action: https://hacs.xyz/docs/publish/action
hassfest action: https://developers.home-assistant.io/blog/2020/04/16/hassfest/
-->
