### PR TITLE
add-seneye-integration

### DIFF
--- a/integration
+++ b/integration
@@ -1624,4 +1624,6 @@
   "zubir2k/homeassistant-esolatgps",
   "zubir2k/homeassistant-esolattakwim",
   "zulufoxtrot/ha-zyxel"
+  "tamengual/home-assistant-seneye-pi"
+
 ]


### PR DESCRIPTION
Adds the Seneye USB Sensor custom component to the HACS default store.

Repo: https://github.com/tamengual/home-assistant-seneye-pi
Category: integration
Features: Temp, pH, NH3, PAR, PUR, Lux, Kelvin + binary sensors

Local‑first integration for Seneye USB probes. Polls the device via pyseneye and exposes sensors for Temperature, pH, NH3, PAR, PUR, LUX, Kelvin; plus binary sensors for In Water and Slide Problem. Includes UI options (poll interval + calibration), diagnostics export, and a seneye.force_update service.