### PR TITLE
Add custom gauge card

### DIFF
--- a/plugin
+++ b/plugin
@@ -176,6 +176,7 @@
   "go-hass/go-hass-cards",
   "goggybox/compact-light-card",
   "grinstantin/todoist-card",
+  "guiohm79/custom-gauge-card",
   "guiohm79/psychrometric-chart-advanced",
   "gurbyz/power-wheel-card",
   "GyroGearl00se/lovelace-froeling-card",


### PR DESCRIPTION
## Description

This PR adds the Custom Gauge Card - a modern, animated circular LED gauge card for Home Assistant.

## Repository
__https://github.com/guiohm79/custom-gauge-card__

**Latest Release:**
__https://github.com/guiohm79/custom-gauge-card/releases/latest__

### Features
- Animated circular LED gauge with smooth transitions
- Customizable themes (light, dark, custom)
- Zones and markers for value visualization
- 24-hour trend indicator
- Multi-button control for various entities
- Performance optimized with power save mode
- Fully accessible with ARIA support

### Category
Lovelace Plugin (Frontend)

---

## Checklist

- [x] I have read and understood the [guidelines for adding a new repository](https://hacs.xyz/docs/publish/start)
- [x] The repository has a description
- [x] The repository has topics set (including `hacs`)
- [x] I have updated the repository description to include that this is made for Home Assistant
- [x] The repository has a README with information about what it does and how to use it
- [x] The repository has at least one release (not a pre-release)
- [x] The default branch is not named `master` or the repository has a `hacs.json` file with the branch specified
- [x] If this is a plugin for Lovelace, it has `type: module` in the resources configuration

### Plugin specific (Lovelace)
- [x] The repository contains a `hacs.json` file with required keys (`name`, `content_in_root`, `filename`)
- [x] The `filename` in `hacs.json` matches the actual JavaScript filename (`custom-gauge-card.js`)
- [x] The repository has an `info.md` file for HACS information panel
- [x] The plugin doesn't require external dependencies or they are properly loaded from CDN
- [x] The repository includes proper documentation in README.md