### PR TITLE
Add integration: martindell/ha-entity-notes

### DIFF
--- a/integration
+++ b/integration
@@ -988,6 +988,7 @@
   "marq24/ha-tibber-pulse-local",
   "marq24/ha-waterkotte",
   "martinarva/dynamic_energy_cost",
+  "martindell/ha-entity-notes",
   "MartinDybal/TapHome-HomeAssistant",
   "martinstafford/daikin_d3net",
   "Martinvdm/garbage-nissewaard-homeassistant",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: https://github.com/martindell/ha-entity-notes/releases/tag/v1.3.0  
Link to successful HACS action (without the `ignore` key): https://github.com/martindell/ha-entity-notes/actions/runs/17154593424  
Link to successful hassfest action (if integration): https://github.com/martindell/ha-entity-notes/actions/runs/17154593418
