### PR TITLE
Add new integration bbckr/hacs-synology-tasks

### DIFF
--- a/integration
+++ b/integration
@@ -167,6 +167,7 @@
   "basilfx/homeassistant-biketrax",
   "basnijholt/adaptive-lighting",
   "basschipper/homeassistant-generic-hygrostat",
+  "bbckr/hacs-synology-tasks",
   "bbr111/byd_hvs",
   "bcpearce/homeassistant-gtfs-realtime",
   "bdunn44/hass-jellyfish-lighting",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [X] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [X] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [X] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [X] The actions are passing without any disabled checks in my repository.
- [X] I've added a link to the action run on my repository below in the links section.
- [X] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: https://github.com/bbckr/hacs-synology-tasks/releases/tag/0.1.0
Link to successful HACS action (without the `ignore` key): https://github.com/bbckr/hacs-synology-tasks/actions/runs/17713647757/job/50335656027
Link to successful hassfest action (if integration): https://github.com/bbckr/hacs-synology-tasks/actions/runs/17713647757/job/50335656032

