### PR TITLE
Adds new plugin [eyalgal/ha-shopping-list-card]

### DIFF
--- a/plugin
+++ b/plugin
@@ -117,6 +117,7 @@
   "elyobelyob/octopus-energy-greenness-forecast-card",
   "EnkodoNL/tabbed-card-programmable",
   "entekadesign/kobold-alarm-clock-card",
+  "eyalgal/ha-shopping-list-card",
   "ExperienceLovelace/ha-floorplan",
   "ezand/lovelace-posten-card",
   "faeibson/lovelace-multiline-text-input-card",


### PR DESCRIPTION
Adds the Shopping List Card custom frontend card to the HACS default repository list.

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/eyalgal/ha-shopping-list-card/releases/tag/v1.0.0>
Link to successful HACS action (without the `ignore` key): <https://github.com/eyalgal/ha-shopping-list-card/actions/runs/15830191965/job/44620666240>
Link to successful hassfest action (if integration): <>

