### PR TITLE
change name of xweather integration to xweatherly

### DIFF
--- a/integration
+++ b/integration
@@ -1434,7 +1434,7 @@
   "tarikbc/ha-intelbras-alarm",
   "tarikbc/ha-ppa-contatto",
   "Tasshack/dreame-vacuum",
-  "tbclark3/homeassistant-xweather",
+  "tbclark3/ha-xweatherly",
   "tbouron/ha-agur",
   "tcarwash/home-assistant_noaa-space-weather",
   "tefinger/hass-brematic",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

This PR changes the name of my integration from Xweather to Xweatherly in order to avoid a conflict with the brand of Vaisala Xweather.  I understand that changing the name of an integration is serious, but I think the fallout in this case is minimal because the integration has existed for such a short time. I doubt if anybody has downloaded it yet. It is a necessary action, however, because I realized that the original name could have been seen as a trademark infringement. 

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/tbclark3/ha-xweatherly>
Link to successful HACS action (without the `ignore` key): <https://github.com/tbclark3/ha-xweatherly/actions/runs/16980277092>
Link to successful hassfest action (if integration): <https://github.com/tbclark3/ha-xweatherly/actions/runs/16980124781>

