### PR TITLE
feat: add HomeSeer (HS3/HS4) integration

### DIFF
--- a/integration
+++ b/integration
@@ -1585,5 +1585,5 @@
   "zubir2k/homeassistant-esolatgps",
   "zubir2k/homeassistant-esolattakwim",
   "zulufoxtrot/ha-zyxel"
-  "tzachb/Homeseer-HA"
+  "tzachb/Homeseer-HA",
 

--- a/integration
+++ b/integration
@@ -1585,4 +1585,5 @@
   "zubir2k/homeassistant-esolatgps",
   "zubir2k/homeassistant-esolattakwim",
   "zulufoxtrot/ha-zyxel"
-]
+  "tzachb/Homeseer-HA"
+


### PR DESCRIPTION
<!--## Proposed change
Add the HomeSeer (HS3/HS4) custom integration to HACS so that users of HS3 or HS4 on HA 2025.6+ can install it directly.

## Checklist
- [x] I’ve read the [publishing documentation](https://hacs.xyz/docs/publish/include)
- [x] I’ve added a `.github/workflows/hacs.yaml` to run the HACS validation
- [x] I’ve added a `hacs.json` (and `topics`) in my repo
- [x] I’ve moved all integration files under `custom_components/homeseer/`
- [x] My `manifest.json` includes `documentation`, `issue_tracker`, `codeowners`, `iot_class`
- [x] The integration validation and HACS action have both passed on my fork

## Links
- **Release**: https://github.com/tzachb/Homeseer-HA/releases/tag/1.0.0‑rc10  
- **HACS action**: https://github.com/tzachb/Homeseer-HA/actions/runs/                              
  _(copy the URL of your successful “Validate HACS Integration” run on your fork)_

---

DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [ ] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [ ] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [ ] The actions are passing without any disabled checks in my repository.
- [ ] I've added a link to the action run on my repository below in the links section.
- [ ] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <>
Link to successful HACS action (without the `ignore` key): <>
Link to successful hassfest action (if integration): <>

