### PR TITLE
Adds new integration [Korkuttum/tuya_body_fat_scale]

### DIFF
--- a/integration
+++ b/integration
@@ -808,6 +808,7 @@
   "kongo09/hass-dell-printer",
   "kongo09/philips-airpurifier-coap",
   "konnected-io/noonlight-hass",
+  "Korkuttum/tuya_body_fat_scale",
   "Korkuttum/tuya_scale",
   "kotborealis/home-assistant-custom-components-cover-time-based-synced",
   "koying/jellyfin_ha",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [X] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [X] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [X] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [X] The actions are passing without any disabled checks in my repository.
- [X] I've added a link to the action run on my repository below in the links section.
- [X] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/Korkuttum/tuya_body_fat_scale/releases/tag/v1.1.2>
Link to successful HACS action (without the `ignore` key): <https://github.com/Korkuttum/tuya_body_fat_scale/actions/runs/15705614790>
Link to successful hassfest action (if integration): <https://github.com/Korkuttum/tuya_body_fat_scale/actions/runs/15705614779>

