### PR TITLE
Add InfoSecured/ha-tovala

### DIFF
--- a/integration
+++ b/integration
@@ -754,6 +754,7 @@
   "iMicknl/ha-nest-protect",
   "insound/iohouse_climate",
   "InTheDaylight14/nginx-proxy-manager-switches",
+  "InfoSecured/ha-tovala",
   "IoTFenster/MySmartWindow",
   "iprak/sensi",
   "iprak/weatherapi",


### PR DESCRIPTION
## Proposed change

Add Tovala Smart Oven integration to HACS default repository.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- Integration URL: https://github.com/InfoSecured/ha-tovala
- First release: v1.0.0
- HACS validation: ✅ Passing
- Hassfest validation: ✅ Passing  
- Brand icon submitted and merged: https://github.com/home-assistant/brands/pull/8348

**Integration Features:**
- Real-time cooking status monitoring
- Timer tracking with meal details and images
- Cooking history
- Automation-ready events and attributes

## Checklist

- [x] The pull request is done against the latest dev branch
- [x] Only relevant files were touched
- [x] Only one file was modified
- [x] The entry is added in alphabetical order
- [x] The repository is public and not a fork
- [x] The repository has a hacs.json file in the root
- [x] The repository has a manifest.json in the integration folder  
- [x] The integration has a unique ID in the manifest
- [x] The integration is added to Home Assistant using the UI
- [x] The integration has at least one release
- [x] All HACS and Hassfest validation checks pass