### PR TITLE
Add integration nocturno66/MicroPIC_Energy_Meter

### DIFF
--- a/integration
+++ b/integration
@@ -1045,6 +1045,7 @@
   "NinDTendo/homeassistant_gradual_volume_control",
   "NinDTendo/tobi",
   "nkvoll/home-assistant-qsys-qrc",
+  "nocturno66/MicroPIC_Energy_Meter",
   "nordicopen/easee_hass",
   "normcyr/home-assistant-montreal-aqi",
   "nstrelow/ha_philips_android_tv",


### PR DESCRIPTION
Repository: https://github.com/nocturno66/MicroPIC_Energy_Meter
Domain: micropic_energy_meter
Minimum Home Assistant version: 2023.7.0
Supports config flow: ✅

This is a custom integration for Home Assistant that connects to a MicroPIC-based energy meter via MQTT.
It allows real-time monitoring of power and energy parameters from a Microchip PIC microcontroller.

✅ Checklist
- [x] I've read the publishing documentation.
- [x] I've added the HACS action to my repository.
- [x] I've added the Hassfest action to my repository.
- [x] The actions are passing without any disabled checks.
- [x] I've created a release of the repository after the validation actions ran successfully.

🔗 Links:
- [Release 1.0.2](https://github.com/nocturno66/MicroPIC_Energy_Meter/releases/tag/1.0.2)
- [HACS action](https://github.com/nocturno66/MicroPIC_Energy_Meter/actions/workflows/hacs.yaml)
- [Hassfest action](https://github.com/nocturno66/MicroPIC_Energy_Meter/actions/workflows/hassfest.yaml)
