### PR TITLE
Adds new integration [frimtec/hass-swiss-pollen]

### DIFF
--- a/integration
+++ b/integration
@@ -516,6 +516,7 @@
   "frenck/spook",
   "freol35241/ltss",
   "frimtec/hass-compal-wifi",
+  "frimtec/hass-swiss-pollen",
   "frlequ/homeassistant-mojelektro",
   "fsaris/home-assistant-awox",
   "fsaris/home-assistant-zonneplan-one",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully. => missing brand error remains, see open PR: https://github.com/home-assistant/brands/pull/7272; requires no new release to fix it.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: https://github.com/frimtec/hass-swiss-pollen/releases/tag/0.2.0
Link to successful HACS action (without the `ignore` key):  https://github.com/frimtec/hass-swiss-pollen/actions/runs/15663009177/job/44123475814 - missing brand error remains, see open PR: https://github.com/home-assistant/brands/pull/7272
Link to successful hassfest action (if integration):  https://github.com/frimtec/hass-swiss-pollen/actions/runs/15663009177/job/44123475817

