### PR TITLE
Add cew-hacs/cheapest_energy_windows integration

### DIFF
--- a/integration
+++ b/integration
@@ -268,6 +268,7 @@
   "cazeaux/ha-iracing",
   "cdnninja/yoto_ha",
   "cedricziel/ha-sunlit",
+  "cew-hacs/cheapest_energy_windows",
   "chaimchaikin/molad-ha",
   "CharlesGillanders/homeassistant-alphaESS",
   "CharlesP44/Beem_Energy",


### PR DESCRIPTION
  Adding Cheapest Energy Windows integration for Home Assistant.

 Optimizes energy consumption and battery storage by automatically identifying cheapest charging windows and most expensive discharging periods based on dynamic electricity prices from Nord Pool.

  - Repository: https://github.com/cew-hacs/cheapest_energy_windows
  - Documentation: https://github.com/cew-hacs/cheapest_energy_windows#readme
  - Latest release: v1.0.3
