### PR TITLE
Add ha-previous-statetracker integration

### DIFF
--- a/integration
+++ b/integration
@@ -829,6 +829,7 @@
   "kirei/hass-chargeamps",
   "kirill-k2/hass-guk-krasnodar",
   "klacol/homeassistant-clage_homeserver",
+  "klaptafel/ha-previous-state-tracker",
   "klatka/nc-talk-bot-component",
   "klausj1/homeassistant-statistics",
   "Kleinrotti/hass-senertec",


### PR DESCRIPTION
https://github.com/klaptafel/ha-previous-state-tracker

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: https://github.com/klaptafel/ha-previous-state-tracker/releases/tag/1.0.1 
Link to successful HACS action (without the `ignore` key): https://github.com/klaptafel/ha-previous-state-tracker/actions/runs/16820316976/job/47645757288
Link to successful hassfest action (if integration): https://github.com/klaptafel/ha-previous-state-tracker/actions/runs/16819179461/job/47642612117 

