### PR TITLE
Adding integration dmoralesdev/zha_lock_manager

### DIFF
--- a/integration
+++ b/integration
@@ -443,6 +443,7 @@
   "dm82m/hass-Deltasol-KM2",
   "dmamontov/hass-miwifi",
   "dmamontov/hass-seafile",
+  "dmoralesdev/zha_lock_manager",
   "dmoranf/home-assistant-wattio",
   "dolezsa/thermal_comfort",
   "dominikamann/oekofen-pellematic-compact",


### PR DESCRIPTION
Add dmoralesdev/zha_lock_manager to default integrations.

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: https://github.com/dmoralesdev/zha_lock_manager/releases/tag/v0.3.7
Link to successful HACS action (without the `ignore` key): https://github.com/dmoralesdev/zha_lock_manager/actions/runs/16999000651
Link to successful hassfest action (if integration): https://github.com/dmoralesdev/zha_lock_manager/actions/runs/16999000657

