### PR TITLE
Remove cgarwood/homeassistant-fullykiosk

### DIFF
--- a/integration
+++ b/integration
@@ -141,7 +141,6 @@
   "caiosweet/Home-Assistant-custom-components-INGV",
   "caronc/ha-ultrasync",
   "cathiele/homeassistant-goecharger",
-  "cgarwood/homeassistant-fullykiosk",
   "chaimchaikin/molad-ha",
   "chises/ha-oilfox",
   "Chouffy/home_assistant_libratone_zipp",


### PR DESCRIPTION
The custom component is now part of HA core

## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [ ] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [ ] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [ ] The actions are passing without any disabled checks in my repository.
- [ ] I've added a link to the action run on my repository below in the links section.
- [ ] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <>
Link to successful HACS action (without the `ignore` key): <>
Link to successful hassfest action (if integration): <>

