### PR TITLE
Add Sikom integration to default list

### DIFF
--- a/integration
+++ b/integration
@@ -680,6 +680,7 @@
   "hopkins-tk/home-assistant-aseko-local",
   "hostcc/hass-gs-alarm",
   "houthacker/remeha-modbus",
+  "Howard0000/home-assistant-sikom",
   "HrGaertner/HA-vent-optimization",
   "hsakoh/ha-switchbot-kvs-camera",
   "hsk-dk/home-assistant-thermex",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.


## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/Howard0000/home-assistant-sikom/releases/tag/V1.0.0>
Link to successful HACS action (without the `ignore` key): <https://github.com/Howard0000/home-assistant-sikom/actions/runs/17654063862>
Link to successful hassfest action (if integration): <https://github.com/Howard0000/home-assistant-sikom/actions/runs/17654063862>

