### PR TITLE
Add integration Frisquet Connect

### DIFF
--- a/integration
+++ b/integration
@@ -881,6 +881,7 @@
   "TheByteStuff/RemoteSyslog_Service",
   "thecode/ha-onewire-sysbus",
   "thecode/ha-rpi_gpio",
+  "TheGui01/Frisquet-connect-for-home-assistant",
   "TheHolyRoger/hass-cryptoinfo",
   "TheRealWaldo/thermal",
   "ThermIQ/thermiq_mqtt-ha",


### PR DESCRIPTION

## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [ ] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/TheGui01/Frisquet-connect-for-home-assistant/releases/tag/v1.0.0>
Link to successful HACS action (without the `ignore` key): <https://github.com/TheGui01/Frisquet-connect-for-home-assistant/actions/runs/7468835443>
Link to successful hassfest action (if integration): <https://github.com/TheGui01/Frisquet-connect-for-home-assistant/actions/runs/7468948774/>

