### PR TITLE
Add jonducrou/ha_visualiser integration

### DIFF
--- a/integration
+++ b/integration
@@ -755,6 +755,7 @@
   "JonasJoKuJonas/homeassistant-trias",
   "JonasJoKuJonas/homeassistant-WebUntis",
   "JonasPed/homeassistant-eloverblik",
+  "jonducrou/ha_visualiser",
   "jonkristian/wasteplan_trv",
   "jonnybergdahl/HomeAssistant_NewsbinPro_Integration",
   "joosthoi1/hockey-team-tracker",


### PR DESCRIPTION
Home Assistant Entity Visualizer - Interactive entity relationship visualization

Repository: https://github.com/jonducrou/ha_visualiser
- Visualizes HA entities as interactive network graphs
- Shows relationships between entities, devices, areas, automations
- Professional interface with comprehensive relationship detection
- Production ready (v0.8.2) with extensive testing
- HACS-compatible structure
- Added to home-assistant/brands repository

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: https://github.com/jonducrou/ha_visualiser/releases/tag/v0.8.2
Link to successful HACS action (without the `ignore` key): https://github.com/jonducrou/ha_visualiser/actions/runs/16801107338
Link to successful hassfest action (if integration): https://github.com/jonducrou/ha_visualiser/actions/runs/16801107331
