### PR TITLE
Add Yamaha R-N301 network receiver integration

### DIFF
--- a/integration
+++ b/integration
@@ -1223,6 +1223,7 @@
   "rgc99/irrigation_unlimited",
   "rgerbranda/rbfa",
   "rhanekom/hass-qwikswitch-api",
+  "rihokirss/homeasisstant-rn301",
   "rine77/homeassistantedupage",
   "rinyakok/homeassistant_idokep",
   "rknightion/meraki-dashboard-ha",


### PR DESCRIPTION
Home Assistant custom component for Yamaha R-N301 network receiver. Provides media player functionality with support for power control, volume, source selection, and media playback control.

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
 ## Checklist

  <!-- Do not open a pull request before you have completed all these, it will be closed. -->

 - [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
 - [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
 - [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
 - [x] The actions are passing without any disabled checks in my repository.
 - [x] I've added a link to the action run on my repository below in the links section.
 - [x] I've created a new release of the repository after the validation actions were run successfully.

 ## Links

 <!-- Do not open a pull request before you have provided all these, it will be closed. -->

 Link to current release: <https://github.com/rihokirss/homeasisstant-rn301/releases/tag/v1.2.0>
 Link to successful HACS action (without the `ignore` key): <https://github.com/rihokirss/homeasisstant-rn301/actions/workflows/hacs.yaml>
 Link to successful hassfest action (if integration): <https://github.com/rihokirss/homeasisstant-rn301/actions/workflows/hassfest.yaml>
