### PR TITLE
Add custom gauge card

### DIFF
--- a/plugin
+++ b/plugin
@@ -177,6 +177,7 @@
   "goggybox/compact-light-card",
   "grinstantin/todoist-card",
   "guiohm79/psychrometric-chart-advanced",
+  "guiohm79/custom-gauge-card",
   "gurbyz/power-wheel-card",
   "GyroGearl00se/lovelace-froeling-card",
   "hacf-fr/EcoleDirecteHACards",


### PR DESCRIPTION
## Description
  Adding Custom Gauge Card - A custom card for Home Assistant that displays sensors      
  as an animated and interactive circular LED gauge.

  ## Repository
  https://github.com/guiohm79/custom-gauge-card

 **Latest Release:**
  https://github.com/guiohm79/custom-gauge-card/releases/latest

  ## Features
  - Circular LED gauge display
  - Animated transitions
  - Multi-button control
  - Zones and markers
  - Trend indicator
  - Multiple themes support
  - HACS ready

  ## Checklist
  - [x] I have read and understood the [guidelines for
  contributing](https://hacs.xyz/docs/publish/include).
  - [x] The repository name is correct and matches the name in `hacs.json`.
  - [x] I am the owner of this repository.
  - [x] This is not a fork of another repository.
  - [x] There is a `hacs.json` file in the root of the repository.
  - [x] The repository has at least one release.
  - [x] The default branch is correctly set in the repository settings.
