### PR TITLE
Restore briis/meteobridge integration

### DIFF
--- a/blacklist
+++ b/blacklist
@@ -39,7 +39,6 @@
   "brefra/home-assistant-plugwise-stick",
   "briis/hass-weatherflow",
   "briis/mbweather",
-  "briis/meteobridge",
   "briis/securityspy",
   "briis/smartweather",
   "briis/unifiprotect",

--- a/integration
+++ b/integration
@@ -1206,5 +1206,6 @@
   "zeronounours/HA-custom-component-energy-meter",
   "zhbjsh/homeassistant-ssh",
   "zigul/HomeAssistant-CEZdistribuce",
-  "ZsBT/hass-w1000-portal"
+  "ZsBT/hass-w1000-portal",
+  "briis/meteobridge"
 ]

--- a/removed
+++ b/removed
@@ -1763,12 +1763,6 @@
     "link": "https://github.com/hacs/default/pull/3046"
   },
   {
-    "repository": "briis/meteobridge",
-    "reason": "Repository is archived",
-    "removal_type": "remove",
-    "link": "https://github.com/hacs/default/pull/3046"
-  },
-  {
     "repository": "dahlb/ha_sense",
     "reason": "Repository is archived",
     "removal_type": "remove",


### PR DESCRIPTION
Restotore the integration Meteobridge on default repository.

