### PR TITLE
Add thanoskas/arrowhead_alarm integration

### DIFF
--- a/integration
+++ b/integration
@@ -1362,6 +1362,7 @@
   "tetele/hvac_group",
   "tggm/rointe-radiators",
   "Thank-you-Linus/Linus-Dashboard",
+  "thanoskas/arrowhead_alarm",
   "ThaStealth/alfen_modbus",
   "TheByteStuff/RemoteSyslog_Service",
   "thecem/octopus_germany",


### PR DESCRIPTION
## Integration Details

**Repository**: https://github.com/thanoskas/arrowhead_alarm
**Integration Name**: Arrowhead Alarm Panel
**Domain**: arrowhead_alarm

## Description
Professional Home Assistant integration for Arrowhead alarm panels with advanced zone detection and multi-panel support.

## Features
- Multi-panel support (ESX Elite-SX and ECi Series)
- Automatic zone detection for ECi panels
- Comprehensive alarm control and monitoring
- Professional documentation and extensive testing

## Verification
- [x] Repository is public
- [x] Repository has description and topics
- [x] Repository has GitHub release (v1.0.0)
- [x] Integration has valid manifest.json
- [x] Integration has valid hacs.json
- [x] Repository has comprehensive README
- [x] Repository has MIT license
- [x] Repository has issues enabled
- [x] Integration follows Home Assistant best practices

## Testing
Integration has been tested with:
- ESX Elite-SX panels
- ECi Series panels
- Home Assistant 2024.4.0+
- Extensive test suite (400+ tests)

## Submission Checklist
- [x] Added entry in alphabetical order
- [x] Repository meets all HACS requirements
- [x] Integration is working and stable
- [x] Documentation is complete