### PR TITLE
Remove skodaconnect integration

### DIFF
--- a/blacklist
+++ b/blacklist
@@ -299,6 +299,7 @@
   "Shreyas-R/lovelace-wallpanel-screensaver",
   "shutupflanders/sensor.moneydashboard",
   "sinclairpaul/ha_purple_theme",
+  "skodaconnect/homeassistant-skodaconnect",
   "SNoof85/lovelace-tempometer-gauge-card",
   "speleolontra/daikin_residential_altherma",
   "spycle/microbot_push",

--- a/integration
+++ b/integration
@@ -978,7 +978,6 @@
   "signalkraft/mypyllant-component",
   "sillyfrog/Automate-Pulse-v2",
   "Skarbo/hass-scinan-thermostat",
-  "skodaconnect/homeassistant-skodaconnect",
   "Slalamander/Home-Assistant-Eetlijst",
   "slashback100/presence_simulation",
   "slesinger/HomeAssistant-BMR",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->

This is a removal request for the skodaconnect custom integration. The server API's have been closed, the integration is archived.

A PR to add it's successor has been opened a few months ago at #2824 , consideration of this PR would be much appreciated.

## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [X] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [X] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [X] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [X] The actions are passing without any disabled checks in my repository.
- [ ] I've added a link to the action run on my repository below in the links section.
- [ ] I've created a new release of the repository after the validation actions were run successfully.

## Links

Links are not applicable, since the integration is being removed
