### PR TITLE
Remove archived Renault integration

### DIFF
--- a/blacklist
+++ b/blacklist
@@ -110,6 +110,7 @@
   "futuretense/lock-manager",
   "GeorgeSG/lovelace-folder-card",
   "georgezhao2010/climate_ewelink",
+  "hacf-fr/hassRenaultZE",
   "heinoldenhuis/home_assistant_area_waste",
   "heinoldenhuis/home_assistant_omnik_solar",
   "home-assistant-community-themes/template",

--- a/integration
+++ b/integration
@@ -335,7 +335,6 @@
   "h4de5/home-assistant-toshiba_ac",
   "h4de5/home-assistant-vimar",
   "ha0y/xiaomi_miot_raw",
-  "hacf-fr/hassRenaultZE",
   "hardbyte/ha-evnex",
   "hasl-sensor/integration",
   "hasscc/hass-edge-tts",

--- a/removed
+++ b/removed
@@ -987,5 +987,11 @@
     "reason": "Repository archived",
     "removal_type": "remove",
     "link": "https://github.com/DavidMStraub/homeassistant-homeconnect/commit/e7231c522b35e8d571a7317c69b5003bf144f48a"
+  },
+  {
+    "repository": "hacf-fr/hassRenaultZE",
+    "reason": "Repository archived",
+    "removal_type": "remove",
+    "link": "https://github.com/hacf-fr/hassRenaultZE/pull/155"
   }
 ]


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start

Do not open a PR without passing actions in your repository that you link to in this PR template.
-->

**Link to successful HACS action:**  n/a
**Link to successful hassfest action (if integration):**  n/a

Remove the Renault integration from HACS.
The Renault integration was originally merged into core in 2021.8 and finalised in 2021.10.
The use of the custom component has been deprecated since February 2022 (https://github.com/hacf-fr/hassRenaultZE/pull/155), now it is time to clean it up.
The upstream repository has been archived.

<!--
Action documentation:
HACS Action: https://hacs.xyz/docs/publish/action
hassfest action: https://developers.home-assistant.io/blog/2020/04/16/hassfest/
-->
