### PR TITLE
Adds new plugin [flixlix/energy-flow-card-plus]

### DIFF
--- a/plugin
+++ b/plugin
@@ -109,6 +109,7 @@
   "finity69x2/light-brightness-preset-row",
   "finity69x2/toggle-control-button-row",
   "flixlix/power-flow-card-plus",
+  "flixlix/energy-flow-card-plus",
   "flyrmyr/system-flow-card",
   "fratsloos/fr24_card",
   "frozenwizard/onlylocklock",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [N/A] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [ ] I've added a link to the action run on my repository below in the links section.
- [ ] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/flixlix/energy-flow-card-plus/releases/tag/v0.0.0.1>
Link to successful HACS action (without the `ignore` key): <https://github.com/flixlix/energy-flow-card-plus/actions/runs/4946524137>
Link to successful hassfest action (if integration): <>

