### PR TITLE
Add ahamitd/cosa-homeassistant to integrations

### DIFF
--- a/integration
+++ b/integration
@@ -718,6 +718,7 @@
   "hacf-fr/hass-ecoledirecte",
   "HAEdwin/homeassistant-apsystems_ecu_reader",
   "Haluska77/regulus-ha",
+  "hamitdurmus/cosa-homeassistant",
   "HamletDuFromage/ha_real-last-changed",
   "Hankanman/Area-Occupancy-Detection",
   "hanwg/sg-bus-arrivals",


### PR DESCRIPTION
Add COSA thermostat integration (ahamitd/cosa-homeassistant) to the default HACS integration list. This integration has release v1.0.6 and passes validation (CI checks: HACS Action, hassfest). Please review.