### PR TITLE
Remove stl integration

### DIFF
--- a/integration
+++ b/integration
@@ -318,7 +318,6 @@
   "gieljnssns/kostalpiko-sensor-homeassistant",
   "gilsonmandalogo/hacs-minerstat",
   "gjohansson-ST/sector",
-  "gjohansson-ST/stl",
   "gndean/home-assistant-hypervolt-charger",
   "godely/ha-dremel-3d-printer",
   "golles/ha-kamstrup_403",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start

Do not open a PR without passing actions in your repository that you link to in this PR template.
-->

Removes `stl` integration as it's archived and not maintained.

<!--
Action documentation:
HACS Action: https://hacs.xyz/docs/publish/action
hassfest action: https://developers.home-assistant.io/blog/2020/04/16/hassfest/
-->
