### PR TITLE
Adds new plugin [redkanoon/embedded-view-card]

### DIFF
--- a/plugin
+++ b/plugin
@@ -344,6 +344,7 @@
   "r-renato/ha-card-weather-conditions",
   "rautesamtr/thermal_comfort_icons",
   "rccoleman/lovelace-lamarzocco-config-card",
+  "redkanoon/embedded-view-card",
   "redstone99/hass-alert2-ui",
   "rejuvenate/lovelace-horizon-card",
   "reptilex/tesla-style-solar-power-card",


### PR DESCRIPTION
Embedded View Card for Home Assistant

Repository : https://github.com/redkanoon/embedded-view-card

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [X] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [X] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [X] The actions are passing without any disabled checks in my repository.
- [X] I've added a link to the action run on my repository below in the links section.
- [X] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/redkanoon/embedded-view-card/releases/tag/v1.2.5>
Link to successful HACS action (without the `ignore` key): <https://github.com/redkanoon/embedded-view-card/actions/runs/16815821465>

