### PR TITLE
Add Eleven Energy integration to HACS

### DIFF
--- a/integration
+++ b/integration
@@ -763,6 +763,7 @@
   "itchannel/fordpass-ha",
   "itchannel/optus-ha",
   "itchannel/tdarr_ha",
+  "iPeel/HA-Eleven-Energy",
   "ITSpecialist111/ai_automation_suggester",
   "ivancoppa/homeassistant-perry-cdom",
   "IvanSanchez/homeassistant-freeds",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [ x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x ] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x ] The actions are passing without any disabled checks in my repository.
- [x ] I've added a link to the action run on my repository below in the links section.
- [x ] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/iPeel/HA-Eleven-Energy/releases/tag/v1.2>
Link to successful HACS action (without the `ignore` key): <https://github.com/iPeel/HA-Eleven-Energy/actions/runs/19011209322>
Link to successful hassfest action (if integration): <https://github.com/iPeel/HA-Eleven-Energy/actions/runs/19011209325>

