### PR TITLE
Adds new appdaemon [jm-cook/ha-havvarsel-deprecated]

### DIFF
--- a/appdaemon
+++ b/appdaemon
@@ -24,7 +24,7 @@
   "jbouwh/ha-entity-cache",
   "jbouwh/omnikdatalogger",
   "jeeftor/mint-scraper-for-homeassistant",
-  "jm-cook/ha-havvarsel",
+  "jm-cook/ha-havvarsel-deprecated",
   "jmarsik/ad-eurotronic-trv-valvepos",
   "joBr99/nspanel-lovelace-ui",
   "kprestel/appdaemon-climate",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->

ha-havvarsel was an appdaemon app for Home Assistant and has been superseeded by a full integration. I maybe could have done this migration better in retrospect but what I did was renamed the appdaemon repo to https://github.com/jm-cook/ha-havvarsel-deprecated

For proper removal I have renamed the repo in hacs/default/appdaemon. When that is done I will archive it and as I understand it it will be removed automatically.

## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: https://github.com/jm-cook/ha-havvarsel-deprecated/releases/tag/v2025.10.0
Link to successful HACS action (without the `ignore` key): https://github.com/jm-cook/ha-havvarsel-deprecated/actions/runs/18706731542/job/53346097541
Link to successful hassfest action (if integration): appdaemon
