### PR TITLE
Adds new integration [krissen/pollenprognos-card]

### DIFF
--- a/integration
+++ b/integration
@@ -811,6 +811,7 @@
   "krasnoukhov/homeassistant-oncharger",
   "krasnoukhov/homeassistant-smart-maic",
   "krasnoukhov/homeassistant-tesy",
+  "krissen/pollenprognos-card",
   "kubawolanin/ha-reaper",
   "kuchel77/diskspace",
   "kukulich/home-assistant-jablotron100",


### PR DESCRIPTION

## Checklist

- [X] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [X] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [X] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [X] The actions are passing without any disabled checks in my repository.
- [X] I've added a link to the action run on my repository below in the links section.
- [X] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: https://github.com/krissen/polleninformation/releases/tag/v0.2.0
Link to successful HACS action (without the `ignore` key): https://github.com/krissen/polleninformation/actions/runs/15542725025/job/43757101822
Link to successful hassfest action (if integration): https://github.com/krissen/polleninformation/actions/runs/15542725025/job/43757101836

