### PR TITLE
Added mitsubishi_matouch & monarco integrations

### DIFF
--- a/integration
+++ b/integration
@@ -222,6 +222,8 @@
   "custom-components/weatheralerts",
   "custom-components/youtube",
   "custom-components/zaptec",
+  "cyaneous/mitsubishi_matouch",
+  "cyaneous/monarco",
   "cyberjunky/home-assistant-arpscan_tracker",
   "cyberjunky/home-assistant-garmin_connect",
   "cyberjunky/home-assistant-hvcgroep",


### PR DESCRIPTION
Added Mitsubishi MA Touch thermostat integration and Monarco HAT integration.

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

For mitsubishi_matouch:
Link to current release: <https://github.com/cyaneous/mitsubishi_matouch/releases/tag/0.1.1>
Link to successful HACS action (without the `ignore` key): <https://github.com/cyaneous/mitsubishi_matouch/actions/runs/12498294024/job/34871894946>
Link to successful hassfest action (if integration): <https://github.com/cyaneous/mitsubishi_matouch/actions/runs/12498294022/job/34871894948>

For monarco:
Link to current release: <https://github.com/cyaneous/monarco/releases/tag/0.1.1>
Link to successful HACS action (without the `ignore` key): <https://github.com/cyaneous/monarco/actions/runs/12498294919/job/34871897173>
Link to successful hassfest action (if integration): <https://github.com/cyaneous/monarco/actions/runs/12498294918/job/34871897294>
