### PR TITLE
Add new plugin [dropqube/pv-forecast-card]

### DIFF
--- a/plugin
+++ b/plugin
@@ -108,6 +108,7 @@
   "dooz127/swipe-glance-card",
   "drakulis/jb-battery-card",
   "drkpxl/printwatch-card",
+  "dropqube/pv-forecast-card",
   "dvb6666/homed-zigbee-networkmap",
   "dylandoamaral/uptime-card",
   "elax46/custom-brand-icons",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [X] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [X] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [X] The actions are passing without any disabled checks in my repository.
- [X] I've added a link to the action run on my repository below in the links section.
- [X] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/dropqube/pv-forecast-card/releases/tag/v1.0.9>
Link to successful HACS action (without the `ignore` key): <https://github.com/dropqube/pv-forecast-card/actions/runs/15636629119>
Link to successful hassfest action (if integration): <>

