### PR TITLE
Replace plugin TarheelGrad1998/gallery-card (unsupported) with lukela…

### DIFF
--- a/plugin
+++ b/plugin
@@ -278,7 +278,7 @@
   "swingerman/lovelace-fluid-level-background-card",
   "t1gr0u/rain-gauge-card",
   "t1gr0u/uv-index-card",
-  "TarheelGrad1998/gallery-card",
+  "lukelalo/gallery-card",
   "tcarlsen/lovelace-light-with-profiles",
   "tdvtdv/ha-tdv-bar",
   "TheLastProject/lovelace-media-art-background",


### PR DESCRIPTION
…lo/gallery-card

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: [<>](https://github.com/lukelalo/gallery-card/releases/tag/v1.1.0)
Link to successful HACS action (without the `ignore` key): [<>](https://github.com/lukelalo/gallery-card/actions/runs/8679646216/job/23798723207)

