### PR TITLE
Adds new plugin [maybetaken/ha-makeskyblue-mppt-card]

### DIFF
--- a/plugin
+++ b/plugin
@@ -286,6 +286,7 @@
   "mawinkler/astroweather-card",
   "maxwroc/battery-state-card",
   "maxwroc/github-flexi-card",
+  "maybetaken/ha-makeskyblue-mppt-card",
   "MelleD/lovelace-expander-card",
   "mentalilll/ha-vpd-chart",
   "micash545/hass-selfhst-icons",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: 
https://github.com/maybetaken/ha-makeskyblue-mppt-card/releases/tag/v0.0.2
Link to successful HACS action (without the `ignore` key):
https://github.com/maybetaken/ha-makeskyblue-mppt-card/actions/runs/17706477093/job/50319335109
Link to successful hassfest action (if integration): <>

