### PR TITLE
Add HomeAssistantLGThinkQCards

### DIFF
--- a/plugin
+++ b/plugin
@@ -225,6 +225,7 @@
   "jm-cook/lovelace-meteogram-card",
   "JMatuszczakk/Locked-Button",
   "jo-ket/compact-cover-control-card",
+  "john-lazarus/HomeAssistantLGThinkQCards",
   "jonahkr/power-distribution-card",
   "JonasDoebertin/ha-today-card",
   "jonkristian/entur-card",


### PR DESCRIPTION
Add john-lazarus/HomeAssistantLGThinkQCards to the plugin category.