### PR TITLE
Adds new integration [CMGeorge/homeassistant_sabiana_smart_energy]

### DIFF
--- a/integration
+++ b/integration
@@ -290,6 +290,7 @@
   "ClusterM/skykettle-ha",
   "CM000n/qss",
   "Cmajda/ha_golemio",
+  "CMGeorge/homeassistant_sabiana_smart_energy",
   "cmgrayb/hass-dyson",
   "cnecrea/cursbnr",
   "cnecrea/eonromania",


### PR DESCRIPTION
A custom integration for Home Assistant that enables communication with Sabiana Smart Energy heat recovery units over Modbus (RTU or TCP). This integration provides access to diagnostic data, environmental sensors, fan status, and control over various operational parameters.

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [X] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [X] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [X] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [X] The actions are passing without any disabled checks in my repository.
- [X] I've added a link to the action run on my repository below in the links section.
- [X] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/CMGeorge/homeassistant_sabiana_smart_energy/releases/tag/1.0.2>
Link to successful HACS action (without the `ignore` key): <https://github.com/CMGeorge/homeassistant_sabiana_smart_energy/actions/runs/17783736785/job/50565191768>
Link to successful hassfest action (if integration): <https://github.com/CMGeorge/homeassistant_sabiana_smart_energy/actions/runs/17790348208>

