### PR TITLE
Add rosch100/fritzbox-vpn integration

### DIFF
--- a/integration
+++ b/integration
@@ -1417,6 +1417,7 @@
   "ronald-willems/dewarmte-homeassistant",
   "ronnnnnnnnnnnnn/etekcity_fitness_scale_ble",
   "RonnyWinkler/homeassistant.homey",
+  "rosch100/fritzbox-vpn",
   "rosenkolev/home-assistant-gpio-integration",
   "roslovets/SP110E-HASS",
   "rospogrigio/localtuya",


### PR DESCRIPTION
This PR adds the FritzBox VPN integration to the HACS default list.

**Repository:** rosch100/fritzbox-vpn
**Description:** Home Assistant integration to control WireGuard VPN connections on AVM FritzBox routers

**Requirements checked:**
- [x] Public GitHub repository
- [x] manifest.json with all required fields
- [x] hacs.json present
- [x] README.md present
- [x] Releases available (v0.6.0)
- [x] Logo in brands repository
- [x] Repository description and topics set
- [x] GitHub Actions workflow for validation

**Required Links:**
- Repository: https://github.com/rosch100/fritzbox-vpn
- Latest Release: https://github.com/rosch100/fritzbox-vpn/releases/tag/v0.6.0
- CI Action Runs: https://github.com/rosch100/fritzbox-vpn/actions

The integration is alphabetically sorted in the list.