### PR TITLE
Add ha-aecc-cloud

### DIFF
--- a/integration
+++ b/integration
@@ -1,6 +1,7 @@
 [
   "0jety0/emaux_spv150",
   "0xAlon/dolphin",
+  "huang021119/HACS_ceshi",
   "0xQuantumHome/bayrol-home-hassistant",
   "3ll3d00d/jriver_homeassistant",
   "3p3v/berluf_selen_2",


### PR DESCRIPTION
集成名称：ha-aecc-cloud
功能简介：用于监测储能设备数据的传感器集成，支持实时数据更新。
仓库地址：https://github.com/huang021119/HACS_ceshi
最低 Home Assistant 版本：2023.8.0