### PR TITLE
Add hid_usbrelay integration  HID USB Relay integration for Home Assistant

### DIFF
--- a/integration
+++ b/integration
@@ -140,6 +140,7 @@
   "arevindh/ha-tinxy-cloud",
   "arifwn/homeassistant-whatspie-integration",
   "ArikShemesh/ha-simple-timer",
+  "arnoudkooi/ha-hid-usbrelay",
   "aronkahrs-us/inumet-weather-ha",
   "aropop/home-assistant-cronicle",
   "artspb/homeassistant-tk-husteblume",


### PR DESCRIPTION
Add hid_usbrelay integration

HID USB Relay integration for Home Assistant - controls USB HID relay boards (16c0:05df) with native UI configuration, switch entities, and pulse buttons. Ideal for users migrating from Raspberry Pi GPIO to Mini PCs.

Repository: https://github.com/arnoudkooi/ha-hid-usbrelay
Category: integration

## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/arnoudkooi/ha-hid-usbrelay/releases/tag/v1.0.0>

Link to successful HACS action (without the `ignore` key): <https://github.com/arnoudkooi/ha-hid-usbrelay/actions/runs/19592915980/job/56113649054>

Link to successful hassfest action (if integration): <https://github.com/arnoudkooi/ha-hid-usbrelay/actions/runs/19592915980/job/56113649057>