### PR TITLE
Ajout de BaillClim - Intégration BaillConnect pour Home Assistant

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -1,0 +1,13 @@
+{
+  "baillclim": {
+    "name": "BaillClim",
+    "content_in_root": false,
+    "country": "fr",
+    "description": "Piloter vos thermostats BaillConnect depuis Home Assistant.",
+    "domain": "baillclim",
+    "filename": "custom_components/baillclim/manifest.json",
+    "location": "https://github.com/hebrru/baillclim",
+    "type": "integration",
+    "authors": ["herbru"]
+  }
+}


### PR DESCRIPTION
Nouvelle intégration : BaillClim
Ajout de l’intégration personnalisée BaillClim, permettant de piloter la climatisation d'une unité BaillIndustrie via la passerelle BaillConnect, directement depuis Home Assistant.

Dépôt : [hebrru/baillclim](https://github.com/hebrru/baillclim)

Catégorie : integration

Type : custom_components

Auteur : @herbru

Version actuelle : [v4.0.0](https://github.com/hebrru/baillclim/releases/tag/v4.0.0)

Merci à toute l’équipe HACS pour votre travail.
