### PR TITLE
Add Syslog Receiver integration to default HACS integration list

### DIFF
--- a/integration
+++ b/integration
@@ -1491,6 +1491,7 @@
   "zeronounours/HA-custom-component-energy-meter",
   "zhbjsh/homeassistant-ssh",
   "zigul/HomeAssistant-CEZdistribuce",
+  "zollak/homeassistant-syslog-receiver",
   "ZsBT/hass-w1000-portal",
   "zubir2k/homeassistant-dailyhadith",
   "zubir2k/homeassistant-esolatgps",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: https://github.com/zollak/homeassistant-syslog-receiver/releases/tag/v1.0.7
Link to successful HACS action (without the `ignore` key): https://github.com/zollak/homeassistant-syslog-receiver/actions/runs/15092956198
Link to successful hassfest action (if integration): https://github.com/zollak/homeassistant-syslog-receiver/actions/runs/15092956210
