### PR TITLE
Add BaillClim integration to HACS default repository

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -1,0 +1,13 @@
+{
+  "baillclim": {
+    "name": "BaillClim",
+    "content_in_root": false,
+    "country": "fr",
+    "description": "Piloter vos thermostats BaillConnect depuis Home Assistant.",
+    "domain": "baillclim",
+    "filename": "custom_components/baillclim/manifest.json",
+    "location": "https://github.com/hebrru/baillclim",
+    "type": "integration",
+    "authors": ["herbru"]
+  }
+}


### PR DESCRIPTION
Hello HACS team,

This PR proposes a new integration for the HACS default list:

- Name: BaillClim
- Description: Controls BaillConnect-based climate systems via Home Assistant
- Repo: https://github.com/hebrru/baillclim
- Author: @herbru
- Category: integration
- First release: [v4.0.0](https://github.com/hebrru/baillclim/releases/tag/v4.0.0)

Thank you for your time and your work on HACS 🙏
