### PR TITLE
Add ziogref/TAS-Fuel-HA-Intergration

### DIFF
--- a/integration
+++ b/integration
@@ -1579,6 +1579,7 @@
   "zhbjsh/homeassistant-ssh",
   "zheffie/mijn_waterlink",
   "zigul/HomeAssistant-CEZdistribuce",
+  "ziogref/TAS-Fuel-HA-Intergration"
   "zollak/homeassistant-syslog-receiver",
   "ZsBT/hass-w1000-portal",
   "zubir2k/homeassistant-dailyhadith",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

> **Note**
> The `brands` validation check is currently failing as expected. The pull request to add the required logos has been submitted to the `home-assistant/brands` repository and is awaiting review here: https://github.com/home-assistant/brands/pull/7523

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: https://github.com/ziogref/TAS-Fuel-HA-Intergration/releases/tag/v1.0.1
Link to successful HACS action (without the `ignore` key): https://github.com/ziogref/TAS-Fuel-HA-Intergration/actions/runs/16538983727
Link to successful hassfest action (if integration): https://github.com/ziogref/TAS-Fuel-HA-Intergration/actions/runs/16538983727