### PR TITLE
Adds new integration [yohaybn/HA_aliexpress_package_tracker_sensor]

### DIFF
--- a/integration
+++ b/integration
@@ -1333,6 +1333,7 @@
   "ydogandjiev/hass-sutro",
   "yinyang17/pvpc_energy",
   "yo-han/Home-Assistant-Carelink",
+  "yohaybn/HA_aliexpress_package_tracker_sensor",
   "yohaybn/HomeAssistant-EPG",
   "youdroid/home-assistant-couchpotato",
   "youdroid/home-assistant-gitea",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: https://github.com/yohaybn/HA_aliexpress_package_tracker_sensor/releases/tag/2.3.1
Link to successful HACS action (without the `ignore` key): https://github.com/yohaybn/HA_aliexpress_package_tracker_sensor/actions/runs/15176398074
Link to successful hassfest action (if integration): https://github.com/yohaybn/HA_aliexpress_package_tracker_sensor/actions/runs/15176140656

