### PR TITLE
Adds new plugin [fixtse/office365-card]

### DIFF
--- a/plugin
+++ b/plugin
@@ -108,6 +108,7 @@
   "finity69x2/fan-percent-button-row",
   "finity69x2/light-brightness-preset-row",
   "finity69x2/toggle-control-button-row",
+  "fixtse/office365-card",
   "flixlix/power-flow-card-plus",
   "flyrmyr/system-flow-card",
   "fratsloos/fr24_card",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/fixtse/office365-card/releases/tag/v1.0.0>
Link to successful HACS action (without the `ignore` key): <https://github.com/fixtse/office365-card/actions/runs/5584244346>
Link to successful hassfest action (if integration): <>

