### PR TITLE
Add ziogref/TAS-Fuel-HA-Intergration

### DIFF
--- a/integration
+++ b/integration
@@ -1655,6 +1655,7 @@
   "zheffie/mijn_waterlink",
   "zhheo/ha_honghui_climate",
   "zigul/HomeAssistant-CEZdistribuce",
+  "ziogref/TAS-Fuel-HA-Intergration",
   "zollak/homeassistant-syslog-receiver",
   "ZsBT/hass-w1000-portal",
   "zubir2k/homeassistant-dailyhadith",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

> **Note**
> I had previously created pull request #3857 the last comment on July 28 2025 "hacs-bot" said it would be added and then my PR was closed. It has not been added, I suspect due to a missing comma in my original PR. Its been 6 weeks and still not added so I thought I would re-raise as I assumed it was closed by accident. I'm aware of the rules and this is not an attempt to speed up the process I honestly believe a mistake was made.
## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: https://github.com/ziogref/TAS-Fuel-HA-Intergration/releases/tag/v1.0.2
Link to successful HACS action (without the `ignore` key): https://github.com/ziogref/TAS-Fuel-HA-Intergration/actions/runs/17719272713
Link to successful hassfest action (if integration): https://github.com/ziogref/TAS-Fuel-HA-Intergration/actions/runs/17719272713

