### PR TITLE
add bravia quad

### DIFF
--- a/integration
+++ b/integration
@@ -1627,6 +1627,7 @@
   "stackia/ha-deye-dehumidifier",
   "stanus74/home-assistant-saj-h2-modbus",
   "starwarsfan/shadow-control",
+  "steamEngineer/bravia-quad-homeassistant",
   "stefanes/tibber-graph",
   "stephan192/hochwasserportal",
   "StephanJoubert/home_assistant_solarman",


### PR DESCRIPTION
This pull request adds support for Bravia Quad Atmos set integration. It could expand to other bravia audio devices in the future with user support.

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/steamEngineer/bravia-quad-homeassistant/releases/tag/v1.3.1>
Link to successful HACS action (without the `ignore` key): <https://github.com/steamEngineer/bravia-quad-homeassistant/actions/runs/20102830940/job/57678201712?pr=23>
Link to successful hassfest action (if integration): <https://github.com/steamEngineer/bravia-quad-homeassistant/actions/runs/20102831044?pr=23>

