### PR TITLE
Remove rogsme/ute_homeassistant_integration

### DIFF
--- a/blacklist
+++ b/blacklist
@@ -234,6 +234,7 @@
   "robmarkcole/Hue-remotes-HASS",
   "robmarkcole/Hue-sensors-HASS",
   "Rocka84/dual-gauge-card",
+  "rogsme/ute_homeassistant_integration",
   "rsnodgrass/hass-flo-water",
   "rsnodgrass/hass-integrations",
   "ryanbateman/bvg-sensor",

--- a/integration
+++ b/integration
@@ -792,7 +792,6 @@
   "RogerSelwyn/AICO_HomeLINK",
   "RogerSelwyn/Home_Assistant_SkyQ_MediaPlayer",
   "RogerSelwyn/O365-HomeAssistant",
-  "rogsme/ute_homeassistant_integration",
   "roleoroleo/yi-hack_ha_integration",
   "RonnyWinkler/homeassistant.homey",
   "roslovets/SP110E-HASS",

--- a/removed
+++ b/removed
@@ -1533,5 +1533,11 @@
     "reason": "Requested by author",
     "removal_type": "remove",
     "link": "https://github.com/hultenvp/home_assistant_omnik_solar"
+  },
+  {
+    "repository": "rogsme/ute_homeassistant_integration",
+    "reason": "The core API was deprecated by UTE",
+    "removal_type": "remove",
+    "link": "https://github.com/rogsme/ute_homeassistant_integration"
   }
 ]


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/rogsme/ute_homeassistant_integration/releases/tag/1.5.0>
Link to successful HACS action (without the `ignore` key): <https://github.com/rogsme/ute_homeassistant_integration/actions/runs/8745200076/job/23999730263>
Link to successful hassfest action (if integration): <https://github.com/rogsme/ute_homeassistant_integration/actions/runs/8745209252>

