### PR TITLE
Add Bubble Room card

### DIFF
--- a/plugin
+++ b/plugin
@@ -260,6 +260,7 @@
   "MindFreeze/ha-sankey-chart",
   "mlamberts78/weather-chart-card",
   "Mofeywalker/openmensa-lovelace-card",
+  "mon3y78/Lovelace-Bubble-room",
   "MrBartusek/MeteoalarmCard",
   "nathan-gs/ha-map-card",
   "nathanmarlor/foxess_modbus_charge_period_card",


### PR DESCRIPTION
This PR adds the Bubble Room Lovelace card to the plugin list.

