### PR TITLE
Adds new integration [hstrohmaier/ha_comfoconnectpro]

### DIFF
--- a/integration
+++ b/integration
@@ -699,6 +699,7 @@
   "HrGaertner/HA-vent-optimization",
   "hsakoh/ha-switchbot-kvs-camera",
   "hsk-dk/home-assistant-thermex",
+  "hstrohmaier/ha_comfoconnectpro",
   "hudsonbrendon/HA-drivvo",
   "hudsonbrendon/HA-solar-plus-intelbras",
   "hudsonbrendon/ha_epic_games",


### PR DESCRIPTION
Add integration for Zehnder ComfoConnect PRO interface

Harold Strohmaier <hs@ategus.de>

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x ] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x ] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x ] The actions are passing without any disabled checks in my repository.
- [x ] I've added a link to the action run on my repository below in the links section.
- [x ] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/hstrohmaier/ha_comfoconnectpro/releases/tag/1.0.4>
Link to successful HACS action (without the `ignore` key): <https://github.com/hstrohmaier/ha_comfoconnectpro/actions/runs/17958180082>
Link to successful hassfest action (if integration): <https://github.com/hstrohmaier/ha_comfoconnectpro/actions/runs/17958180088>

