### PR TITLE
Add `frisquet-connect` to integration file

### DIFF
--- a/integration
+++ b/integration
@@ -460,6 +460,7 @@
   "hif2k1/battery_sim",
   "hmn/siku-integration",
   "hokiebrian/eia_hourly_demand",
+  "home-assistant-custom-components/frisquet-connect",
   "home-assistant-HomeWhiz/home-assistant-HomeWhiz",
   "Home-Is-Where-You-Hang-Your-Hack/sensor.goveetemp_bt_hci",
   "HomeAssistant-Mods/home-assistant-miele",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/home-assistant-custom-components/frisquet-connect/releases/tag/v1.0-rc.03091744>
Link to successful HACS action (without the `ignore` key): <https://github.com/home-assistant-custom-components/frisquet-connect/actions/runs/13750504298>
Link to successful hassfest action (if integration): <https://github.com/home-assistant-custom-components/frisquet-connect/actions/runs/13750504292>

