### PR TITLE
Remove mtrab/clever

### DIFF
--- a/blacklist
+++ b/blacklist
@@ -159,6 +159,7 @@
   "maykar/plex_assistant",
   "Michsior14/ha-kaiterra",
   "Michsior14/ha-laser-egg",
+  "mtrab/clever",
   "nagyrobi/home-assistant-custom-components-cover-rf-time-based",
   "nagyrobi/home-assistant-custom-components-pfsense-gateways",
   "natekspencer/hacs-litterrobot",

--- a/integration
+++ b/integration
@@ -597,7 +597,6 @@
   "msp1974/homeassistant-jlrincontrol",
   "msvisser/remeha_home",
   "mtarjoianu/ha_lektrico",
-  "mtrab/clever",
   "mtrab/danfoss_ally",
   "mtrab/energidataservice",
   "MTrab/landroid_cloud",

--- a/removed
+++ b/removed
@@ -1149,5 +1149,11 @@
     "reason": "zadnego ale API is down",
     "removal_type": "remove",
     "link": "https://github.com/bieniu/ha-zadnego-ale/issues/150"
+  },
+  {
+    "repository": "mtrab/clever",
+    "reason": "Repository is archived",
+    "removal_type": "deprecated",
+    "link": "https://github.com/MTrab/clever/pull/29"
   }
 ]


### PR DESCRIPTION
Remove mtrab/clever because the unofficial API used is no longer available

## Checklist
* [x]  I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
* [x]  I've run the remove_integration script