### PR TITLE
Adds new plugin [DigiLive/mushroom-strategy]

### DIFF
--- a/plugin
+++ b/plugin
@@ -1,7 +1,7 @@
 [
   "9a4gl/lovelace-centrometal-boiler-card",
   "a-p-z/datetime-card",
-  "AalianKhan/mushroom-strategy",
+  "DigiLive/mushroom-strategy",
   "abmantis/ozw-network-visualization-card",
   "abualy/philips-tv-remote-card",
   "adizanni/floor3d-card",


### PR DESCRIPTION
The ownership of the Mushroom Strategy repository has changed from user AalianKhan to DigiLive.

Old: https://github.com/AalianKhan/mushroom-strategy
New: https://github.com/DigiLive/mushroom-strategy

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: https://github.com/DigiLive/mushroom-strategy/releases/tag/v2.2.0
Link to successful HACS action (without the `ignore` key): https://github.com/DigiLive/mushroom-strategy/actions/runs/14678893975
Link to successful hassfest action (if integration): N.A.

