### PR TITLE
Adding support for the SDVoE API and devices

### DIFF
--- a/integration
+++ b/integration
@@ -1556,6 +1556,7 @@
   "swartjean/ha-eskom-loadshedding",
   "swartjean/ha-seedboxes-cc",
   "swingerman/ha-dual-smart-thermostat",
+  "switch180/RiverLink-SDVoE",
   "Syonix/ha-wiser-by-feller",
   "syssi/homeassistant-goecharger-mqtt",
   "syssi/nextbike",


### PR DESCRIPTION
Hi! This is a new integration for the SDVoE API - an AVoIP-type API to control SDVoE devices which are traditionally found in commercial installs, but which I have in my own home network. SDVoE stands for software-defined video over ethernet and it is a trademark of the SDVoE Alliance found at [sdvoe.org](https://sdvoe.org/). I have added logos for sdvoe, my plugin's domain, to the official [HA brand repo]()https://github.com/home-assistant/brands/pull/8412) for inclusion. I have tested this plugin in my home environment and included a detailed getting started page to allow any SDVoE device owner to immediately use this plugin (if they follow the steps). I have many issues already registered for feature enhancements, and I'm committed to accepting PRs to keep this integration up-to-date.


<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: https://github.com/switch180/RiverLink-SDVoE/releases/tag/0.3.1
Link to successful HACS action (without the `ignore` key): https://github.com/switch180/RiverLink-SDVoE/actions/runs/19279895762/job/55128529326
Link to successful hassfest action (if integration): https://github.com/switch180/RiverLink-SDVoE/actions/runs/19279895762/job/55128529312

