### PR TITLE
Add ha-media-index integration

### DIFF
--- a/integration
+++ b/integration
@@ -1067,6 +1067,7 @@
   "MarcoGos/kleenex_pollenradar",
   "marcolivierarsenault/moonraker-home-assistant",
   "mariusz-ostoja-swierczynski/tech-controllers",
+  "markaggar/ha-media-index",
   "markaggar/Water-Monitor",
   "markfrancisonly/ha-cameralux",
   "markgdev/home-assistant_OctopusAgile",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/markaggar/ha-media-index>
Link to successful HACS action (without the `ignore` key): <https://github.com/markaggar/ha-media-index/actions/runs/19352289449/job/55366340849>
Link to successful hassfest action (if integration): <https://github.com/markaggar/ha-media-index/actions/runs/19352289449/job/55366340847>

