### PR TITLE
Add Phil-Barker/hass-bosch-ebike

### DIFF
--- a/integration
+++ b/integration
@@ -1258,6 +1258,7 @@
   "petretiandrea/home-assistant-tapo-p100",
   "Petro31/ha-integration-multizone-controller",
   "PhantomPhoton/S3-Compatible",
+  "Phil-Barker/hass-bosch-ebike",
   "Phil7989/advanced_snapshot",
   "Pho3niX90/solis_modbus",
   "phoinixgrr/sigma_connect_ha",


### PR DESCRIPTION
## Integration Information

- **Repository:** https://github.com/Phil-Barker/hass-bosch-ebike
- **Latest Release:** https://github.com/Phil-Barker/hass-bosch-ebike/releases/tag/v1.0.2
- **CI Actions:** https://github.com/Phil-Barker/hass-bosch-ebike/actions
- **Integration Name:** Bosch eBike Flow
- **Description:** Integration for Bosch eBike Flow to monitor bike status, battery level, range, and more

## Checklist

- [x] Repository is public
- [x] Integration follows HACS requirements
- [x] GitHub Actions (HACS validation and Hassfest) are configured and passing
- [x] Release v1.0.2 is published
- [x] Icon submitted to home-assistant/brands (PR #8295)
- [x] Documentation (README.md) is complete
- [x] All required files are present (hacs.json, manifest.json, etc.)

## Additional Notes

This integration allows Home Assistant users to monitor their Bosch eBikes equipped with a ConnectModule. It provides sensors for battery level, reachable range, odometer, and binary sensors for charging status.

Note: The brands repository PR is still pending approval, but the icon has been submitted correctly.