### PR TITLE
Add mon3y78/Lovelace-Bubble-room to plugins.json

### DIFF
--- a/plugin
+++ b/plugin
@@ -272,6 +272,7 @@
   "MindFreeze/ha-sankey-chart",
   "mlamberts78/weather-chart-card",
   "Mofeywalker/openmensa-lovelace-card",
+  "mon3y78/Lovelace-Bubble-room",
   "MrBartusek/MeteoalarmCard",
   "nathan-gs/ha-map-card",
   "nathanmarlor/foxess_modbus_charge_period_card",


### PR DESCRIPTION
## Repository

- Name: Lovelace Bubble Room
- URL: https://github.com/mon3y78/Lovelace-Bubble-room
- Category: plugin

## Description

A customizable Lovelace card for total visual room control in Home Assistant.

## Validation

- Repository structure: ✅
- hacs.json file present and valid: ✅
- HACS validation successful with hacs/action: ✅

Thank you for considering this addition to HACS default repositories.