### PR TITLE
Add WJDDesigns/Ultra-Card plugin

### DIFF
--- a/plugin
+++ b/plugin
@@ -437,6 +437,7 @@
   "wassy92x/lovelace-ha-dashboard",
   "wilsto/pool-monitor-card",
   "wiltodelta/homeassistant-sugartv-card",
+  "WJDDesigns/Ultra-Card",
   "WJDDesigns/Ultra-Vehicle-Card",
   "wrodie/mixer-card",
   "xBourner/area-card-plus",


### PR DESCRIPTION
## Plugin Submission: Ultra Card

**Repository:** https://github.com/WJDDesigns/Ultra-Card
**Category:** Plugin (Dashboard/Frontend)
**Version:** 1.0.0

### Description
Ultra Card is a modular card builder for Home Assistant with a professional page-builder interface. It provides:

- 🛠 Visual editor with drag-and-drop interface
- 🧩 12 module types for any dashboard need
- 🔧 Conditional logic and animation system
- 🌈 Professional design controls
- 📱 Mobile optimized and responsive
- 🌎 Internationalization (14 languages)

### Repository Compliance
- [x] Repository is public and properly documented
- [x] Contains required `hacs.json` file
- [x] Main file `ultra-card.js` is in repository root
- [x] Has GitHub releases with semantic versioning (v1.0.0)
- [x] Passes all validation requirements
- [x] Repository owner/major contributor submitting

### Additional Information
This card has been in development and testing for several months, with an active community providing feedback and translations. The v1.0.0 release includes a complete feature set with professional-grade visual editing capabilities.
