### PR TITLE
Adds new integration [juacas/zte_tracker]

### DIFF
--- a/integration
+++ b/integration
@@ -388,6 +388,7 @@
   "jseidl/hass-magic_areas",
   "jtbgroup/kodi-media-sensors",
   "juacas/honor_x3",
+  "juacas/zte_tracker",
   "jugla/battery_consumption",
   "jugla/keyatome",
   "jugla/worldtidesinfocustom",


### PR DESCRIPTION
This integration gets the list of connected devices to a ZTE F6640 router.

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start

Do not open a PR without passing actions in your repository that you link to in this PR template.
-->

**Link to successful HACS action:**  https://github.com/juacas/zte_tracker/actions/runs/3087929028
**Link to successful hassfest action (if integration):**  https://github.com/juacas/zte_tracker/actions/runs/3087929022

<!--
Action documentation:
HACS Action: https://hacs.xyz/docs/publish/action
hassfest action: https://developers.home-assistant.io/blog/2020/04/16/hassfest/
-->
