### PR TITLE
Remove Music Assistant custom integration

### DIFF
--- a/integration
+++ b/integration
@@ -705,7 +705,6 @@
   "mudape/iphonedetect",
   "muhlba91/onyx-homeassistant-integration",
   "mullerdavid/hass_GreeExt",
-  "music-assistant/hass-music-assistant",
   "muxa/home-assistant-niwa-tides",
   "mvdwetering/huesyncbox",
   "mvdwetering/yamaha_ynca",


### PR DESCRIPTION
Remove Music Assistant from the repositories, it is now part of HA core.

## Checklist

- [ ] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [ ] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [ ] The actions are passing without any disabled checks in my repository.
- [ ] I've added a link to the action run on my repository below in the links section.
- [ ] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <>
Link to successful HACS action (without the `ignore` key): <>
Link to successful hassfest action (if integration): <>

