### PR TITLE
Adds new plugin [figorr/meteocat-card]

### DIFF
--- a/plugin
+++ b/plugin
@@ -133,6 +133,7 @@
   "ezand/lovelace-posten-card",
   "faeibson/lovelace-multiline-text-input-card",
   "FamousWolf/week-planner-card",
+  "figorr/meteocat-card,
   "fineemb/lovelace-air-filter-card",
   "fineemb/lovelace-car-card",
   "fineemb/lovelace-cn-map-card",


### PR DESCRIPTION
This PR adds the Meteocat Card, a custom card for the Meteocat integration, to HACS under the plugin category. It has passed HACS validation tests.

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x ] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x ] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x ] The actions are passing without any disabled checks in my repository.
- [x ] I've added a link to the action run on my repository below in the links section.
- [x ] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/figorr/meteocat-card/releases/tag/v1.0.0>
Link to successful HACS action (without the `ignore` key): <https://github.com/figorr/meteocat-card/actions/runs/17978480006/job/51137848438>
Link to successful hassfest action (if integration): <>

