### PR TITLE
Add HeWeDe/custom-gauge-card to default HACS plugins

### DIFF
--- a/plugin
+++ b/plugin
@@ -153,6 +153,7 @@
   "harmonie-durrant/hha-cards",
   "hasl-sensor/lovelace-hasl-departure-card",
   "hasl-sensor/lovelace-hasl-traffic-status-card",
+  "HeWeDe/custom-gauge-card",
   "hulkhaugen/hass-bha-icons",
   "Hypfer/lovelace-valetudo-map-card",
   "iablon/HomeAssistant-Touchpad-Card",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [X ] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [X] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [X] The actions are passing without any disabled checks in my repository.
- [X] I've added a link to the action run on my repository below in the links section.
- [X] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: [<https://github.com/HeWeDe/custom-gauge-card>](https://github.com/HeWeDe/custom-gauge-card/releases/tag/v1.0.0)
Link to successful HACS action (without the `ignore` key): https://github.com/HeWeDe/custom-gauge-card/actions/runs/15186831648
Link to successful hassfest action (if integration): <>

