### PR TITLE
Add to plugin list

### DIFF
--- a/plugin
+++ b/plugin
@@ -217,6 +217,7 @@
   "mlamberts78/weather-chart-card",
   "Mofeywalker/openmensa-lovelace-card",
   "MrBartusek/MeteoalarmCard",
+  "nathkrill/lovelace-google-fonts-header-card",
   "nathanmarlor/foxess_modbus_charge_period_card",
   "NemesisRE/kiosk-mode",
   "NemesisRE/upcoming-media-card",


### PR DESCRIPTION
Adds google-fonts-header-card to plugins list

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [✅] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [✅ ] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [✅ ] The actions are passing without any disabled checks in my repository.
- [✅ ] I've added a link to the action run on my repository below in the links section.
- [✅ ] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/nathkrill/lovelace-google-fonts-header-card/releases/tag/v1.0.1>
Link to successful HACS action (without the `ignore` key): <https://github.com/nathkrill/lovelace-google-fonts-header-card/actions/runs/10539473504>
Link to successful hassfest action (if integration): <>

