### PR TITLE
Adds new plugin [hyperb1iss/hyper-light-card]

### DIFF
--- a/plugin
+++ b/plugin
@@ -146,6 +146,7 @@
   "hasl-sensor/lovelace-hasl-traffic-status-card",
   "hulkhaugen/hass-bha-icons",
   "Hypfer/lovelace-valetudo-map-card",
+  "hyperb1iss/hyper-light-card",
   "iablon/HomeAssistant-Touchpad-Card",
   "iantrich/config-template-card",
   "iantrich/podcast-card",


### PR DESCRIPTION
Please add my hyper-light-card plugin to the official repository! It's a custom card to control my [SignalRGB plugin](https://github.com/hyperb1iss/signalrgb-homeassistant), which is already a default in HACS. The project is pretty mature and just hit it's 1.0.0 release.

Thanks!

 I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
 I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
 (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
 The actions are passing without any disabled checks in my repository.
 I've added a link to the action run on my repository below in the links section.
 I've created a new release of the repository after the validation actions were run successfully.
Links
Link to current release: https://github.com/hyperb1iss/hyper-light-card/releases/tag/v1.0.0
Link to successful HACS action (without the ignore key): https://github.com/hyperb1iss/hyper-light-card/actions/runs/13870812424/job/38817177964
Link to successful hassfest action (if integration): <n/a>

