### PR TITLE
Add divomen/ha-captcha-balance integration

### DIFF
--- a/integration
+++ b/integration
@@ -418,6 +418,7 @@
   "dimagoltsman/ha-proof-dashcam-integration",
   "dingo35/ha-SmartEVSEv3",
   "dinki/view_assist_integration",
+  "divomen/ha-captcha-balance",
   "dirkgroenen/hass-evse-load-balancer",
   "djansen1987/SAJeSolar",
   "djbulsink/panasonic_ac",


### PR DESCRIPTION
Adds RuCaptcha / 2Captcha Home Assistant integration for monitoring account balance.

## Integration Details
- **Repository**: https://github.com/divomen/ha-captcha-balance
- **Version**: v1.2.0
- **Release**: https://github.com/divomen/ha-captcha-balance/releases/tag/v1.2.0

## Features
- Support for both RuCaptcha and 2Captcha services
- Configurable update intervals (1-1440 minutes) and currency display
- Device registry and options flow support
- Automatic retry with exponential backoff
- Dynamic icons based on balance level
- Proper error handling and logging

## Testing
- [x] Integration tested with HACS custom repository
- [x] Proper release created with correct version tags
- [x] HACS.json configuration verified
- [x] Integration follows Home Assistant best practices

The integration allows users to monitor their captcha service account balance directly in Home Assistant and can be used in automations for low balance alerts.