### PR TITLE
added ha_telegram_client integration

### DIFF
--- a/integration
+++ b/integration
@@ -579,6 +579,7 @@
   "Ludy87/ecotrend-ista",
   "Ludy87/ipv64",
   "Ludy87/xplora_watch",
+  "lufton/ha_telegram_client",
   "luuuis/hass_wibeee",
   "maciej-or/hikvision_next",
   "macxq/foxess-ha",


### PR DESCRIPTION
It's still pending icons to be added to [brands repo](https://github.com/home-assistant/brands/pull/5830).
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [ ] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: https://github.com/lufton/ha_telegram_client
Link to successful HACS action (without the `ignore` key): https://github.com/lufton/ha_telegram_client/actions/runs/10682964245
Link to successful hassfest action (if integration): https://github.com/lufton/ha_telegram_client/actions/runs/10682964250

