### PR TITLE
Adds new integration [alternize/ha-zeptrion-air-integration]

### DIFF
--- a/integration
+++ b/integration
@@ -59,6 +59,7 @@
   "alryaz/hass-pik-intercom",
   "alryaz/hass-tns-energo",
   "alryaz/hass-turkov",
+  "alternize/ha-zeptrion-air-integration",
   "Altrec/remko_mqtt-ha",
   "Amateur-God/home-assistant-technitiumdns",
   "amaximus/anniversary",


### PR DESCRIPTION
This adds the repository for the new "Zeptrion Air" integration

## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/alternize/ha-zeptrion-air-integration/releases/tag/release-2025.5.0>
Link to successful HACS action (without the `ignore` key): <https://github.com/alternize/ha-zeptrion-air-integration/actions/runs/15303141257/job/43048798812>
Link to successful hassfest action (if integration): <https://github.com/alternize/ha-zeptrion-air-integration/actions/runs/15303141257/job/43048798829>

