### PR TITLE
Add kattcrazy/tuya_unsupported_sensors to integration

### DIFF
--- a/integration
+++ b/integration
@@ -904,6 +904,7 @@
   "Kaptensanders/skolmat",
   "Kartax/home-assistant-binance",
   "KartoffelToby/better_thermostat",
+  "kattcrazy/tuya_unsupported_sensors"
   "kclif9/hassactronneo",
   "kcoffau/AUS_BOM_Space_Weather_Alert_System",
   "kcofoni/ha-netro-watering",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [ ] The actions are passing without any disabled checks in my repository.
- [ ] I've added a link to the action run on my repository below in the links section.
- [ ] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/kattcrazy/tuya_unsupported_sensors/releases/tag/large_release>
Link to successful HACS action (without the `ignore` key): <https://github.com/kattcrazy/tuya_unsupported_sensors/blob/main/.github/workflows/Validate.yml>
Link to successful hassfest action (if integration): <https://github.com/kattcrazy/tuya_unsupported_sensors/blob/main/.github/workflows/Hassfest.yml>

