### PR TITLE
Remove geertmeersman/telenet

### DIFF
--- a/blacklist
+++ b/blacklist
@@ -133,6 +133,7 @@
   "fred-oranje/rituals-genie",
   "frenck/home-assistant-theme-outline",
   "futuretense/lock-manager",
+  "geertmeersman/telenet",
   "GeorgeSG/lovelace-folder-card",
   "georgezhao2010/climate_ewelink",
   "gjohansson-ST/stl",

--- a/integration
+++ b/integration
@@ -325,7 +325,6 @@
   "geertmeersman/miwa",
   "geertmeersman/mobile_vikings",
   "geertmeersman/nexxtmove",
-  "geertmeersman/telenet",
   "geertmeersman/youfone",
   "geoffreylagaisse/Hass-Microsoft-Graph",
   "GeorgeSG/ha-slack-user",

--- a/removed
+++ b/removed
@@ -1395,5 +1395,11 @@
     "reason": "Integration is missing a version, and is abandoned.",
     "removal_type": "remove",
     "link": "https://github.com/hacs/default/pull/1978"
+  },
+  {
+    "repository": "geertmeersman/telenet",
+    "reason": "Requested by Telenet Security & Legal",
+    "removal_type": "Not allowed",
+    "link": "LinkedIn request from Telenet :-("
   }
 ]


### PR DESCRIPTION
Remove geertmeersman/telenet upon request by Telenet security & legal

## Checklist
* [x]   I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
* [x]   I've run the remove_integration script