### PR TITLE
Add alexlenk/ecowitt_local integration

### DIFF
--- a/integration
+++ b/integration
@@ -47,6 +47,7 @@
   "alexdelprete/ha-4noks-elios4you",
   "alexdelprete/ha-abb-powerone-pvi-sunspec",
   "alexdelprete/ha-sinapsi-alfa",
+  "alexlenk/ecowitt_local",
   "Alexwijn/SAT",
   "AlexxIT/Jura",
   "AlexxIT/SonoffLAN",


### PR DESCRIPTION
## Summary

Add Ecowitt Local integration to HACS default repository.

## Integration Details

**Repository**: https://github.com/alexlenk/ecowitt_local
**Integration Name**: Ecowitt Local
**Description**: A Home Assistant custom integration that replaces the webhook-based Ecowitt integration with local web interface polling to solve sensor ID stability issues and provide enhanced device organization.

## Key Features

- **Hardware-based stable entity IDs** - Uses sensor hardware IDs for permanent entity identification that never change when batteries are replaced
- **Individual sensor devices** - Each physical sensor gets its own Home Assistant device with proper organization
- **Enhanced security** - No HTTP exposure required unlike webhook integration
- **Rich monitoring data** - Battery levels, signal strength, online status, and hardware information
- **Local polling** - More reliable than webhook dependency with robust error handling

## HACS Compliance

✅ All required manifest.json fields present
✅ Proper repository structure with integration in custom_components/ecowitt_local/
✅ Comprehensive README.md documentation
✅ hacs.json configuration file
✅ Active maintenance with recent releases (v1.4.2)
✅ Comprehensive testing (89% coverage)

## Quality Metrics

- **Test Coverage**: 89% with 96 automated tests
- **Type Safety**: Full mypy compliance
- **Documentation**: Comprehensive README with installation, configuration, and troubleshooting
- **CI/CD**: Automated testing pipeline
- **Quality Scale**: Platinum (as declared in manifest.json)

🤖 Generated with [Claude Code](https://claude.ai/code)