### PR TITLE
Add baillclim integration to default list

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -1,0 +1,13 @@
+{
+  "baillclim": {
+    "name": "BaillClim",
+    "content_in_root": false,
+    "country": "fr",
+    "description": "Piloter vos thermostats BaillConnect depuis Home Assistant.",
+    "domain": "baillclim",
+    "filename": "custom_components/baillclim/manifest.json",
+    "location": "https://github.com/hebrru/baillclim",
+    "type": "integration",
+    "authors": ["herbru"]
+  }
+}


### PR DESCRIPTION
✅ Add baillclim integration to default list
Hello HACS team 👋

I would like to propose adding my custom integration baillclim to the default list of HACS integrations.

This integration allows users to connect their BaillConnect thermostats (used in many French HVAC systems) to Home Assistant. It provides support for:

✅ climate entities (on/off, heating/cooling modes, setpoints)

✅ sensor entities (ambient temperature, mode)

✅ switch, number, select (control thermostats and schedules)

✅ A full implementation with config flow, coordinator, and API session management

🌍 Frequently requested in French-speaking Home Assistant communities

GitHub repository:
🔗 https://github.com/hebrru/baillclim

Latest release (v4.1):
📦 https://github.com/hebrru/baillclim/releases/tag/v5.0.0

🔧 HACS Action validation
✅ HACS validation passes (except brands which is being submitted here)

✅ Integration is well-documented and actively maintained

✅ Tests passed on Home Assistant 2023.5+

📌 Checklist
 I have read the publishing guide

 I have added the HACS action

 The actions are passing successfully

 I have created a tagged release v5.0.0

 This integration is useful to the community and safe to add

Thanks for your time and for making HACS awesome! 🙏
Hervé / @hebrru