### PR TITLE
Add NirBY/ha-mashov to integration list

### DIFF
--- a/integration
+++ b/integration
@@ -1180,6 +1180,7 @@
   "nimroddolev/chime_tts",
   "NinDTendo/homeassistant_gradual_volume_control",
   "NinDTendo/tobi",
+  "NirBY/ha-mashov",
   "nitaybz/optimistic_feedback",
   "nkvoll/home-assistant-qsys-qrc",
   "nnnlog/homeassistant-cvnet-smarthome",


### PR DESCRIPTION
Add Mashov integration for Israeli school management system

**Repository**: https://github.com/NirBY/ha-mashov
**Category**: integration

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [V ] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [V ] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [V ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [V ] The actions are passing without any disabled checks in my repository.
- [V ] I've added a link to the action run on my repository below in the links section.
- [V ] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/NirBY/ha-mashov/releases/tag/v1.0.1>
Link to successful HACS action (without the `ignore` key): <https://github.com/NirBY/ha-mashov/actions/runs/18620254157/job/53090445590>
Link to successful hassfest action (if integration): <https://github.com/NirBY/ha-mashov/actions/runs/18620254157/job/53090445588>

