### PR TITLE
Added Olarm Integration

### DIFF
--- a/integration
+++ b/integration
@@ -692,6 +692,7 @@
   "Pyhass/Hive-Custom-Component",
   "r-renato/ha-climacell-weather",
   "Racailloux/home-assistant-pijuice",
+  "rainepretorius/olarm-ha-integration",
   "raman325/ha-zoom-automation",
   "rccoleman/channels_dvr_recently_recorded",
   "rccoleman/lamarzocco",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [*] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [*] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [*] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [*] The actions are passing without any disabled checks in my repository.
- [*] I've added a link to the action run on my repository below in the links section.
- [*] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/rainepretorius/olarm-ha-integration/releases/tag/version2.1.6>
Link to successful HACS action (without the `ignore` key): <https://github.com/rainepretorius/olarm-ha-integration/actions/runs/5195592411>
Link to successful hassfest action (if integration): <https://github.com/rainepretorius/olarm-ha-integration/actions/runs/5195592415>

