### PR TITLE
Adds new integration [perosb/power_max_tracker]

### DIFF
--- a/integration
+++ b/integration
@@ -1204,6 +1204,7 @@
   "pdw-mb/tsmart_ha",
   "peetereczek/ztm",
   "peribeir/homeassistant-rademacher",
+  "perosb/power_max_tracker",
   "perosb/qvantum_custom_component",
   "persuader72/silla-prism-integration",
   "PeteRager/lennoxs30",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/perosb/power_max_tracker/releases/tag/2025.10.4>
Link to successful HACS action (without the `ignore` key): <https://github.com/perosb/power_max_tracker/actions/runs/18225418716/job/51895261067>
Link to successful hassfest action (if integration): <https://github.com/perosb/power_max_tracker/actions/runs/18225418716/job/51895261067>

