### PR TITLE
Add mac8005/xiaozhi-mcp-hacs to default integrations

### DIFF
--- a/integration
+++ b/integration
@@ -1575,3 +1575,4 @@
   "zubir2k/homeassistant-esolattakwim",
   "zulufoxtrot/ha-zyxel"
 ]
+mac8005/xiaozhi-mcp-hacs


### PR DESCRIPTION
This PR adds **mac8005/xiaozhi-mcp-hacs** to `integration` in alphabetical order.