### PR TITLE
 integration of chourmovs/ha-sunforecast-plus

### DIFF
--- a/integration
+++ b/integration
@@ -192,6 +192,7 @@
   "chkuendig/hass-amphiro-ble",
   "Chouffy/home_assistant_libratone_zipp",
   "Chouffy/home_assistant_tgtg",
+  "chourmovs/ha-sunforecast-plus",
   "chris-mc1/homeconnect_local_hass",
   "chriscamicas/gazdebordeaux-ha",
   "ciejer/metservice-weather",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x ] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x ] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- x[ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x ] The actions are passing without any disabled checks in my repository.
- [x ] I've added a link to the action run on my repository below in the links section.
- [x ] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/chourmovs/ha-sunforecast-plus/releases/tag/0.31>
Link to successful HACS action (without the `ignore` key): <https://github.com/chourmovs/ha-sunforecast-plus/actions/runs/14510398291>
Link to successful hassfest action (if integration): <https://github.com/chourmovs/ha-sunforecast-plus/actions/runs/14510398293>

