### PR TITLE
Update integration - add repository rwunsch/schulmanager-online-hass

### DIFF
--- a/integration
+++ b/integration
@@ -1635,6 +1635,7 @@
   "wlcrs/huawei_solar",
   "wolffshots/hass-audiobookshelf",
   "wrodie/ha_behringer_mixer",
+  "rwunsch/schulmanager-online-hass",
   "wuwentao/midea_ac_lan",
   "xannor/ha_reolink_discovery",
   "xiaodong-lx/tplink-ipc-control",


### PR DESCRIPTION
# Schulmanager Online Integration for Home Assistant

A comprehensive Home Assistant integration for Schulmanager Online with extended sensors and calendar integration.  A powerful custom UI card will be available in the future.

## Sensors (8 per child)
- Current Lesson: Shows the currently active lesson
- Next Lesson: Shows the next upcoming lesson
- Today's Lessons: Count and details of today's lessons
- Today's Changes: Substitutions and changes for today
- Next School Day: Lessons for the next school day (skips weekends)
- This Week: Complete overview of the current school week
- Next Week: Complete overview of the next school week
- Changes Detected: Diff sensor with before/after comparison ##  Calendar (per child)
- Schedule Calendar: All lessons as calendar entries ⚠️ Times are estimates
- Homework Calendar: Homework with due dates (optional)
- Substitution Plan: Automatic marking of substitutions

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [ ] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [ ] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [ ] The actions are passing without any disabled checks in my repository.
- [ ] I've added a link to the action run on my repository below in the links section.
- [ ] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/rwunsch/schulmanager-online-hass/releases/tag/v1.0.3>
Link to successful HACS action (without the `ignore` key): <> (tbd. brand missing)
Link to successful hassfest action (if integration): <https://github.com/rwunsch/schulmanager-online-hass/actions/runs/17733796143>
Location BRAND pull request: <https://github.com/home-assistant/brands/pull/7925>

