### PR TITLE
Add Allianz-BonusDrive integration

### DIFF
--- a/integration
+++ b/integration
@@ -1810,6 +1810,7 @@
   "WulfgarW/homeassistant-pycupra",
   "wuwentao/midea_ac_lan",
   "xannor/ha_reolink_discovery",
+  "xathon/Allianz-BonusDrive-HomeAssistant",
   "xiaodong-lx/tplink-ipc-control",
   "XiaoMi/ha_xiaomi_home",
   "xilense/aimp_custom_component",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/xathon/Allianz-BonusDrive-HomeAssistant/releases/tag/v0.2.2>
Link to successful HACS action (without the `ignore` key): <https://github.com/xathon/Allianz-BonusDrive-HomeAssistant/actions/runs/19723471264/job/56510248180>
Link to successful hassfest action (if integration): <https://github.com/xathon/Allianz-BonusDrive-HomeAssistant/actions/runs/19723471264/job/56510248218>

