### PR TITLE
Add trend-analysis-card to the plugin list

### DIFF
--- a/plugin
+++ b/plugin
@@ -367,6 +367,7 @@
   "rgc99/irrigation-unlimited-card",
   "rianadon/opensprinkler-card",
   "rianadon/timer-bar-card",
+  "Riscue/trend-analysis-card",
   "Rishi8078/TimeFlow-Card",
   "RJArmitage/rfxtrx-stateful-blinds-icons",
   "rkotulan/ha-wall-clock-card",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: https://github.com/Riscue/trend-analysis-card/releases/tag/0.0.1
Link to successful HACS action (without the `ignore` key): https://github.com/Riscue/trend-analysis-card/actions/runs/18563916792
Link to successful hassfest action (if integration): <>

