### PR TITLE
Add Battery Notes integration

### DIFF
--- a/integration
+++ b/integration
@@ -53,6 +53,7 @@
   "And3rsL/VisonicAlarm-for-Hassio",
   "andersonshatch/midea-ac-py",
   "Andre0512/hon",
+  "andrew-codechimp/HA-Battery-Notes",
   "andrzejchm/blebox_shutterbox_tilt",
   "andvikt/mega_hacs",
   "aneeshd/schedule_state",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [X] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [X] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [X] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [X] The actions are passing without any disabled checks in my repository.
- [X] I've added a link to the action run on my repository below in the links section.
- [X] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/andrew-codechimp/HA-Battery-Notes/releases/tag/1.0.0>
Link to successful HACS action (without the `ignore` key): <https://github.com/andrew-codechimp/HA-Battery-Notes/actions/runs/6172397432/job/16752573965>
Link to successful hassfest action (if integration): <https://github.com/andrew-codechimp/HA-Battery-Notes/actions/runs/6172397432/job/16752574417>

