### PR TITLE
isable Honda Recall integration

### DIFF
--- a/integration
+++ b/integration
@@ -380,7 +380,6 @@
   "danielcherubini/elegoo-homeassistant",
   "danieldiazi/homeassistant-meteogalicia",
   "Danieldiazi/homeassistant-meteogalicia_tides",
-  "Danieldiazi/honda_recall_check",
   "danieldotnl/ha-measureit",
   "danieldotnl/ha-multiscrape",
   "Danielhiversen/home_assistant_adax",


### PR DESCRIPTION
The integration has been temporarily disabled because the Honda recall endpoint enforces anti-bot protections (cookies and JS challenges) which cannot be handled directly from Home Assistant. The project is archived until further notice.

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: https://github.com/Danieldiazi/honda_recall_check/releases/tag/2025.9.0
Link to successful HACS action (without the `ignore` key): https://github.com/Danieldiazi/honda_recall_check/actions/runs/18078581298
Link to successful hassfest action (if integration): <>

## ❌ Disable Honda Recall integration

This integration is being **temporarily disabled**.

### Reason
The official Honda recall endpoint (`https://www.honda.es/cars/owners/recalls-and-updates/_jcr_content/service.submit.html`) has recently been updated with stricter anti-bot protections (cookies, JavaScript challenges, WAF).  
As a result, the integration no longer works reliably from within Home Assistant.


### Future
If the endpoint changes in the future and becomes compatible again, the integration may be re-enabled and re-submitted to HACS.


