### PR TITLE
Adds new integration [wimb0/home-assistant-saj-r5-modbus]

### DIFF
--- a/integration
+++ b/integration
@@ -971,7 +971,7 @@
   "WillCodeForCats/tekmar-482",
   "willholdoway/hifiberry",
   "wills106/homeassistant-solax-modbus",
-  "wimb0/home-assistant-saj-modbus",
+  "wimb0/home-assistant-saj-r5-modbus",
   "wizmo2/zidoo-player",
   "wlcrs/huawei_solar",
   "wolffshots/hass-audiobookshelf",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->

I have renamed my integration from home-assistant-saj-modbus to home-assistant-saj-r5-modbus.
This to end confusion about which Inverters are supported.

## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [X] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [X] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [X] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [X] The actions are passing without any disabled checks in my repository.
- [X] I've added a link to the action run on my repository below in the links section.
- [X] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: https://github.com/wimb0/home-assistant-saj-r5-modbus/releases/tag/v2.2.1
Link to successful HACS action (without the `ignore` key): https://github.com/wimb0/home-assistant-saj-r5-modbus/actions/runs/9548712989
Link to successful hassfest action (if integration): https://github.com/wimb0/home-assistant-saj-r5-modbus/actions/runs/9548712995

