### PR TITLE
Adds new integration [DFranzen/Simple-Universal-Touchpad-for-Homeassistant]

### DIFF
--- a/plugin
+++ b/plugin
@@ -97,6 +97,7 @@
   "denysdovhan/vacuum-card",
   "dermotduffy/advanced-camera-card",
   "dezihh/my-harmony-card",
+  "DFranzen/Simple-Universal-Touchpad-for-Homeassistant",
   "DigiLive/mushroom-strategy",
   "dimagoltsman/content-card-remote-control",
   "dimagoltsman/generic-remote-control-card",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [X] I've added a link to the action run on my repository below in the links section.
- [X] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/DFranzen/Simple-Universal-Touchpad-for-Homeassistant/releases/tag/v0.2>
Link to successful HACS action (without the `ignore` key): <https://github.com/DFranzen/Simple-Universal-Touchpad-for-Homeassistant/actions/runs/15620480051>
Link to successful hassfest action (if integration): plugin

