### PR TITLE
Add sxdjt/ha-nws-alert-card

### DIFF
--- a/plugin
+++ b/plugin
@@ -415,6 +415,7 @@
   "stefmde/HomeAssistant-TwitchFollowedLiveStreamsCard",
   "studiobts/device-pulse-timeline-card",
   "swingerman/lovelace-fluid-level-background-card",
+  "sxdjt/ha-nws-alert-card",
   "sxdjt/horizontal-waterfall-history-card",
   "t1gr0u/rain-gauge-card",
   "t1gr0u/uv-index-card",


### PR DESCRIPTION
## Checklist
- [x] I have checked that my repository name follows the naming requirements.
- [x] I have read and understood the requirements.
- [x] I have checked the current list and my repository is not already there.
- [x] My repository have a hacs.json file.
- [x] My repository have a info.md file.
- [x] My repository have a README.md file.
- [x] I have created a release.
- [x] My repository is not a fork (if it's a fork changes are pushed to the original repository).

## Links
- Repository: https://github.com/sxdjt/ha-nws-alert-card
- Latest Release: https://github.com/sxdjt/ha-nws-alert-card/releases/tag/v2.0.0
- CI/Actions: https://github.com/sxdjt/ha-nws-alert-card/actions

## Description
Adding US NWS Alert Card - A custom Lovelace card that displays active US National Weather Service alerts with real-time updates, severity-based color coding, and expandable descriptions.

## Repository Information
- **Repository:** https://github.com/sxdjt/ha-nws-alert-card
- **Category:** Plugin (Lovelace Card)
- **Latest Release:** v2.0.0
- **HACS Validation:** Passing ✓

## Features
- Real-time NWS weather alerts for specified zones
- Severity-based color coding (Extreme, Severe, Moderate, Minor, Unknown)
- Expandable alert descriptions
- Security hardened (XSS protection, input sanitization)
- Performance optimized with event delegation and alert caching
- Accessible with ARIA labels and keyboard navigation

## Verification
- ✅ Repository has valid hacs.json
- ✅ Repository has README.md with documentation
- ✅ Repository has info.md for HACS store display
- ✅ Repository has LICENSE file (MIT)
- ✅ HACS validation workflow is passing
- ✅ Release v2.0.0 is tagged and published