### PR TITLE
Update integration

### DIFF
--- a/integration
+++ b/integration
@@ -254,6 +254,7 @@
   "cavefire/Bose-Homeassistant",
   "cavefire/hass-openid",
   "cazeaux/ha-iracing",
+  "CBdesignS/ha-wordplay"
   "cdnninja/yoto_ha",
   "chaimchaikin/molad-ha",
   "CharlesGillanders/homeassistant-alphaESS",


### PR DESCRIPTION
add CBDesignS/ha-wordplay to hacs

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [X] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [X] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [X] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [X] The actions are passing without any disabled checks in my repository.
- [X] I've added a link to the action run on my repository below in the links section.
- [X] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/CBDesignS/ha-wordplay/releases/tag/v5.0.3.3>
Link to successful HACS action (without the `ignore` key): <https://github.com/CBDesignS/ha-wordplay/actions/runs/17085403792>
Link to successful hassfest action (if integration): <https://github.com/CBDesignS/ha-wordplay/actions/runs/17085975761>

