### PR TITLE
refactor: add alryaz/hass-yandex-music-browser to blacklist

### DIFF
--- a/blacklist
+++ b/blacklist
@@ -6,6 +6,7 @@
   "AitorDB/home-assistant-sun-card",
   "alryaz/hass-component-yandex-smart-home",
   "alryaz/hass-mosenergosbyt",
+  "alryaz/hass-yandex-music-browser",
   "amaximus/bkk_stop_card",
   "amelchio/logbook_cache",
   "And3rsL/Deebot-for-Home-Assistant",


### PR DESCRIPTION
This integration will no longer be actively supported due to lack of development resources.

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [ ] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [ ] The actions are passing without any disabled checks in my repository.
- [ ] I've added a link to the action run on my repository below in the links section.
- [ ] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <>
Link to successful HACS action (without the `ignore` key): <>
Link to successful hassfest action (if integration): <>

