### PR TITLE
feat: add HomeSeer (HS3/HS4) integration

### DIFF
--- a/integration
+++ b/integration
@@ -1585,5 +1585,5 @@
   "zubir2k/homeassistant-esolatgps",
   "zubir2k/homeassistant-esolattakwim",
   "zulufoxtrot/ha-zyxel"
-  "tzachb/Homeseer-HA"
+  "tzachb/Homeseer-HA",
 

--- a/integration
+++ b/integration
@@ -1585,4 +1585,5 @@
   "zubir2k/homeassistant-esolatgps",
   "zubir2k/homeassistant-esolattakwim",
   "zulufoxtrot/ha-zyxel"
-]
+  "tzachb/Homeseer-HA"
+


### PR DESCRIPTION



This PR adds a custom integration for HomeSeer HS3/HS4 to Home Assistant via HACS.  
Replaces previous PR #3863 with corrected structure.
