### PR TITLE
Update integration

### DIFF
--- a/integration
+++ b/integration
@@ -7,6 +7,7 @@
   "3ll3d00d/jriver_homeassistant",
   "3p3v/berluf_selen_2",
   "404GamerNotFound/vserver-ssh-stats",
+  "5a2v0/HA-WiFi-Sensor-Tracker",
   "5high/konke",
   "5high/phicomm-dc1-homeassistant",
   "62fixolab/HA-Panda-PWR",


### PR DESCRIPTION
Added 5a2v0 WiFi sensor tracker integration

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/5a2v0/HA-WiFi-Sensor-Tracker/tree/2.0.2>
Link to successful HACS action (without the ignore key): <https://github.com/5a2v0/HA-WiFi-Sensor-Tracker/actions/runs/18261476181>
Link to successful hassfest action (if integration): <https://github.com/5a2v0/HA-WiFi-Sensor-Tracker/actions/runs/18261687796>

