### PR TITLE
Add omachala/ha-treemap-card

### DIFF
--- a/plugin
+++ b/plugin
@@ -346,6 +346,7 @@
   "nutteloost/todo-swipe-card",
   "Nyaran/myjdownloader-card",
   "ofekashery/vertical-stack-in-card",
+  "omachala/ha-treemap-card",
   "OtisPresley/snmp-switch-manager-card",
   "ownbee/bootstrap-grid-card",
   "partach/switch_port_card",


### PR DESCRIPTION
## New repository

**Repository:** https://github.com/omachala/ha-treemap-card

**Description:** Treemap card for Home Assistant - visualize sensor data as interactive heatmaps. Rectangle size and color show relative values at a glance.

**Category:** Plugin (Lovelace card)

**Links:**
- Latest release: https://github.com/omachala/ha-treemap-card/releases/tag/v0.4.0
- CI runs: https://github.com/omachala/ha-treemap-card/actions

### Checklist
- [x] I am the owner or a major contributor to this repository
- [x] I have read the [contribution guidelines](https://hacs.xyz/docs/publish/include)
- [x] The repository has a valid `hacs.json` file
- [x] The repository has a description
- [x] The repository has topics set
- [x] The repository has at least one release
- [x] The repository passes HACS validation