### PR TITLE
Add MicroPIC Energy Meter integration

### DIFF
--- a/integration
+++ b/integration
@@ -809,6 +809,7 @@
   "NinDTendo/homeassistant_gradual_volume_control",
   "NinDTendo/tobi",
   "nkvoll/home-assistant-qsys-qrc",
+  "nocturno66/MicroPIC-Energy-Meter-comp",
   "nordicopen/easee_hass",
   "nstrelow/ha_philips_android_tv",
   "nyffchanium/argoclima-integration",
@@ -1177,6 +1178,5 @@
   "zeronounours/HA-custom-component-energy-meter",
   "zhbjsh/homeassistant-ssh",
   "zigul/HomeAssistant-CEZdistribuce",
-  "ZsBT/hass-w1000-portal",
-  "nocturno66/MicroPIC-Energy-Meter-comp"
+  "ZsBT/hass-w1000-portal"  
 ]

--- a/integration
+++ b/integration
@@ -809,7 +809,7 @@
   "NinDTendo/homeassistant_gradual_volume_control",
   "NinDTendo/tobi",
   "nkvoll/home-assistant-qsys-qrc",
-  "nocturno66/MicroPIC-Energy-Meter-comp",
+  "nocturno66/MicroPIC_Energy_Meter",
   "nordicopen/easee_hass",
   "nstrelow/ha_philips_android_tv",
   "nyffchanium/argoclima-integration",

--- a/integration
+++ b/integration
@@ -1177,5 +1177,6 @@
   "zeronounours/HA-custom-component-energy-meter",
   "zhbjsh/homeassistant-ssh",
   "zigul/HomeAssistant-CEZdistribuce",
-  "ZsBT/hass-w1000-portal"
+  "ZsBT/hass-w1000-portal",
+  "nocturno66/MicroPIC-Energy-Meter-comp"
 ]


### PR DESCRIPTION
Repository: https://github.com/nocturno66/MicroPIC_Energy_Meter  
Domain: `micropic_energy_meter`  
Minimum Home Assistant version: 2023.7.0  
Supports config flow: ✅  

This is a custom integration for Home Assistant that connects to a MicroPIC Energy Meter via MQTT.

---

### Checklist

- [x] I’ve read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I’ve added the [HACS action](https://hacs.xyz/docs/publish/include#github-action) to my repository.
- [x] I’ve added the [hassfest action](https://hacs.xyz/docs/publish/include#hassfest-action) to my repository.
- [x] The actions are passing without any disabled checks.
- [x] I’ve created a release of the repository after the validation actions ran successfully.

### Links

- 🔗 [Release v1.0.1](https://github.com/nocturno66/MicroPIC_Energy_Meter/releases/tag/v1.0.1)  
- ✅ [HACS action](https://github.com/nocturno66/MicroPIC_Energy_Meter/actions/runs/14316128842/job/40122549444)  
- ✅ [Hassfest action](https://github.com/nocturno66/MicroPIC_Energy_Meter/actions/runs/14315965030/job/40122010000)

