### PR TITLE
Update plugin file to include "0Paul89/vienna-transport-card"

### DIFF
--- a/plugin
+++ b/plugin
@@ -1,5 +1,6 @@
 [
   "9a4gl/lovelace-centrometal-boiler-card",
+  "0Paul89/vienna-transport-card",
   "a-p-z/datetime-card",
   "abmantis/ozw-network-visualization-card",
   "abualy/philips-tv-remote-card",


### PR DESCRIPTION
Added "0Paul89/vienna-transport-card", which is a dashboard card for displaying Vienna public transport departure times.

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: https://github.com/0Paul89/vienna-transport-card/releases/tag/v1.0.0
Link to successful HACS action (without the `ignore` key): https://github.com/0Paul89/vienna-transport-card/actions/runs/15968731603
Link to successful hassfest action (if integration): <>

