### PR TITLE
Adds new plugin [homeassistant-extras/petkit-device-cards]

### DIFF
--- a/plugin
+++ b/plugin
@@ -146,6 +146,7 @@
   "gurbyz/power-wheel-card",
   "hasl-sensor/lovelace-hasl-departure-card",
   "hasl-sensor/lovelace-hasl-traffic-status-card",
+  "homeassistant-extras/petkit-device-cards",
   "hulkhaugen/hass-bha-icons",
   "Hypfer/lovelace-valetudo-map-card",
   "iablon/HomeAssistant-Touchpad-Card",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] ~~(For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.~~
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: https://github.com/homeassistant-extras/petkit-device-cards/releases/tag/0.2.0
Link to successful HACS action (without the `ignore` key): https://github.com/homeassistant-extras/petkit-device-cards/actions/runs/14337764013
~~Link to successful hassfest action (if integration): <>~~

