### PR TITLE
Add Dom.ru integration to HACS default

### DIFF
--- a/integration
+++ b/integration
@@ -546,6 +546,7 @@
   "epoplavskis/homeassistant_salus",
   "erikkastelec/hass-WEM-Portal",
   "eriknn/ha-pax_ble",
+  "ErilovNikita/ha-domru",
   "esbenwiberg/easyiq",
   "eseglem/hass-wattbox",
   "eseverson/hass-balena",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: [Release 0.1.19](https://github.com/ErilovNikita/ha-domru/releases/tag/v0.1.19)
Link to successful HACS action (without the `ignore` key): [HACS Validate Action](https://github.com/ErilovNikita/ha-domru/actions/runs/19229229580)
Link to successful hassfest action (if integration): [HACS Validate Action](https://github.com/ErilovNikita/ha-domru/actions/runs/19229229580)

