### PR TITLE
Add Sunseeker lawn mower integration

### DIFF
--- a/integration
+++ b/integration
@@ -1404,6 +1404,7 @@
   "ScratMan/HASmartThermostat",
   "ScreamingToaster/Bluesky-Integration",
   "script0803/BituoPMD",
+  "Sdahl1234/Sunseeker-lawn-mower",
   "SDR3078/ps3-home-assistant",
   "sdrapha/home-assistant-custom-components-pfsense-gateways",
   "Seba101288/home-assistant-ever-ups",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/Sdahl1234/Sunseeker-lawn-mower/releases/tag/v1.1.12>
Link to successful HACS action (without the `ignore` key): <https://github.com/Sdahl1234/Sunseeker-lawn-mower/actions/runs/18378867835/job/52359817148>
Link to successful hassfest action (if integration): <https://github.com/Sdahl1234/Sunseeker-lawn-mower/actions/runs/18378867856/job/52359817706>

