### PR TITLE
Add weirdtangent/pulse-photo-card to plugin dependencies

### DIFF
--- a/plugin
+++ b/plugin
@@ -463,6 +463,7 @@
   "wassy92x/lovelace-digital-clock",
   "wassy92x/lovelace-entities-btn-group",
   "wassy92x/lovelace-ha-dashboard",
+  "weirdtangent/pulse-photo-card",
   "wilsto/pool-monitor-card",
   "wiltodelta/homeassistant-sugartv-card",
   "WJDDesigns/Ultra-Card",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [ x ] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [ x ] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [ x ] The actions are passing without any disabled checks in my repository.
- [ x ] I've added a link to the action run on my repository below in the links section.
- [ x ] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/weirdtangent/pulse-photo-card/releases/latest>
Link to successful HACS action (without the `ignore` key): <https://github.com/weirdtangent/pulse-photo-card/actions/runs/19445079953>
Link to successful hassfest action (if integration): <>

