### PR TITLE
Add Solis Cloud Monitoring integration

### DIFF
--- a/integration
+++ b/integration
@@ -835,6 +835,7 @@
   "jobvk/Home-Assistant-Windcentrale",
   "joemcc-90/leeds-bins-hass",
   "joggs/home_assistant_ebeco",
+  "john-lazarus/HomeAssistant-SolisCloudMonitoring",
   "JohNan/homeassistant-wellbeing",
   "johnnybegood/ha-ksenia-lares",
   "johnvoipguy/Traeger-WiFire",


### PR DESCRIPTION
## Summary
- add john-lazarus/HomeAssistant-SolisCloudMonitoring to the integration list
- initial release v1.0.2 provides Solis Cloud inverter monitoring for Home Assistant 2024.8+

## Checklist
- [x] Repository release: https://github.com/john-lazarus/HomeAssistant-SolisCloudMonitoring/releases/tag/v1.0.2
- [x] hassfest: https://github.com/john-lazarus/HomeAssistant-SolisCloudMonitoring/actions/runs/18995501262
- [ ] HACS validation: https://github.com/john-lazarus/HomeAssistant-SolisCloudMonitoring/actions/runs/18995501261 (blocked until https://github.com/home-assistant/brands/pull/8330 lands)
