### PR TITLE
Add new integration [mweinelt/ha-prometheus-sensor]

### DIFF
--- a/integration
+++ b/integration
@@ -655,6 +655,7 @@
   "muxa/home-assistant-niwa-tides",
   "mvdwetering/huesyncbox",
   "mvdwetering/yamaha_ynca",
+  "mweinelt/ha-prometheus-sensor",
   "myhomeiot/DahuaVTO",
   "myTselection/bibliotheek_be",
   "myTselection/Carbu_com",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [ ] The actions are passing without any disabled checks in my repository.
  - Disabled the brands check for now, wondering if I can reuse the Prometheus brand that already exists in the repo
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: 1.1.0
Link to successful HACS action (without the `ignore` key):  https://github.com/mweinelt/ha-prometheus-sensor/actions/runs/9160020959
Link to successful hassfest action (if integration): https://github.com/mweinelt/ha-prometheus-sensor/actions/runs/9160020963

