### PR TITLE
Add rosch100/fritzbox-vpn integration

### DIFF
--- a/integration
+++ b/integration
@@ -1417,6 +1417,7 @@
   "ronald-willems/dewarmte-homeassistant",
   "ronnnnnnnnnnnnn/etekcity_fitness_scale_ble",
   "RonnyWinkler/homeassistant.homey",
+  "rosch100/fritzbox-vpn",
   "rosenkolev/home-assistant-gpio-integration",
   "roslovets/SP110E-HASS",
   "rospogrigio/localtuya",


### PR DESCRIPTION
This PR adds the FritzBox VPN integration to the HACS default list.

**Repository:** rosch100/fritzbox-vpn
**Description:** Home Assistant integration to control WireGuard VPN connections on AVM FritzBox routers

**Requirements checked:**
- ✓ Public GitHub repository
- ✓ manifest.json with all required fields
- ✓ hacs.json present
- ✓ README.md present
- ✓ Releases available (v0.5.9)
- ✓ Logo in brands repository
- ✓ Repository description and topics set

The integration is alphabetically sorted in the list.