### PR TITLE
Adds new plugin [kibibit/kb-alert-badge]

### DIFF
--- a/plugin
+++ b/plugin
@@ -238,6 +238,7 @@
   "karlis-vagalis/circular-timer-card",
   "KartoffelToby/better-thermostat-ui-card",
   "kevin-briand/massa-node-card",
+  "kibibit/kb-alert-badge",
   "kibibit/kb-better-graph-colors",
   "kibibit/kb-frosted-cards",
   "kibibit/kb-steam-card",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: https://github.com/Kibibit/kb-alert-badge/releases/tag/v1.18.0
Link to successful HACS action (without the `ignore` key): https://github.com/Kibibit/kb-alert-badge/actions/runs/18556496777
Link to successful hassfest action (if integration): not an integration


## Additional Information

Animated Home Assistant Lovelace badge for critical alerts (smoke, water, alarms). This badge provides visual feedback for important home automation alerts with smooth animations.

https://github.com/user-attachments/assets/493d4976-cf2a-4155-8b96-5594d8353992

https://github.com/user-attachments/assets/1b159804-7303-4130-aa98-dc6f74e03d6b

