### PR TITLE
Add Lovelace Bubble Room to default repositories

### DIFF
--- a/plugin
+++ b/plugin
@@ -273,6 +273,7 @@
   "MindFreeze/ha-sankey-chart",
   "mlamberts78/weather-chart-card",
   "Mofeywalker/openmensa-lovelace-card",
+  "mon3y78/Lovelace-Bubble-room",
   "MrBartusek/MeteoalarmCard",
   "nathan-gs/ha-map-card",
   "nathanmarlor/foxess_modbus_charge_period_card",


### PR DESCRIPTION
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->

## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release:  
https://github.com/mon3y78/Lovelace-Bubble-room/releases/tag/v3.1

Link to successful HACS action (without the `ignore` key):  
https://github.com/mon3y78/Lovelace-Bubble-room/actions/runs/15361907198

Link to successful hassfest action (if integration):  
N/A