### PR TITLE
Add MicroPIC Energy Meter to HACS default integration list

### DIFF
--- a/integration
+++ b/integration
@@ -1177,5 +1177,6 @@
   "zeronounours/HA-custom-component-energy-meter",
   "zhbjsh/homeassistant-ssh",
   "zigul/HomeAssistant-CEZdistribuce",
-  "ZsBT/hass-w1000-portal"
+  "ZsBT/hass-w1000-portal",
+  "nocturno66/MicroPIC-Energy-Meter-comp"
 ]


### PR DESCRIPTION
Repository: https://github.com/nocturno66/MicroPIC-Energy-Meter-comp  
Domain: `micropic_energy_meter`  
Minimum Home Assistant version: `2023.7.0`  
Supports config flow: ✅  

This is a custom integration for Home Assistant that connects to a MicroPIC Energy Meter via MQTT.

## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

- Link to current release: https://github.com/nocturno66/MicroPIC-Energy-Meter-comp/releases/tag/v1.0.1
- Link to successful HACS action: https://github.com/nocturno66/MicroPIC-Energy-Meter-comp/actions/runs/14164372793
- Link to successful hassfest action: https://github.com/nocturno66/MicroPIC-Energy-Meter-comp/actions/runs/14164372794