### PR TITLE
Add pvyleta/xcc-integration

### DIFF
--- a/integration
+++ b/integration
@@ -1191,6 +1191,7 @@
   "ptimatth/GeorideHA",
   "PTST/LibreView-HomeAssistant",
   "pveiga90/What-s-up-Docker-Updates-Monitor",
+  "pvyleta/xcc-integration",
   "py-smart-gardena/hass-gardena-smart-system",
   "pyalarmdotcom/alarmdotcom",
   "Pyhass/Hive-Custom-Component",


### PR DESCRIPTION
## Checklist

- [x] I have read the [guidelines for repository inclusion](https://hacs.xyz/docs/publish/include)
- [x] The repository comply with the [repository requirements](https://hacs.xyz/docs/publish/start)
- [x] This is not a duplicate request
- [x] I am the owner of this repository

## Links

- **Repository**: https://github.com/pvyleta/xcc-integration
- **Latest Release**: https://github.com/pvyleta/xcc-integration/releases/tag/v1.9.64
- **Hassfest Action** (✅ Passing): https://github.com/pvyleta/xcc-integration/actions/runs/16448839490
- **HACS Action** (❌ Failing - Brands requirement): https://github.com/pvyleta/xcc-integration/actions/runs/16448839469

## Repository Information

**Name**: AC Heating XCC Heat Pump Controller  
**Description**: Home Assistant integration for AC Heating XCC heat pump controllers with photovoltaic integration. Provides comprehensive monitoring and control capabilities with automatic entity discovery and bilingual support (English/Czech).

**Category**: Integration  
**Topics**: home-assistant, integration, heat-pump, xcc, hacs, custom-component

## Note on Brands Requirement

The HACS Action currently fails due to the brands repository requirement. The integration passes all other validation checks:
- ✅ Hassfest validation
- ✅ HACS JSON format
- ✅ Repository structure
- ✅ GitHub releases
- ✅ Repository topics
- ❌ Brands repository (pending)

I understand that the integration must be added to home-assistant/brands before HACS inclusion. Should I:
1. Submit to brands repository first, then resubmit this PR?
2. Or can this PR remain open pending brands approval?

The integration is fully functional and ready for use as a custom repository while awaiting brands inclusion.