### PR TITLE
Add Nanoleaf Essentials integration

### DIFF
--- a/custom_components.json
+++ b/custom_components.json
@@ -1,0 +1,6 @@
+{
+  "mcaonline/nanoleaf-essentials-hass": {
+    "name": "Nanoleaf Essentials",
+    "domains": ["light"]
+  }
+}


### PR DESCRIPTION
Adds support for Nanoleaf Essentials devices.
Solves known POST/GET issues with standard integration. 

Repository: https://github.com/mcaonline/nanoleaf-essentials-hass
Features: Brightness, color, and effect controls with robust API communication

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [ ] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [ ] The actions are passing without any disabled checks in my repository.
- [ ] I've added a link to the action run on my repository below in the links section.
- [ ] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/mcaonline/nanoleaf-essentials-hass/releases>
Link to successful HACS action (without the `ignore` key): <Currently failing due to brands check - Brands PR submitted to https://github.com/mcaonline/brands/tree/master/custom_integrations/nanoleaf_essentials
Link to successful hassfest action https://github.com/mcaonline/nanoleaf-essentials-hass/actions/runs/15454785275
## Additional Information

**Brands PR Status**: Submitted to home-assistant/brands (awaiting merge)
- Brand assets have been added to `custom_integrations/nanoleaf_essentials/`
- Once the brands PR is merged, the HACS validation will pass automatically

**Integration Description**: 
This custom integration provides support for Nanoleaf Essentials devices, which are not supported by the core Nanoleaf integration. It solves known POST/GET API communication issues and provides stable connectivity for Essentials devices.

**Why this integration is needed**:
- The core Nanoleaf integration does not support Essentials devices
- Solves documented issues with Essentials API communication [ref: Home Assistant Core Issue #132084](https://github.com/home-assistant/core/issues/132084)
- Provides dedicated support for Nanoleaf Essentials product line

**Installation via Custom Repository** (available now):
Users can already install this integration by adding it as a custom repository in HACS:
- Repository: `https://github.com/mcaonline/nanoleaf-essentials-hass`
- Category: Integration

