### PR TITLE
Add Horizontal Forecast Card

### DIFF
--- a/plugin
+++ b/plugin
@@ -256,6 +256,7 @@
   "Makin-Things/bom-radar-card",
   "Makin-Things/platinum-weather-card",
   "Makin-Things/weather-radar-card",
+  "Matbe34/Horizontal-Forecast-Card",
   "malcolmrigg/wizard-clock-card",
   "mampfes/ha-knx-uf-iconset",
   "ManfredTremmel/lovelace-heat-pump-card",


### PR DESCRIPTION
## Description
Add Horizontal Forecast Card to the HACS default store.

## Repository Details
- **Repository**: https://github.com/Matbe34/Horizontal-Forecast-Card
- **Category**: Plugin (Lovelace Dashboard)
- **Latest Release**: v1.0.1

## Features
- Modern horizontal weather forecast display
- Drag-to-scroll functionality for desktop and mobile
- Local SVG weather icons for reliability
- Responsive design with mobile optimization
- Smart caching and auto-refresh capabilities
- Cross-browser compatibility

## Validation
- ✅ Repository has proper HACS configuration (`hacs.json`)
- ✅ GitHub Actions workflow for HACS validation passes
- ✅ Proper documentation and README
- ✅ MIT License included
- ✅ Release v1.0.1 available with distribution file
- ✅ Images provided for HACS validation
- ✅ follows HACS guidelines for plugin submission

## Screenshots
Repository includes preview images showing the card in both desktop and mobile views.

## Testing
The plugin has been tested with Home Assistant and works correctly with weather entities.