### PR TITLE
Add Traeger WiFire integration

### DIFF
--- a/integration
+++ b/integration
@@ -774,6 +774,7 @@
   "joggs/home_assistant_ebeco",
   "JohNan/homeassistant-wellbeing",
   "johnnybegood/ha-ksenia-lares",
+  "johnvoipguy/hacs-Traeger-WiFire",
   "Johnwulp/rad-afval",
   "joleys/niko-home-control-II",
   "jonandel/ha-hildebrandglow-dcc",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [Y ] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [Y] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [Y] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [Y] The actions are passing without any disabled checks in my repository.
- [Y] I've added a link to the action run on my repository below in the links section.
- [Y] I've created a new release of the repository after the validation actions were run successfully.

## Links
<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/johnvoipguy/hacs-Traeger-WiFire/releases/tag/v1.0.2> 
Link to successful HACS action (without the `ignore` key): <https://github.com/johnvoipguy/hacs-Traeger-WiFire/actions/runs/17163909185>
Link to successful hassfest action (if integration): <https://github.com/johnvoipguy/hacs-Traeger-WiFire/actions/runs/17163909185>

