### PR TITLE
Add moerk-o/ha-solstice_season

### DIFF
--- a/integration
+++ b/integration
@@ -1196,6 +1196,7 @@
   "mmillmor/geo_home",
   "moarph/homeassistant_berner_torantriebe",
   "moehrem/DiveraControl",
+  "moerk-o/ha-solstice_season",
   "Mofeywalker/openmensa-hass-component",
   "Monitor-My-Solar/monitormysolar",
   "monty68/uniled",


### PR DESCRIPTION
## Repository

https://github.com/moerk-o/ha-solstice_season

## Description

Home Assistant integration providing sensors for current season, start of the next four seasons, and daylight trend. Supports astronomical and meteorological calculation modes for both hemispheres.

## Checklist

- [x] I am the owner or a major contributor to this repository
- [x] The repository is publicly available on GitHub
- [x] The repository has a valid `hacs.json` file
- [x] The repository has at least one release
- [x] The repository uses GitHub Actions with HACS and Hassfest validation
- [x] Brand icons have been added to home-assistant/brands (PR #8618 merged)