### PR TITLE
Add integration Olarm Sensors

### DIFF
--- a/integration
+++ b/integration
@@ -769,6 +769,7 @@
   "Racailloux/home-assistant-pijuice",
   "radical-squared/aquatemp",
   "Rain1971/V2C_trydant",
+  "rainepretorius/olarm-ha-integration",
   "raman325/ha-zoom-automation",
   "rccoleman/channels_dvr_recently_recorded",
   "rdehuyss/homeassistant-custom_components-denkovi",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [X] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [X] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [X] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [X] The actions are passing without any disabled checks in my repository.
- [X] I've added a link to the action run on my repository below in the links section.
- [X] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/rainepretorius/olarm-ha-integration/releases/tag/version2.2.8>
Link to successful HACS action (without the `ignore` key): <https://github.com/rainepretorius/olarm-ha-integration/actions/runs/8057863744>
Link to successful hassfest action (if integration): <https://github.com/rainepretorius/olarm-ha-integration/actions/runs/8058023476>

