### PR TITLE
Reopening PR as hacs-bot auto closes all of them

### DIFF
--- a/integration
+++ b/integration
@@ -903,6 +903,7 @@
   "SLG/home-assistant-whatpulse",
   "slydiman/sscpoe",
   "snarky-snark/home-assistant-variables",
+  "snell-evan-itt/hassio-ecoflow-cloud-US",
   "snicker/zwift_hass",
   "snikch/climate.escea",
   "sockless-coding/garo_wallbox",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [ ] The actions are passing without any disabled checks in my repository.
- [ ] I've added a link to the action run on my repository below in the links section.
- [ ] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: https://github.com/snell-evan-itt/hassio-ecoflow-cloud-US/releases/tag/v1.0.1
Link to successful HACS action (without the ignore key): https://github.com/snell-evan-itt/hassio-ecoflow-cloud-US/actions/runs/12037896215
Link to successful hassfest action (if integration): https://github.com/snell-evan-itt/hassio-ecoflow-cloud-US/actions/runs/12037896164

