### PR TITLE
Add movistar_rft8115vw integration

### DIFF
--- a/integration
+++ b/integration
@@ -627,6 +627,7 @@
   "Ludy87/ecotrend-ista",
   "Ludy87/ipv64",
   "Ludy87/xplora_watch",
+  "luis-garza/movistar_rft8115vw",
   "luuuis/hass_wibeee",
   "maciej-or/hikvision_next",
   "macxq/foxess-ha",


### PR DESCRIPTION
## Checklist
- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links
Link to current release: https://github.com/luis-garza/movistar_rft8115vw/releases/tag/1.0.0
Link to successful HACS action (without the `ignore` key): https://github.com/luis-garza/movistar_rft8115vw/actions/runs/13137823017/job/36657344001
Link to successful hassfest action (if integration): https://github.com/luis-garza/movistar_rft8115vw/actions/runs/13137823017/job/36657344646
