### PR TITLE
Add qlerup/thermostat-pro-timeline-sync to HACS default (integration)

### DIFF
--- a/integration
+++ b/integration
@@ -1296,6 +1296,7 @@
   "pytoyoda/ha_toyota",
   "QNimbus/haefele-connect-mesh",
   "QuickMadeSimulation/QmdevHA",
+  "qlerup/thermostat-pro-timeline-sync",
   "r-renato/ha-climacell-weather",
   "radical-squared/aquatemp",
   "raelix/HA-Radoff-integration",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: https://github.com/qlerup/thermostat-pro-timeline-sync/releases/tag/v1.0.1  
Link to successful HACS action (without the `ignore` key): https://github.com/qlerup/thermostat-pro-timeline-sync/actions/runs/18604925473
Link to successful hassfest action (if integration): https://github.com/qlerup/thermostat-pro-timeline-sync/actions/runs/18604925477
