### PR TITLE
"SPZB0001 Thermostat" no longer maintained, please remove

### DIFF
--- a/integration
+++ b/integration
@@ -787,7 +787,6 @@
   "wimb0/home-assistant-saj-modbus",
   "wizmo2/zidoo-player",
   "wlcrs/huawei_solar",
-  "WolfRevo/climate.spzb0001_thermostat",
   "xannor/ha_reolink_discovery",
   "xannor/ha_reolink_rest",
   "xilense/aimp_custom_component",


### PR DESCRIPTION
As I don't maintain "SPZB0001 Thermostat" any longer it should not be available in the official HACS store.

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start

Do not open a PR without passing actions in your repository that you link to in this PR template.
-->

**Link to successful HACS action:**  
**Link to successful hassfest action (if integration):**  

<!--
Action documentation:
HACS Action: https://hacs.xyz/docs/publish/action
hassfest action: https://developers.home-assistant.io/blog/2020/04/16/hassfest/
-->
