### PR TITLE
Add plugwise_usb-beta integration to HACS

### DIFF
--- a/integration
+++ b/integration
@@ -1206,6 +1206,7 @@
   "plamish/xcomfort",
   "plmilord/Hass.io-custom-component-ikamand",
   "plmilord/Hass.io-custom-component-spaclient",
+  "plugwise/plugwise_usb-beta",
   "Poeschl/Remote-PicoTTS",
   "popeen/Home-Assistant-Custom-Component-Brandrisk-Eldningsforbud",
   "popeen/Home-Assistant-Custom-Component-Hemglass",


### PR DESCRIPTION
## Checklist 
- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [ ] I've added a link to the action run on my repository below in the links section.
- [ ] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/plugwise/plugwise_usb-beta/releases/tag/v0.55.11>
Link to successful HACS action (without the `ignore` key): <https://github.com/plugwise/plugwise_usb-beta/actions/runs/17331574048>
Link to successful hassfest action (if integration): <https://github.com/plugwise/plugwise_usb-beta/actions/runs/17331574048>

