### PR TITLE
removed ElVit/netdaemon-notify-on-update

### DIFF
--- a/blacklist
+++ b/blacklist
@@ -135,6 +135,7 @@
   "edenhaus/ha-prosenic",
   "eifinger/here_travel_time",
   "elad-bar/ha-dahuavto",
+  "ElVit/netdaemon-notify-on-update",
   "enriqg9/dual-thermostat",
   "ericpignet/home-assistant-lg_hombot",
   "ericpignet/home-assistant-tplink_router",

--- a/netdaemon
+++ b/netdaemon
@@ -1,5 +1,4 @@
 [
-  "ElVit/netdaemon-notify-on-update",
   "hacs/ND-NotifyUpdates",
   "isabellaalstrom/ND-MotionSnapshot",
   "LiranSX/NetDaemon-ITach-Wifi2IR"

--- a/removed
+++ b/removed
@@ -1617,5 +1617,11 @@
     "reason": "Repository no longer exsist",
     "removal_type": "remove",
     "link": "https://github.com/hacs/default/pull/2537"
+  },
+  {
+    "repository": "ElVit/netdaemon-notify-on-update",
+    "reason": "netdaemon apps are deprecated",
+    "removal_type": "remove",
+    "link": "https://github.com/ElVit/netdaemon-notify-on-update/issues/5"
   }
 ]


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: **v1.4.1**
Link to successful HACS action (without the `ignore` key): <https://github.com/ElVit/netdaemon-notify-on-update/actions/runs/9349588287>
Link to successful hassfest action (if integration): <none>

