### PR TITLE
Update theme

### DIFF
--- a/theme
+++ b/theme
@@ -13,6 +13,7 @@
   "basnijholt/lovelace-ios-dark-mode-theme",
   "basnijholt/lovelace-ios-light-mode-theme",
   "basnijholt/lovelace-ios-themes",
+  "bessertristan09/graphite-nightshade-theme",
   "bbbenji/synthwave-hass",
   "brezlord/BrezNET-iOS",
   "catppuccin/home-assistant",


### PR DESCRIPTION
### 🌓 Adds "Graphite Nightshade" theme

**Repository:** https://github.com/bessertristan09/graphite-nightshade-theme   **Maintainer:** Tristan Besser (@bessertristan09)

A refined and atmospheric dark theme for Home Assistant, based on the original Graphite Theme by Tilman Griesel — and reimagined with Figtree font, soft gradients, and full `ha-*` token support.

- ✅ HACS action passed
- ✅ Public GitHub repo with release
- ✅ Images in README
- ✅ Topics set

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [X] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [X] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [X] The actions are passing without any disabled checks in my repository.
- [X] I've added a link to the action run on my repository below in the links section.
- [ X I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/bessertristan09/graphite-nightshade-theme/releases/tag/1.0.0-alpha3>
Link to successful HACS action (without the `ignore` key): <https://github.com/bessertristan09/graphite-nightshade-theme/actions/runs/15073131478>
Link to successful hassfest action (if integration): <>

