### PR TITLE
Add weather-overlay plugin

### DIFF
--- a/plugin
+++ b/plugin
@@ -318,7 +318,7 @@
   "mon3y78/Lovelace-Bubble-room",
   "MrBartusek/MeteoalarmCard",
   "MrSjodin/HomeAssistant_Trafiklab_TravelSearch_Card",
-  "mzuniga51/weather-overlay"
+  "mzuniga51/weather-overlay",
   "nathan-gs/ha-map-card",
   "nathanmarlor/foxess_modbus_charge_period_card",
   "nathkrill/lovelace-google-fonts-header-card",


### PR DESCRIPTION
Fullscreen weather animations for Home Assistant with 11 different effects. Compatible with all weather integrations.

## Checklist
- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository. (N/A - this is a plugin, not an integration)
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links
Link to current release: https://github.com/mzuniga51/weather-overlay/releases/tag/v1.0.0
Link to successful HACS action (without the `ignore` key): https://github.com/mzuniga51/weather-overlay/actions
Link to successful hassfest action (if integration): N/A (this is a plugin, not an integration)

## Features
- 11 weather effects (rain, pouring, clouds, partly cloudy, fog, lightning, lightning+rain, snow, mixed, stars, sunny)
- Toggle control and test mode
- Dashboard filtering
- iPad/iPhone optimized
- 60fps canvas animations

**Repository:** https://github.com/mzuniga51/weather-overlay
**License:** MIT
