### PR TITLE
Add meteoltforecast integration

### DIFF
--- a/integration
+++ b/integration
@@ -688,6 +688,7 @@
   "modrzew/hass-flashforge-adventurer-3",
   "Mofeywalker/openmensa-hass-component",
   "monty68/uniled",
+  "moonia33/meteoltforecast",
   "moox-it/hass-moox-track",
   "moralmunky/Home-Assistant-Mail-And-Packages",
   "morosanmihail/HA-LondonTfL",


### PR DESCRIPTION
## What is being added?
- This is a new integration for Meteo.lt weather forecasts
- Provides hourly weather forecasts for Lithuanian locations using official LHMT API

## Checklist
- [x] The integration has been tested locally
- [x] Has required files:
  - README.md with installation and configuration instructions
  - manifest.json with all required fields
  - hacs.json with required configuration
- [x] Repository structure follows HACS requirements
- [x] Integration uses Home Assistant core weather platform
- [x] Has proper version tags and releases

## Additional Information
- Integration automatically selects closest location based on HA coordinates
- Updates every 30 minutes to respect API limits
- Data is provided under CC BY-SA 4.0 license from LHMT