### PR TITLE
Adding Max Hauri MaxSmart integration

### DIFF
--- a/integration
+++ b/integration
@@ -1366,6 +1366,7 @@
   "solarssk/ztm_warsaw",
   "soloam/ha-pid-controller",
   "sopelj/hass-ember-mug-component",
+  "Superkikim/mh-maxsmart-hass",
   "SpanPanel/span",
   "SplinterHead/ha-honeygain",
   "sprocket-9/hacs-nuvo-serial",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->

Adding Max Hauri MaxSmart power strips and smart plugs integration.

**Features:**
- Local control (no cloud required)  
- Real-time power monitoring every 5 seconds
- Supports 1-port smart plugs and 6-port power stations
- Home Assistant native name management
- Automatic device detection and migration

**Device Compatibility:**
- Max Hauri MaxSmart Power Station (6-port) - Firmware v1.30 ✅ Tested
- Max Hauri MaxSmart Smart Plug (1-port) - Firmware v1.30 ✅ Tested  
- MaxSmart devices with firmware v2.11+ ✅ Tested
- Other REVOGI-based devices (community testing welcome)

## Checklist
<!-- Do not open a pull request before you have completed all these, it will be closed. -->
- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links
<!-- Do not open a pull request before you have provided all these, it will be closed. -->
Link to current release: <https://github.com/superkikim/mh-maxsmart-hass/releases/tag/2025.7.1>
Link to successful HACS action (with the `ignore` key): <https://github.com/Superkikim/mh-maxsmart-hass/actions/runs/16418056870>
Link to successful hassfest action (if integration): <https://github.com/Superkikim/mh-maxsmart-hass/actions/runs/16418056858>