### PR TITLE
Add OpenAQ custom integration repo

### DIFF
--- a/integration
+++ b/integration
@@ -1764,5 +1764,6 @@
   "zubir2k/homeassistant-dailyhadith",
   "zubir2k/homeassistant-esolatgps",
   "zubir2k/homeassistant-esolattakwim",
-  "zulufoxtrot/ha-zyxel"
+  "zulufoxtrot/ha-zyxel",
+  "zenguru84/ha-openaq"
 ]


### PR DESCRIPTION
Add OpenAQ (https://openaq.org) custom integration repo.


<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: https://github.com/zenguru84/ha-openaq/releases/tag/v0.1.2
Link to successful HACS action (without the `ignore` key): https://github.com/zenguru84/ha-openaq/actions/runs/19136771934/job/54690735637
Link to successful hassfest action (if integration): https://github.com/zenguru84/ha-openaq/actions/runs/19136771928/job/54690735364

