### PR TITLE
Removed tomaae/homeassistant-portainer

### DIFF
--- a/integration
+++ b/integration
@@ -1737,7 +1737,6 @@
   "tom42530/asys_ble_ha",
   "tomaae/homeassistant-mikrotik_router",
   "tomaae/homeassistant-openmediavault",
-  "tomaae/homeassistant-portainer",
   "tomaae/homeassistant-truenas",
   "tomasbedrich/home-assistant-hikconnect",
   "tomasbedrich/home-assistant-skydance",


### PR DESCRIPTION
Removal request, since HA now has integration with same name and similar features.
I'm the owner of this repository