### PR TITLE
remove austinmroczek/neovolta

### DIFF
--- a/blacklist
+++ b/blacklist
@@ -15,6 +15,7 @@
   "au190/au190_bkk_stop_card",
   "au190/au190_lock_entity",
   "au190/au190_thermostat_card",
+  "austinmroczek/neovolta",
   "avdeevsv91/ha_generic_hygrostat",
   "azogue/fasthue",
   "badguy99/octocost",

--- a/integration
+++ b/integration
@@ -87,7 +87,6 @@
   "atxbyea/samsungrac",
   "atymic/project_three_zero_ha",
   "augustas2/eldes",
-  "austinmroczek/neovolta",
   "avolmensky/panasonic_eolia",
   "ayavilevich/homeassistant-dlink-presence",
   "azogue/eventsensor",

--- a/removed
+++ b/removed
@@ -1629,5 +1629,11 @@
     "reason": "Repository is archived",
     "removal_type": "remove",
     "link": "https://github.com/hacs/default/pull/2609"
+  },
+  {
+    "repository": "austinmroczek/neovolta",
+    "reason": "obsolete",
+    "removal_type": "complete?",
+    "link": "https://github.com/austinmroczek/neovolta"
   }
 ]


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

Following https://hacs.xyz/docs/publish/remove/

A device firmware update makes this integration obsolete.  My repo README points to instructions for a fix with the new firmware, but it uses an add-on and MQTT instead of a HACS integration.

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [ ] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [ ] The actions are passing without any disabled checks in my repository.
- [ ] I've added a link to the action run on my repository below in the links section.
- [ ] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <>
Link to successful HACS action (without the `ignore` key): <>
Link to successful hassfest action (if integration): <>

