### PR TITLE
Adds new plugin [eyalgal/hatch-card]

### DIFF
--- a/plugin
+++ b/plugin
@@ -124,6 +124,7 @@
   "entekadesign/kobold-alarm-clock-card",
   "ExperienceLovelace/ha-floorplan",
   "eyalgal/ha-shopping-list-card",
+  "eyalgal/hatch-card",
   "ezand/lovelace-posten-card",
   "faeibson/lovelace-multiline-text-input-card",
   "FamousWolf/week-planner-card",


### PR DESCRIPTION
Added 'eyalgal/hatch-card' to the plugin list.

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/eyalgal/hatch-card/releases/tag/V1.0.0>
Link to successful HACS action (without the `ignore` key): <https://github.com/eyalgal/hatch-card/actions/runs/16408748052>
Link to successful hassfest action (if integration): <https://github.com/eyalgal/hatch-card/actions/runs/16408748052>