### PR TITLE
Add qlerup/chores4kids-sync to HACS Default (integration)

### DIFF
--- a/integration
+++ b/integration
@@ -1317,6 +1317,7 @@
   "Pyhass/Hive-Custom-Component",
   "pypolestar/polestar_api",
   "pytoyoda/ha_toyota",
+  "qlerup/chores4kids-sync",
   "qlerup/thermostat-pro-timeline-sync",
   "QNimbus/haefele-connect-mesh",
   "QuickMadeSimulation/QmdevHA",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/qlerup/chores4kids-sync/releases/tag/v1.0.5>
Link to successful HACS action (without the `ignore` key): <https://github.com/qlerup/chores4kids-sync/actions/runs/19182668270>
Link to successful hassfest action (if integration): <https://github.com/qlerup/chores4kids-sync/actions/runs/19182668252>
