### PR TITLE
Add divomen/ha-captcha-balance integration

### DIFF
--- a/integration
+++ b/integration
@@ -418,6 +418,7 @@
   "dimagoltsman/ha-proof-dashcam-integration",
   "dingo35/ha-SmartEVSEv3",
   "dinki/view_assist_integration",
+  "divomen/ha-captcha-balance",
   "dirkgroenen/hass-evse-load-balancer",
   "djansen1987/SAJeSolar",
   "djbulsink/panasonic_ac",


### PR DESCRIPTION
Adds Home Assistant integration for monitoring RuCaptcha and 2Captcha account balance.

## Integration Details
- **Repository**: https://github.com/divomen/ha-captcha-balance
- **Description**: Home Assistant integration for monitoring RuCaptcha and 2Captcha account balance with configurable alerts and automation support
- **Version**: v1.2.1 (HACS validation fixes)
- **Release**: https://github.com/divomen/ha-captcha-balance/releases/tag/v1.2.1

## HACS Requirements Met
- [x] Public GitHub repository with description and topics
- [x] README.md with installation and configuration instructions  
- [x] MIT License
- [x] hacs.json configuration file
- [x] manifest.json with required codeowners field
- [x] Semantic versioning with proper releases
- [x] Integration tested and functional
- [x] Home Assistant 2023.1.0+ compatibility

## Features
- Support for both RuCaptcha and 2Captcha services (same company, identical APIs)
- Configurable update intervals (1-1440 minutes) and currency display (RUB, EUR, USD)
- Device registry and options flow support for easy reconfiguration
- Automatic retry with exponential backoff for reliability
- Dynamic icons based on balance level (low/medium/high)
- Proper error handling and logging
- Creates `sensor.captcha_balance` entity for use in automations

## Use Cases
- Monitor captcha service account balance
- Low balance alerts and automations
- Budget tracking for captcha services
- Service availability monitoring