### PR TITLE
Add GeoLocator integration to default store

### DIFF
--- a/integration
+++ b/integration
@@ -1098,6 +1098,7 @@
   "slesinger/HomeAssistant-PREdistribuce",
   "SLG/home-assistant-whatpulse",
   "slydiman/sscpoe",
+  "SmartyVan/hass-geolocator",
   "smkrv/ha-text-ai",
   "snarky-snark/home-assistant-variables",
   "snell-evan-itt/hassio-ecoflow-cloud-US",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: https://github.com/SmartyVan/hass-geolocator/releases/tag/v0.3.0-beta
Link to successful HACS action (without the `ignore` key): https://github.com/SmartyVan/hass-geolocator/actions/runs/15025001088
Link to successful hassfest action (if integration): https://github.com/SmartyVan/hass-geolocator/actions/runs/15025001093

