### PR TITLE
Adds new plugin [edwardtfn/home-assistant-sun-card]

### DIFF
--- a/plugin
+++ b/plugin
@@ -87,6 +87,7 @@
   "dnguyen800/air-visual-card",
   "dooz127/swipe-glance-card",
   "dylandoamaral/uptime-card",
+  "edwardtfn/home-assistant-sun-card",
   "elax46/custom-brand-icons",
   "ExperienceLovelace/ha-floorplan",
   "ezand/lovelace-posten-card",


### PR DESCRIPTION
Added edwardtfn/home-assistant-sun-card which is a copy of the repository AitorDB/home-assistant-sun-card recently archived and removed from HACS.

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [N/A] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: < https://github.com/edwardtfn/home-assistant-sun-card/releases/tag/2023.3.2 >
Link to successful HACS action (without the `ignore` key): < https://github.com/edwardtfn/home-assistant-sun-card/actions/runs/4440659399 >
Link to successful hassfest action (if integration): <Not applicable>

