### PR TITLE
Adds new plugin [Brianfit/xkcd-card-ha

### DIFF
--- a/plugin
+++ b/plugin
@@ -34,6 +34,7 @@
   "bernikr/lovelace-webos-keyboard-card",
   "berrywhite96/lovelace-shutter-row",
   "bokub/rgb-light-card",
+  "Brianfit/xkcd-card-ha",
   "bramkragten/swipe-card",
   "bramkragten/weather-card",
   "Ceerbeerus/beerbolaget-card",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [X] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [X] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [X] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [X] The actions are passing without any disabled checks in my repository.
- [X] I've added a link to the action run on my repository below in the links section.
- [X] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/Brianfit/xkcd-card-ha/>
Link to successful HACS action (without the `ignore` key): <https://github.com/Brianfit/xkcd-card-ha/actions/runs/7686385716>
Link to successful hassfest action (if integration): <>

