### PR TITLE
feat: add HomeSeer (HS3/HS4) integration

### DIFF
--- a/integration
+++ b/integration
@@ -1585,5 +1585,5 @@
   "zubir2k/homeassistant-esolatgps",
   "zubir2k/homeassistant-esolattakwim",
   "zulufoxtrot/ha-zyxel"
-  "tzachb/Homeseer-HA"
+  "tzachb/Homeseer-HA",
 

--- a/integration
+++ b/integration
@@ -1585,4 +1585,5 @@
   "zubir2k/homeassistant-esolatgps",
   "zubir2k/homeassistant-esolattakwim",
   "zulufoxtrot/ha-zyxel"
-]
+  "tzachb/Homeseer-HA"
+


### PR DESCRIPTION


This PR adds the `tzachb/Homeseer-HA` integration to the HACS default list.

The repository follows the HACS structure:
- `hacs.json` is in the root
- `custom_components/homeseer/` includes `manifest.json`, integration files
- `.github/workflows/hacs.yaml` exists for validation

This PR replaces #3863 and #3896.

@hacs/integration-maintainers — the repo has been cleaned and validation workflow is fixed. Could you please approve the workflows so the checks can run? Thank you!
