### PR TITLE
Remove archived Litter-Robot

### DIFF
--- a/blacklist
+++ b/blacklist
@@ -137,6 +137,7 @@
   "Michsior14/ha-kaiterra",
   "Michsior14/ha-laser-egg",
   "nagyrobi/home-assistant-custom-components-pfsense-gateways",
+  "natekspencer/hacs-litterrobot",
   "nickneos/Appdaemon-Xiaomi-Doorbell",
   "nickneos/Appdaemon-Xiaomi-Smart-Button",
   "nickneos/Appdaemon-ZHA-Xiaomi-Aqara-Switch",

--- a/integration
+++ b/integration
@@ -562,7 +562,6 @@
   "N0ciple/hass-kef-connector",
   "nagyrobi/home-assistant-custom-components-cover-rf-time-based",
   "nagyrobi/home-assistant-custom-components-linkplay",
-  "natekspencer/hacs-litterrobot",
   "nbogojevic/homeassistant-midea-dehumidifier-lan",
   "ndom91/homeassistant-checkly",
   "neggert/hass-egauge",

--- a/removed
+++ b/removed
@@ -969,5 +969,11 @@
     "reason": "The integration can no longer be used",
     "removal_type": "remove",
     "link": "https://github.com/hacs/integration/issues/2863"
+  },
+  {
+    "repository": "natekspencer/hacs-litterrobot",
+    "reason": "Repository archived",
+    "removal_type": "remove",
+    "link": "https://github.com/natekspencer/hacs-litterrobot/issues/17#issuecomment-1370045529"
   }
 ]


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start

Do not open a PR without passing actions in your repository that you link to in this PR template.
-->

**Link to successful HACS action:**  n/a
**Link to successful hassfest action (if integration):**   n.a

<!--
Action documentation:
HACS Action: https://hacs.xyz/docs/publish/action
hassfest action: https://developers.home-assistant.io/blog/2020/04/16/hassfest/
-->


This PR removed the custom Litter-Robot integration, for which the upstream repository has been archived after I've raised an issue.

Ref: https://github.com/natekspencer/hacs-litterrobot/issues/17

../Frenck