### PR TITLE
Add enoch85/ge-spot integration

### DIFF
--- a/integration
+++ b/integration
@@ -352,6 +352,7 @@
   "emes30/facebook_messenger",
   "emics/ham_radio_propagation",
   "enes-oerdek/Home-Assistant-Helium-Integration",
+  "enoch85/ge-spot",
   "enkama/hass-variables",
   "EnzoD86/tuya-smart-ir-ac",
   "epaulsen/energytariff",


### PR DESCRIPTION
Global Electricity Spot Prices integration providing 15-minute electricity spot prices across global markets with multi-source API support and fallback.

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [ ] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [ ] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [ ] The actions are passing without any disabled checks in my repository.
- [ ] I've added a link to the action run on my repository below in the links section.
- [ ] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <>
Link to successful HACS action (without the `ignore` key): <>
Link to successful hassfest action (if integration): <>

