### PR TITLE
Add yomonpet/ha-sofabaton-hub

### DIFF
--- a/integration
+++ b/integration
@@ -1747,6 +1747,7 @@
   "youdroid/home-assistant-gitea",
   "youdroid/home-assistant-gogs",
   "youdroid/home-assistant-sickchill",
+  "yomonpet/ha-sofabaton-hub",
   "ZacheryThomas/homeassistant-smartrent",
   "zachowj/hass-node-red",
   "zacs/ha-energycalc",


### PR DESCRIPTION
## Description
Add Sofabaton Hub integration for Home Assistant - A custom integration for controlling Sofabaton X2 Hub universal remote.

## Repository
https://github.com/yomonpet/ha-sofabaton-hub

## Category
Integration

## Additional Information

### Features
- 🔍 Automatic discovery via mDNS/Zeroconf
- 🎮 Activity control with switch entities
- 🔑 Complete key management (assigned, macro, favorite keys)
- 📱 Beautiful custom Lovelace cards
- 🔄 Real-time MQTT-based updates
- 🌐 Bilingual support (English & Chinese)

### Device Compatibility
- ✅ Sofabaton X2 Hub
- ❌ NOT compatible with Sofabaton X1s

### Requirements
- Home Assistant 2023.1.0+
- MQTT broker (Mosquitto recommended)

### Documentation
Complete documentation with installation guide, configuration steps, and automation examples available in the repository README.

### Quality
- Follows Home Assistant development guidelines
- Includes comprehensive error handling
- Provides diagnostics support
- Well-documented codebase

### Current Version
v1.0.2 (Latest release includes switch entity support and automation examples)

---

**Checklist:**
- [x] Repository follows HACS integration requirements
- [x] manifest.json includes all required fields
- [x] README.md with installation and usage instructions
- [x] hacs.json properly configured
- [x] GitHub releases available
- [x] Home Assistant Brands PR submitted (#8249)
