### PR TITLE
Add mac8005/xiaozhi-mcp-hacs to default integrations

### DIFF
--- a/integration
+++ b/integration
@@ -923,6 +923,7 @@
   "luis-garza/movistar_rft8115vw",
   "luuuis/hass_wibeee",
   "M1R4G376/New_bestway_spa",
+  "mac8005/xiaozhi-mcp-hacs",
   "maciej-or/hikvision_next",
   "macxq/foxess-ha",
   "madpilot/hass-amber-electric",


### PR DESCRIPTION
Insert **mac8005/xiaozhi-mcp-hacs** in alphabetical order without re-sorting the file.