### PR TITLE
Update plugin

### DIFF
--- a/plugin
+++ b/plugin
@@ -363,6 +363,7 @@
   "PiotrMachowski/lovelace-xiaomi-vacuum-map-card",
   "pkissling/clock-weather-card",
   "pkscout/simple-weather-clock",
+  "pmbsa/simple-thermostat"
   "pmongloid/flipdown-timer-card",
   "postlund/search-card",
   "prl159/custom-todo",


### PR DESCRIPTION
Adding maintained fork of simple-thermostat card.
   
   Original repository (nervetattoo/simple-thermostat) has been abandoned.
   This is a community-maintained fork with:
   - Updated dependencies (Lit 3.x)
   - Active maintenance
   - Full backward compatibility
   
   Repository: https://github.com/pmbsa/simple-thermostat
   Release: https://github.com/pmbsa/