### PR TITLE
Add micropic energy meter

### DIFF
--- a/.github/workflows/hacs.yaml
+++ b/.github/workflows/hacs.yaml
@@ -1,0 +1,18 @@
+name: Validate with HACS
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  hacs:
+    name: HACS Validation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run HACS validation
+        uses: hacs/action@main
+        with:
+          category: integration

--- a/.github/workflows/hassfest.yaml
+++ b/.github/workflows/hassfest.yaml
@@ -1,0 +1,16 @@
+name: Hassfest Validation
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  hassfest:
+    name: Run Hassfest
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run Hassfest
+        uses: home-assistant/actions/hassfest@master

--- a/integration
+++ b/integration
@@ -1045,7 +1045,6 @@
   "NinDTendo/homeassistant_gradual_volume_control",
   "NinDTendo/tobi",
   "nkvoll/home-assistant-qsys-qrc",
-  "nocturno66/MicroPIC_Energy_Meter",
   "nordicopen/easee_hass",
   "normcyr/home-assistant-montreal-aqi",
   "nstrelow/ha_philips_android_tv",
@@ -1525,5 +1524,6 @@
   "zubir2k/homeassistant-dailyhadith",
   "zubir2k/homeassistant-esolatgps",
   "zubir2k/homeassistant-esolattakwim",
-  "zulufoxtrot/ha-zyxel"
+  "zulufoxtrot/ha-zyxel",
+  "nocturno66/MicroPIC_Energy_Meter"
 ]

--- a/integration
+++ b/integration
@@ -1045,6 +1045,7 @@
   "NinDTendo/homeassistant_gradual_volume_control",
   "NinDTendo/tobi",
   "nkvoll/home-assistant-qsys-qrc",
+  "nocturno66/MicroPIC_Energy_Meter",
   "nordicopen/easee_hass",
   "normcyr/home-assistant-montreal-aqi",
   "nstrelow/ha_philips_android_tv",


### PR DESCRIPTION
Repository: https://github.com/nocturno66/MicroPIC_Energy_Meter  
Domain: `micropic_energy_meter`  
Minimum Home Assistant version: 2023.7.0  
Supports config flow: ✅  

This is a custom integration for Home Assistant that connects to a MicroPIC Energy Meter via MQTT.

---

### Checklist

- [x] I’ve read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I’ve added the [HACS action](https://hacs.xyz/docs/publish/include#github-action) to my repository.
- [x] I’ve added the [hassfest action](https://hacs.xyz/docs/publish/include#hassfest-action) to my repository.
- [x] The actions are passing without any disabled checks.
- [x] I’ve created a release of the repository after the validation actions ran successfully.

### Links

- 🔗 [Release 1.0.2](https://github.com/nocturno66/MicroPIC_Energy_Meter/releases/tag/1.0.2)  
- ✅ [HACS action](https://github.com/nocturno66/MicroPIC_Energy_Meter/actions/runs/15873948875/job/44756969291)  
- ✅ [Hassfest action](https://github.com/nocturno66/MicroPIC_Energy_Meter/actions/runs/15873948869/job/44756969250)
