### PR TITLE
Add grocy integration

### DIFF
--- a/blacklist
+++ b/blacklist
@@ -93,7 +93,6 @@
   "custom-components/custom_updater",
   "custom-components/fedex",
   "custom-components/google_keep",
-  "custom-components/grocy",
   "custom-components/hassbian_config",
   "custom-components/information",
   "custom-components/linksys_ap",

--- a/integration
+++ b/integration
@@ -306,6 +306,7 @@
   "custom-components/climate.programmable_thermostat",
   "custom-components/feedparser",
   "custom-components/gpodder",
+  "custom-components/grocy",
   "custom-components/healthchecksio",
   "custom-components/media_player.braviatv_psk",
   "custom-components/nordpool",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/custom-components/grocy/releases/tag/2025.7.0>
Link to successful HACS action (without the `ignore` key): <https://github.com/custom-components/grocy/actions/runs/16308442127>
Link to successful hassfest action (if integration): <https://github.com/custom-components/grocy/actions/runs/16308459681>

