### PR TITLE
Add EGDdistribuce integration

### DIFF
--- a/integration
+++ b/integration
@@ -59,6 +59,7 @@
   "Anonym-tsk/homeassistant-climate-xiaomi-remote",
   "anrolosia/shopping-list-with-grocy",
   "Antoni-Czaplicki/vulcan-for-hassio",
+  "Antrac1t/HomeAssistant-EGDdistribuce",
   "Aohzan/ecodevices",
   "Aohzan/hass-polar",
   "Aohzan/hass-prixcarburant",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/Antrac1t/HomeAssistant-EGDdistribuce/releases/tag/v0.2.0>
Link to successful HACS action (without the `ignore` key): <https://github.com/Antrac1t/HomeAssistant-EGDdistribuce/actions/runs/6432097058/job/17466247308>
Link to successful hassfest action (if integration): <https://github.com/Antrac1t/HomeAssistant-EGDdistribuce/actions/runs/6432097045/job/17466247064>

The original author does not have time for this, so we agreed that I will fix and publish the integration to the HACS default.