### PR TITLE
Remove modrzew/hass-flashforge-adventurer-3

### DIFF
--- a/integration
+++ b/integration
@@ -641,7 +641,6 @@
   "mletenay/home-assistant-ev-charge-control",
   "mletenay/home-assistant-goodwe-inverter",
   "mmillmor/geo_home",
-  "modrzew/hass-flashforge-adventurer-3",
   "Mofeywalker/openmensa-hass-component",
   "monty68/uniled",
   "moox-it/hass-moox-track",


### PR DESCRIPTION
The previous repo available at modrzew/hass-flashforge-adventurer-3 is being transferred to the new owner, f00d4tehg0dz/hass-flashforge-adventurer-3 who's going to continue maintaining it.

PR that adds f00d4tehg0dz/hass-flashforge-adventurer-3: https://github.com/hacs/default/pull/2729

Discussion in the original repo: https://github.com/modrzew/hass-flashforge-adventurer-3/pull/17#issuecomment-2227352673

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: https://github.com/modrzew/hass-flashforge-adventurer-3/releases/tag/v1.0.4
Link to successful HACS action (without the `ignore` key): https://github.com/modrzew/hass-flashforge-adventurer-3/actions/runs/9018761035/job/24780081578
Link to successful hassfest action (if integration): https://github.com/modrzew/hass-flashforge-adventurer-3/actions/runs/5627883907
