### PR TITLE
Adds new integration [muppet3000/homeassistant-growatt_server_api]

### DIFF
--- a/integration
+++ b/integration
@@ -552,6 +552,7 @@
   "mudape/iphonedetect",
   "muhlba91/onyx-homeassistant-integration",
   "mullerdavid/hass_GreeExt",
+  "muppet3000/homeassistant-growatt_server_api",
   "music-assistant/hass-music-assistant",
   "muxa/home-assistant-niwa-tides",
   "mvdwetering/huesyncbox",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start

Do not open a PR without passing actions in your repository that you link to in this PR template.
-->

**Link to successful HACS action:**  https://github.com/muppet3000/homeassistant-growatt_server_api/actions/runs/3859655263/jobs/6584063052
**Link to successful hassfest action (if integration):**  https://github.com/muppet3000/homeassistant-growatt_server_api/actions/runs/3859655263/jobs/6584062992

Addition of growatt_server_api integration: https://github.com/muppet3000/homeassistant-growatt_server_api
See README for more info.

This intention of this repo is for it to be an upstream repo for the core integration here: https://www.home-assistant.io/integrations/growatt_server/ (documentation update to follow) so that changes/fixes/issues can be addressed in a quick/beta manner before being rolled up into a monthly PR to the Core repository.

I believe I've followed all of the requests and expectations laid out in the documentation for this repo, please let me know if there are any issues.

<!--
Action documentation:
HACS Action: https://hacs.xyz/docs/publish/action
hassfest action: https://developers.home-assistant.io/blog/2020/04/16/hassfest/
-->
