### PR TITLE
Add andreas-glaser/ha-dessmonitor integration

### DIFF
--- a/integration
+++ b/integration
@@ -92,6 +92,7 @@
   "andrea-mattioli/bticino_x8000_component",
   "andreadegiovine/homeassistant-stellantis-vehicles",
   "andreaprosseda/vimar-byme-plus-homeassistant",
+  "andreas-glaser/ha-dessmonitor",
   "AndreaTomatis/loex-xsmart-integration",
   "andrejs2/arso_potresi",
   "andrejs2/slovenian_weather_integration",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/andreas-glaser/ha-dessmonitor/releases/tag/1.3.1>
Link to successful HACS action (without the `ignore` key): <https://github.com/andreas-glaser/ha-dessmonitor/actions/runs/17312422267>
Link to successful hassfest action (if integration): <https://github.com/andreas-glaser/ha-dessmonitor/actions/runs/17311862949>