### PR TITLE
Add custom integration exo_pool

### DIFF
--- a/integration
+++ b/integration
@@ -179,6 +179,7 @@
   "bendikrb/ha-devtools",
   "bendikrb/ha-politikontroller",
   "benjamin-dcs/file-plusplus",
+  "benjycov/exo_pool",
   "benleb/sureha",
   "Bennett-Wendorf/hass-uplift-desk",
   "BenPru/novus300_Rs485",


### PR DESCRIPTION
## Proposed change
This PR adds the `exo_pool` custom integration to the HACS default repository.

`exo_pool` provides Home Assistant integration for Zodiac / Fluidra Exo pool systems via the iAqualink API. It exposes entities for chlorine generation, pH regulation, water temperature, and system state, giving users direct pool control and monitoring from within Home Assistant.

## Checklist
- [x] The integration has a valid `manifest.json` (with `domain`, `name`, `version`, `documentation`, `issue_tracker`, and `codeowners`)
- [x] A valid `hacs.json` file is present
- [x] The repository has a clear `README.md` with installation/configuration instructions
- [x] A `LICENSE` file is present
- [x] GitHub releases are used for versioning (semantic versioning)
- [x] Branding assets (`icon.png`, `logo.png`) have been added and accepted in `home-assistant/brands`
- [x] Topics set on the repository (`home-assistant`, `hacs`, `pool`, `iaqualink`, `zodiac`)
- [x] Repository includes an `issue tracker` link for support

## Repository
🔗 https://github.com/benjycov/exo_pool

## Additional information
- Users are already actively installing and discussing this integration via custom HACS URLs.
- Adding it to the HACS default list will simplify installation and encourage proper use of GitHub for issues, support, and feature requests.
