### PR TITLE
added integration to check for disruptions with Ennatuurlijk

### DIFF
--- a/integration
+++ b/integration
@@ -553,6 +553,7 @@
   "HASwitchPlate/openHASP-custom-component",
   "hcoohb/hass-yeelightbt",
   "HCookie/Webhook-Service-home-assistant",
+  "heindrichpaul/ennatuurlijk_disruptions",
   "Hellowlol/ha-tide",
   "henricm/ha-ferroamp",
   "herikw/home-assistant-custom-components",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/heindrichpaul/ennatuurlijk_disruptions/releases/tag/v1.0.0>
Link to successful HACS action (without the `ignore` key): <https://github.com/heindrichpaul/ennatuurlijk_disruptions/actions/runs/15272629593>
Link to successful hassfest action (if integration): <https://github.com/heindrichpaul/ennatuurlijk_disruptions/actions/runs/15272629601>

I have created a PR with brands to get the images merged:
https://github.com/home-assistant/brands/pull/7148

