### PR TITLE
Adds new plugin [mawinkler/astroweather-card]

### DIFF
--- a/plugin
+++ b/plugin
@@ -193,6 +193,7 @@
   "MathisAlepis/lovelace-tam-card",
   "mathoudebine/homeassistant-browser-control-card",
   "mattieha/select-list-card",
+  "mawinkler/astroweather-card",
   "maxwroc/battery-state-card",
   "maxwroc/github-flexi-card",
   "MesserschmittX/lovelace-nicehash-excavator-monitor-card",


### PR DESCRIPTION
## Checklist

- [X] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [X] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [X] The actions are passing without any disabled checks in my repository.
- [X] I've added a link to the action run on my repository below in the links section.
- [ ] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/mawinkler/astroweather-card/releases/tag/v0.22.2>
Link to successful HACS action (without the `ignore` key): <https://github.com/mawinkler/astroweather-card/actions/runs/4487358578>
Link to successful hassfest action (if integration): <>

