### PR TITLE
Remove Clever from integrations list

### DIFF
--- a/integration
+++ b/integration
@@ -597,7 +597,6 @@
   "msp1974/homeassistant-jlrincontrol",
   "msvisser/remeha_home",
   "mtarjoianu/ha_lektrico",
-  "mtrab/clever",
   "mtrab/danfoss_ally",
   "mtrab/energidataservice",
   "MTrab/landroid_cloud",


### PR DESCRIPTION
Removing Clever integration as it's broken and probably never will be fixed.