### PR TITLE
Add LesTR/homeassistant-minimalistic-area-card lovelance card.

### DIFF
--- a/plugin
+++ b/plugin
@@ -194,6 +194,7 @@
   "krissen/sixdegrees-card",
   "KTibow/fullscreen-card",
   "kverqus/lovelace-hassam-card",
+  "LesTR/homeassistant-minimalistic-area-card",
   "ljmerza/fitbit-card",
   "ljmerza/github-card",
   "ljmerza/harmony-remote-card",


### PR DESCRIPTION
This is a fork of the abandoned https://github.com/junalmeida/homeassistant-minimalistic-area-card, with many improvements and fixes (currently 162 commits). My version is currently backward compatible, but I renamed the card to better-minimalistic-area-card. At least 10 active users already use my fork, and this will make the process simpler for others.

This will close https://github.com/LesTR/homeassistant-minimalistic-area-card/issues/128.

Thanks!
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: https://github.com/LesTR/homeassistant-minimalistic-area-card/releases/tag/v1.2.25
Link to successful HACS action (without the ignore key):https://github.com/LesTR/homeassistant-minimalistic-area-card/actions/runs/12964691959
Link to successful hassfest action (if integration): <>

