### PR TITLE
Adds new integration [jseidl/magic-areas]

### DIFF
--- a/integration
+++ b/integration
@@ -818,7 +818,7 @@
   "jrgim/Zaragoza_tram",
   "jrmattila/ha-elenia",
   "jscruz/sensor.carbon_intensity_uk",
-  "jseidl/hass-magic_areas",
+  "jseidl/magic-areas",
   "jsheputis/home-assistant-lifetime-fitness",
   "jtbgroup/kodi-media-sensors",
   "juacas/honor_x3",


### PR DESCRIPTION
Following renaming of my repository https://github.com/jseidl/magic-areas/, updating HACS default/integration to point to the new repository name.

Integration name does not change, just the repository name.

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/jseidl/magic-areas/releases/tag/4.4.1>
Link to successful HACS action (without the `ignore` key): <https://github.com/jseidl/magic-areas/actions/runs/17692916493/job/50288854844>
Link to successful hassfest action (if integration): <https://github.com/jseidl/magic-areas/actions/runs/17692916493/job/50288854851>

