### PR TITLE
Adds new plugin [Rishi8078/TimeFlow-Card]

### DIFF
--- a/plugin
+++ b/plugin
@@ -347,6 +347,7 @@
   "rgc99/irrigation-unlimited-card",
   "rianadon/opensprinkler-card",
   "rianadon/timer-bar-card",
+  "Rishi8078/TimeFlow-Card",
   "RJArmitage/rfxtrx-stateful-blinds-icons",
   "rkotulan/ha-wall-clock-card",
   "RodBr/miflora-card",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/Rishi8078/TimeFlow-Card/releases/tag/v1.0.0>
Link to successful HACS action (without the `ignore` key): <https://github.com/Rishi8078/TimeFlow-Card/actions/workflows/validate.yaml>
Link to successful hassfest action (if integration): <N/A - This is a plugin>

## Repository Information

**Repository:** https://github.com/Rishi8078/TimeFlow-Card
**Type:** Plugin (Dashboard)
**Description:** A beautiful countdown timer card for Home Assistant with animated progress circle and intelligent time formatting.

**Features:**
- Animated SVG progress circle with dynamic scaling
- Smart time display with natural language formatting
- Card-mod compatibility for advanced styling
- Entity support for dynamic countdowns
- Cross-platform date parsing

**Repository Requirements:**
- ✅ Public GitHub repository
- ✅ Repository description and topics added
- ✅ Issues enabled
- ✅ HACS validation action implemented and passing
- ✅ GitHub release v1.0.0 available
- ✅ Proper file structure (dist/timeflow-card.js)
- ✅ MIT licensed
- ✅ Comprehensive documentation
- ✅ Repository owner submitting
- ✅ Submitted from feature branch (not master)