### PR TITLE
Add omachala/ha-treemap-card

### DIFF
--- a/plugin
+++ b/plugin
@@ -346,6 +346,7 @@
   "nutteloost/todo-swipe-card",
   "Nyaran/myjdownloader-card",
   "ofekashery/vertical-stack-in-card",
+  "omachala/ha-treemap-card",
   "OtisPresley/snmp-switch-manager-card",
   "ownbee/bootstrap-grid-card",
   "partach/switch_port_card",


### PR DESCRIPTION
## New repository

**Repository:** https://github.com/omachala/ha-treemap-card

**Description:** Treemap card for Home Assistant - visualize sensor data as interactive heatmaps. Rectangle size and color show relative values at a glance.

**Category:** Plugin (Lovelace card)

### Checklist
- [x] Repository is public
- [x] Has `hacs.json` with name field
- [x] Has at least one release with JS asset
- [x] Has description and topics
- [x] Has MIT license
- [x] I am the owner of this repository