### PR TITLE
Remove deprecated Outline theme

### DIFF
--- a/blacklist
+++ b/blacklist
@@ -105,6 +105,7 @@
   "estevez-dev/extended-banner-card",
   "fineemb/lynk-co",
   "fred-oranje/rituals-genie",
+  "frenck/home-assistant-theme-outline",
   "futuretense/lock-manager",
   "GeorgeSG/lovelace-folder-card",
   "georgezhao2010/climate_ewelink",

--- a/removed
+++ b/removed
@@ -969,5 +969,11 @@
     "reason": "The integration can no longer be used",
     "removal_type": "remove",
     "link": "https://github.com/hacs/integration/issues/2863"
+  },
+  {
+    "repository": "frenck/home-assistant-theme-outline",
+    "reason": "Obsolete and now archived",
+    "removal_type": "remove",
+    "link": "https://github.com/frenck/home-assistant-theme-outline/pull/41"
   }
 ]

--- a/theme
+++ b/theme
@@ -24,7 +24,6 @@
   "estiens/sweet_pink_hass_theme",
   "fi-sch/ux_goodie_theme",
   "flejz/hass-cyberpunk-2077-theme",
-  "frenck/home-assistant-theme-outline",
   "hekm77/reeder_dark_theme",
   "home-assistant-community-themes/amoled",
   "home-assistant-community-themes/aqua-fiesta",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start

Do not open a PR without passing actions in your repository that you link to in this PR template.
-->

**Link to successful HACS action:**  n/a
**Link to successful hassfest action (if integration):**  n/a

<!--
Action documentation:
HACS Action: https://hacs.xyz/docs/publish/action
hassfest action: https://developers.home-assistant.io/blog/2020/04/16/hassfest/
-->


Remove the Outline theme from HACS. The feature the theme brought, is now default in HA. The theme shipped a NOOP release a couple of months ago, now it is time to  clean it up. The upstream repository has been archived.

../Frenck
