### PR TITLE
Add BaillClim integration to HACS default repository

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -1,0 +1,8 @@
+{
+  "repository": "https://github.com/hebrru/baillclim",
+  "full_name": "hebrru/baillclim",
+  "category": "integration",
+  "name": "BaillClim",
+  "description": "Contrôle de climatiseur connecté via BaillConnect pour Home Assistant",
+  "authors": ["@herbru"]
+}


### PR DESCRIPTION
## ➕ Nouvelle intégration : BaillClim

Ajout de l'intégration personnalisée **BaillClim** permettant de piloter la climatisation via BaillConnect depuis Home Assistant.

- 🔗 Dépôt : https://github.com/hebrru/baillclim
- 🏷️ Catégorie : integration
- 🧩 Type : custom_components
- 🇫🇷 Auteur : @herbru
- 🔖 Version actuelle : [v4.0.0](https://github.com/hebrru/baillclim/releases/tag/v4.0.0)

Merci à l'équipe HACS 🙏
