### PR TITLE
Remove echoromeo/hanobo

### DIFF
--- a/blacklist
+++ b/blacklist
@@ -102,6 +102,7 @@
   "DSorlov/hasl-platform",
   "dummylabs/watchman",
   "eavanvalkenburg/sia",
+  "echoromeo/hanobo",
   "edenhaus/ha-prosenic",
   "eifinger/here_travel_time",
   "enriqg9/dual-thermostat",

--- a/integration
+++ b/integration
@@ -254,7 +254,6 @@
   "dylandoamaral/trakt-integration",
   "dynasticorpheus/gigasetelements-ha",
   "ec-blaster/magicswitchbot-homeassistant",
-  "echoromeo/hanobo",
   "edekeijzer/osrm_travel_time",
   "edwork/homeassistant-peloton-sensor",
   "eifinger/hass-foldingathomecontrol",

--- a/removed
+++ b/removed
@@ -1065,5 +1065,11 @@
     "reason": "Repository is archived",
     "removal_type": "remove",
     "link": "https://github.com/jessevl/homeassistant-greenchoice"
+  },
+  {
+    "repository": "echoromeo/hanobo",
+    "reason": "Replaced by official integration",
+    "removal_type": "remove",
+    "link": "https://www.home-assistant.io/integrations/nobo_hub/"
   }
 ]


### PR DESCRIPTION
Remove echoromeo/hanobo because it has been replaced by an official integration: https://www.home-assistant.io/integrations/nobo_hub/

## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've run the remove_integration script


