### PR TITLE
Adds new integration [wimb0/home-assistant-nextenergy-battery-modbus]

### DIFF
--- a/integration
+++ b/integration
@@ -1679,7 +1679,7 @@
   "willholdoway/hifiberry",
   "williamschey/hassio-omlet-smartcoop-door",
   "wills106/homeassistant-solax-modbus",
-  "wimb0/home-assistant-nextenergy-battery-modbus ",
+  "wimb0/home-assistant-nextenergy-battery-modbus",
   "wimb0/home-assistant-saj-r5-modbus",
   "wisedeer2022/ha_wisecloud_home",
   "wizmo2/zidoo-player",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [X] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [X] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [X] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [X] The actions are passing without any disabled checks in my repository.
- [X] I've added a link to the action run on my repository below in the links section.
- [X] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: https://github.com/wimb0/home-assistant-nextenergy-battery-modbus/releases/tag/v1.0.5
Link to successful HACS action (without the `ignore` key): https://github.com/wimb0/home-assistant-nextenergy-battery-modbus/actions/runs/18444689326
Link to successful hassfest action (if integration): https://github.com/wimb0/home-assistant-nextenergy-battery-modbus/actions/runs/18444689326

