### PR TITLE
Adds new integration [Elijaht-dev/ovh_ipv6]

### DIFF
--- a/integration
+++ b/integration
@@ -483,6 +483,7 @@
   "elden1337/hass-peaq",
   "elden1337/hass-peaqhvac",
   "elden1337/hass-peaqnext",
+  "Elijaht-dev/ovh_ipv6",
   "elsbrock/cowboy-ha",
   "Elwinmage/ha-reefbeat-component",
   "emes30/facebook_messenger",


### PR DESCRIPTION
add ovh_ipv6 integration to integrations

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/Elijaht-dev/ovh_ipv6/releases/tag/v2.0.4>
Link to successful HACS action (without the `ignore` key): <https://github.com/Elijaht-dev/ovh_ipv6/actions/runs/16607497120/job/46982955119>
Link to successful hassfest action (if integration): <https://github.com/Elijaht-dev/ovh_ipv6/actions/runs/16607497120/job/46982955168>

