### PR TITLE
Add sxdjt/canvas-gauge-card-continued

### DIFF
--- a/plugin
+++ b/plugin
@@ -336,6 +336,7 @@
   "sopelj/lovelace-kanji-clock-card",
   "stefmde/HomeAssistant-TwitchFollowedLiveStreamsCard",
   "swingerman/lovelace-fluid-level-background-card",
+  "sxdjt/canvas-gauge-card-continued",
   "t1gr0u/rain-gauge-card",
   "t1gr0u/uv-index-card",
   "TarheelGrad1998/gallery-card",


### PR DESCRIPTION
## Repository Information

**Repository**: https://github.com/sxdjt/canvas-gauge-card-continued
**Category**: Plugin (Dashboard)
**Description**: Community-maintained continuation of canvas-gauge-card for Home Assistant

## What is this repository?

Canvas Gauge Card - Continued is a custom Lovelace card that allows users to display beautiful radial and linear gauges from https://canvas-gauges.com/ in their Home Assistant dashboards.

This is a community-maintained continuation of the original canvas-gauge-card (custom-cards/canvas-gauge-card) which was officially deprecated in July 2025.

## Why the continuation?

The original project was deprecated with no further maintenance. This continuation ensures:
- Compatibility with current and future Home Assistant versions
- Bug fixes for inherited issues
- Active community support and maintenance
- Preservation of the excellent work by the original authors

## Verification Checklist

- [x] Repository is publicly available on GitHub
- [x] Repository passes HACS Action validation (verified via GitHub Actions)
- [x] Repository has a description
- [x] Repository has GitHub topics
- [x] Repository has a README.md
- [x] Repository has a valid hacs.json
- [x] Repository has GitHub releases (v1.0.0-continued)
- [x] Repository has MIT LICENSE
- [x] Built file located at dist/canvas-gauge-card.js
- [x] Entry added alphabetically to plugin file
- [x] I am the repository owner

## Additional Information

- **Original Project**: https://github.com/custom-cards/canvas-gauge-card (deprecated)
- **Original Author**: @helto4real (Tomas Hellström) - Full attribution maintained
- **License**: MIT (maintained from original)
- **First Release**: v1.0.0-continued (December 2025)
- **Minimum Home Assistant**: 2023.1.0