### PR TITLE
Allow marcokreeft87/room-card again

### DIFF
--- a/blacklist
+++ b/blacklist
@@ -211,7 +211,6 @@
   "mac-zhou/midea-ac-py",
   "mammuth/ha-fritzbox-tools",
   "mampfes/hacs_wiffi",
-  "marcokreeft87/room-card",
   "marcomow/ble-bulb-card",
   "marrobHD/firetv-card",
   "MatthewFlamm/nwsradar",

--- a/removed
+++ b/removed
@@ -1619,12 +1619,6 @@
     "link": "https://github.com/hacs/integration/issues/4023"
   },
   {
-    "repository": "marcokreeft87/room-card",
-    "reason": "Repository is archived",
-    "removal_type": "remove",
-    "link": "https://github.com/hacs/default/pull/2683"
-  },
-  {
     "repository": "nagyrobi/home-assistant-custom-components-linkplay",
     "reason": "Requested by author",
     "removal_type": "remove",


### PR DESCRIPTION
The repository is no longer archived, and it is the next one of the plugins to be added.