### PR TITLE
 Add custom-gauge-card

### DIFF
--- a/plugin
+++ b/plugin
@@ -176,6 +176,7 @@
   "goggybox/compact-light-card",
   "grinstantin/todoist-card",
   "guiohm79/psychrometric-chart-advanced",
+  "guiohm79/custom-gauge-card",
   "gurbyz/power-wheel-card",
   "GyroGearl00se/lovelace-froeling-card",
   "hacf-fr/EcoleDirecteHACards",


### PR DESCRIPTION
 ## Description
  Adding Custom Gauge Card - A custom card for Home Assistant that displays sensors      
  as an animated and interactive circular LED gauge.

  ## Repository
  https://github.com/guiohm79/custom-gauge-card

  ## Features
  - Circular LED gauge display
  - Animated transitions
  - Multi-button control
  - Zones and markers
  - Trend indicator
  - Multiple themes support
  - HACS ready

  ## Checklist
  - [x] Repository is public
  - [x] Has a valid hacs.json
  - [x] Has a README.md
  - [x] Has a LICENSE
  - [x] Has releases/tags
