### PR TITLE
Remove deprecated integration [FaserF/ha-deutschebahn]

### DIFF
--- a/integration
+++ b/integration
@@ -346,7 +346,6 @@
   "faanskit/ha-esolar",
   "faizpuru/ha-ambeo_soundbar",
   "fapfaff/homeassistant-appwash",
-  "faserf/ha-deutschebahn",
   "faserf/ha-rewe",
   "filipvh/hass-nhc2",
   "fineemb/Colorfulclouds-weather",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [X] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [X] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [X] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [X] The actions are passing without any disabled checks in my repository.
- [X] I've added a link to the action run on my repository below in the links section.
- [X] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: https://github.com/FaserF/ha-deutschebahn/releases/tag/3.0.5
Link to successful HACS action (without the `ignore` key): https://github.com/FaserF/ha-deutschebahn/actions/runs/12883746611/job/35918611958
Link to successful hassfest action (if integration): https://github.com/FaserF/ha-deutschebahn/actions/runs/12883759074/job/35918650748

