### PR TITLE
Add cedricziel/ha-matter-helper

### DIFF
--- a/integration
+++ b/integration
@@ -256,6 +256,7 @@
   "cavefire/hass-openid",
   "cazeaux/ha-iracing",
   "cdnninja/yoto_ha",
+  "cedricziel/ha-matter-helper",
   "chaimchaikin/molad-ha",
   "CharlesGillanders/homeassistant-alphaESS",
   "CharlesP44/Beem_Energy",


### PR DESCRIPTION
## Summary
Add Matter Binding Helper integration to HACS default repository.

**Repository:** https://github.com/cedricziel/ha-matter-helper

## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: https://github.com/cedricziel/ha-matter-binding-helper/releases/tag/v0.19.1
Link to successful HACS action (without the `ignore` key): https://github.com/cedricziel/ha-matter-binding-helper/actions/runs/20025924778/job/57423182864
Link to successful hassfest action (if integration): https://github.com/cedricziel/ha-matter-binding-helper/actions/runs/20025924748/job/57423182837