### PR TITLE
add HomeSeer (HS3/HS4) integration

### DIFF
--- a/integration
+++ b/integration
@@ -1585,5 +1585,5 @@
   "zubir2k/homeassistant-esolatgps",
   "zubir2k/homeassistant-esolattakwim",
   "zulufoxtrot/ha-zyxel"
-  "tzachb/Homeseer-HA"
+  "tzachb/Homeseer-HA",
 

--- a/integration
+++ b/integration
@@ -1585,4 +1585,5 @@
   "zubir2k/homeassistant-esolatgps",
   "zubir2k/homeassistant-esolattakwim",
   "zulufoxtrot/ha-zyxel"
-]
+  "tzachb/Homeseer-HA"
+

--- a/integration
+++ b/integration
@@ -1496,6 +1496,7 @@
   "tykeal/homeassistant-rental-control",
   "tykovec/home-assistant-tritius",
   "TypQxQ/Sigenergy-Local-Modbus",
+  "tzachb/Homeseer-HA",
   "ualex73/monitor_docker",
   "ufozone/ha-unifi-voucher",
   "ufozone/ha-zcs-mower",
@@ -1584,6 +1585,6 @@
   "zubir2k/homeassistant-dailyhadith",
   "zubir2k/homeassistant-esolatgps",
   "zubir2k/homeassistant-esolattakwim",
-  "zulufoxtrot/ha-zyxel"
-  "tzachb/Homeseer-HA",
+  "zulufoxtrot/ha-zyxel",
+  
 


### PR DESCRIPTION
Description
This PR adds the tzachb/Homeseer-HA integration to the HACS default list.

Repository details

The repository follows the HACS structure:

hacs.json is in the root.

custom_components/homeseer/ includes manifest.json and all integration files.

.github/workflows/hacs.yaml exists for validation.

Request
The repository has been cleaned, validated, and the HACS validation workflow is fixed.
Could you please approve the workflows so the checks can run? Thank you.

Links

Repository: https://github.com/tzachb/Homeseer-HA

Checklist

 I have read the HACS repository guidelines.

 The repository follows the required structure and file placement.

 All YAML and JSON files are valid and pass lint checks.

 The integration works in Home Assistant without errors.

 I have only changed the integration list to add my repository entry.

 This PR is for adding a new repository, not for modifying or removing an existing one.