### PR TITLE
Adds new integration [craibo/ha-red-energy-au]

### DIFF
--- a/integration
+++ b/integration
@@ -320,6 +320,7 @@
   "connorgallopo/Superior-Plus-Propane",
   "corporategoth/ha-powerpetdoor",
   "cowboyrushforth/home-assistant-molekule",
+  "craibo/ha-red-energy-au",
   "craibo/ha_strava",
   "CreasolTech/home-assistant-creasol-dombus",
   "crowbarz/ha-sql_json",


### PR DESCRIPTION
Add Red Energy integration

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [X] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [X] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [X] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [X] The actions are passing without any disabled checks in my repository.
- [X] I've added a link to the action run on my repository below in the links section.
- [X] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/craibo/ha-red-energy-au/releases/tag/1.5.8>
Link to successful HACS action (without the `ignore` key): <https://github.com/craibo/ha-red-energy-au/actions/runs/18303160001/job/52114798198>
Link to successful hassfest action (if integration): <https://github.com/craibo/ha-red-energy-au/actions/runs/18303160001/job/52114798198>

