### PR TITLE
Add Bubble Room card

### DIFF
--- a/plugin
+++ b/plugin
@@ -260,6 +260,7 @@
   "MindFreeze/ha-sankey-chart",
   "mlamberts78/weather-chart-card",
   "Mofeywalker/openmensa-lovelace-card",
+  "mon3y78/Lovelace-Bubble-room",
   "MrBartusek/MeteoalarmCard",
   "nathan-gs/ha-map-card",
   "nathanmarlor/foxess_modbus_charge_period_card",


### PR DESCRIPTION
This pull request adds the Bubble Room custom Lovelace card to HACS.

GitHub repository: https://github.com/mon3y78/Lovelace-Bubble-room  
Maintainer: mon3y78