### PR TITLE
Adds new integration [TilmanGriesel/ha_trmnl_weather_station]

### DIFF
--- a/integration
+++ b/integration
@@ -1354,6 +1354,7 @@
   "thomluther/ha-anker-solix",
   "tijsverkoyen/HomeAssistant-FusionSolar",
   "tikismoke/home-assistant-plcbus",
+  "TilmanGriesel/ha_trmnl_weather_station",
   "timlaing/modbus_local_gateway",
   "timmo001/homeassistant-integration-goxlr-utility",
   "timniklas/hass-blitzerde",


### PR DESCRIPTION
Use your TRMNL display to monitor live CO₂ levels and up to four custom weather sensors from your Netatmo or other supported stations.

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [ ] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: https://github.com/TilmanGriesel/ha_trmnl_weather_station/releases/tag/v0.3.0
Link to successful HACS action (without the `ignore` key): <>
Link to successful hassfest action (if integration): <>

