### PR TITLE
Add person_location integration

### DIFF
--- a/integration
+++ b/integration
@@ -855,6 +855,7 @@
   "robinostlund/homeassistant-volkswagencarnet",
   "robmarkcole/HASS-amazon-rekognition",
   "robmarkcole/HASS-Machinebox-Classificationbox",
+  "rodpayne/home-assistant_person_location",
   "RogerSelwyn/AICO_HomeLINK",
   "RogerSelwyn/Home_Assistant_SkyQ_MediaPlayer",
   "RogerSelwyn/O365-HomeAssistant",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [X] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [X] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [X] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [X] The actions are passing without any disabled checks in my repository.
- [X] I've added a link to the action run on my repository below in the links section.
- [X] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/rodpayne/home-assistant_person_location/releases/tag/v2025.01.08>
Link to successful HACS action (without the `ignore` key): <https://github.com/rodpayne/home-assistant_person_location/actions/runs/12683719643/job/35351242462>
Link to successful hassfest action (if integration): <https://github.com/rodpayne/home-assistant_person_location/actions/runs/12683719643/job/35351242171>

