### PR TITLE
Add Nanoleaf Essentials integration

### DIFF
--- a/custom_components.json
+++ b/custom_components.json
@@ -1,0 +1,6 @@
+{
+  "mcaonline/nanoleaf-essentials-hass": {
+    "name": "Nanoleaf Essentials",
+    "domains": ["light"]
+  }
+}


### PR DESCRIPTION
Adds support for Nanoleaf Essentials devices.
Solves known POST/GET issues with standard integration. 

Repository: https://github.com/mcaonline/nanoleaf-essentials-hass
Features: Brightness, color, and effect controls with robust API communication

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [ ] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [ ] The actions are passing without any disabled checks in my repository.
- [ ] I've added a link to the action run on my repository below in the links section.
- [ ] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <>
Link to successful HACS action (without the `ignore` key): <>
Link to successful hassfest action (if integration): <>

