### PR TITLE
Remove andrew-codechimp/HA-Mastodon-Profile-Stats

### DIFF
--- a/blacklist
+++ b/blacklist
@@ -10,6 +10,7 @@
   "amaximus/bkk_stop_card",
   "amelchio/logbook_cache",
   "And3rsL/Deebot-for-Home-Assistant",
+  "andrew-codechimp/HA-Mastodon-Profile-Stats",
   "Armaell/home-assistant-custom-icons-loader",
   "atomic7777/atomic_calendar",
   "au190/au190_bkk_stop_card",

--- a/integration
+++ b/integration
@@ -57,7 +57,6 @@
   "Andre0512/speedport",
   "andrew-codechimp/HA-Andrews-Arnold-Quota",
   "andrew-codechimp/HA-Battery-Notes",
-  "andrew-codechimp/HA-Mastodon-Profile-Stats",
   "andrzejchm/blebox_shutterbox_tilt",
   "andvikt/mega_hacs",
   "aneeshd/schedule_state",

--- a/removed
+++ b/removed
@@ -1653,5 +1653,11 @@
     "reason": "Requested by author",
     "removal_type": "remove",
     "link": "https://github.com/hacs/integration/issues/4031"
+  },
+  {
+    "repository": "andrew-codechimp/HA-Mastodon-Profile-Stats",
+    "reason": "Retiring as Mastodon core duplicates functionality",
+    "removal_type": "remove",
+    "link": "https://github.com/andrew-codechimp/HA-Mastodon-Profile-Stats"
   }
 ]


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [ ] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [ ] The actions are passing without any disabled checks in my repository.
- [ ] I've added a link to the action run on my repository below in the links section.
- [ ] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/andrew-codechimp/HA-Mastodon-Profile-Stats/releases/tag/1.0.11>
Link to successful HACS action (without the `ignore` key): <https://github.com/andrew-codechimp/HA-Mastodon-Profile-Stats/actions/runs/10692754992/job/29641754136>
Link to successful hassfest action (if integration): <https://github.com/andrew-codechimp/HA-Mastodon-Profile-Stats/actions/runs/10692754992/job/29641754360>

