### PR TITLE
Update plugin

### DIFF
--- a/plugin
+++ b/plugin
@@ -183,6 +183,7 @@
   "homeassistant-extras/room-summary-card",
   "homeassistant-extras/toolbar-status-chips",
   "homeassistant-extras/zwave-card-set",
+  "Hugo0485/DoubleCurtainCard",
   "hulkhaugen/hass-bha-icons",
   "hyperb1iss/hyper-light-card",
   "Hypfer/lovelace-valetudo-map-card",


### PR DESCRIPTION
Add Hugo0485/DoubleCurtainCard to plugin list

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [ yes] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [ yes] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ yes] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [ yes] The actions are passing without any disabled checks in my repository.
- [ yes] I've added a link to the action run on my repository below in the links section.
- [ yes] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <>
Link to successful HACS action (without the `ignore` key): <>
Link to successful hassfest action (if integration): <>

