### PR TITLE
feat: adds cmgrayb/hass-dyson to the list of default repositories

### DIFF
--- a/integration
+++ b/integration
@@ -289,6 +289,7 @@
   "ClusterM/skykettle-ha",
   "CM000n/qss",
   "Cmajda/ha_golemio",
+  "cmgrayb/hass-dyson",
   "cnecrea/cursbnr",
   "cnecrea/eonromania",
   "cnecrea/erovinieta",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/cmgrayb/hass-dyson/releases/tag/v0.15.1>
Link to successful HACS action (without the `ignore` key): <https://github.com/cmgrayb/hass-dyson/actions/runs/17744232989>
Link to successful hassfest action (if integration): <https://github.com/cmgrayb/hass-dyson/actions/runs/17744188327>

