### PR TITLE
Add integration Riscue/ha-influxdb-query-api

### DIFF
--- a/integration
+++ b/integration
@@ -1355,6 +1355,7 @@
   "rihokirss/homeasisstant-rn301",
   "rine77/homeassistantedupage",
   "rinyakok/homeassistant_idokep",
+  "Riscue/ha-influxdb-query-api",
   "Riscue/ha-wallpanel-media-player",
   "rknightion/autopi-ha",
   "rknightion/meraki-dashboard-ha",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: https://github.com/Riscue/ha-influxdb-query-api/releases/tag/v0.0.2
Link to successful HACS action (without the `ignore` key): https://github.com/Riscue/ha-influxdb-query-api/actions/runs/19201738548
Link to successful hassfest action (if integration): https://github.com/Riscue/ha-influxdb-query-api/actions/runs/19201679178

