### PR TITLE
Add 'farosch/hacs_hp_aruba_switch' to integration

### DIFF
--- a/integration
+++ b/integration
@@ -546,6 +546,7 @@
   "faizpuru/ha-ambeo_soundbar",
   "faizpuru/ha-pilot-wire-climate",
   "fapfaff/homeassistant-appwash",
+  "farosch/hacs_hp_aruba_switch", 
   "FaserF/ha-boulderwelt",
   "FaserF/ha-chefkoch",
   "FaserF/ha-db_infoscreen",


### PR DESCRIPTION
This integration allows configuring port and POE status via home assistant.
It works with common HP and Aruba switches through ssh.

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <>
Link to successful HACS action (without the `ignore` key): <>
Link to successful hassfest action (if integration): <https://github.com/farosch/hacs_hp_aruba_switch/actions/runs/17931261568>

