### PR TITLE
Adding SpangleLabs/history-explorer-card

### DIFF
--- a/plugin
+++ b/plugin
@@ -273,6 +273,7 @@
   "silentbil/silent-remotes-card",
   "slipx06/sunsynk-power-flow-card",
   "sopelj/lovelace-kanji-clock-card",
+  "SpangleLabs/history-explorer-card",
   "stefmde/HomeAssistant-TwitchFollowedLiveStreamsCard",
   "swingerman/lovelace-fluid-level-background-card",
   "t1gr0u/rain-gauge-card",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [X] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [X] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [X] (For integrations only) ~~I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.~~
- [X] The actions are passing without any disabled checks in my repository.
- [X] I've added a link to the action run on my repository below in the links section.
- [X] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: https://github.com/SpangleLabs/history-explorer-card/releases/tag/v1.0.54
Link to successful HACS action (without the `ignore` key): https://github.com/SpangleLabs/history-explorer-card/actions/runs/9054700918
Link to successful hassfest action (if integration): N/A, plugin not integration

This is a fork of the previously listed alexarch21/history-explorer-card repository, which was removed in #2495 such that development can continue