### PR TITLE
Add GrumpyTanker integrations

### DIFF
--- a/integration
+++ b/integration
@@ -701,6 +701,8 @@
   "grimmpp/home-assistant-eltako",
   "gritaro/gigachain",
   "grotan1/denon-avr-3805",
+  "GrumpyTanker/Ecowater-Hydrolink-HACS",
+  "GrumpyTanker/ERCOT-Settlement-Price-Point",
   "gtjadsonsantos/consul",
   "gtjadsonsantos/controlid",
   "gtjadsonsantos/vapix",


### PR DESCRIPTION
This PR adds two custom integrations to the HACS default repository:

## Integrations Added

### 1. [Ecowater-Hydrolink-HACS](https://github.com/GrumpyTanker/Ecowater-Hydrolink-HACS)
- **Name:** EcoWater HydroLink
- **Description:** HACS integration for Ecowater Hydrolink
- **Topics:** ecowater-hydrolink, hacs, homeassistant, hydrolink

### 2. [ERCOT-Settlement-Price-Point](https://github.com/GrumpyTanker/ERCOT-Settlement-Price-Point)
- **Name:** ERCOT Real-Time SPP
- **Description:** Get the ERCOT SPP from their website
- **Topics:** ercot, hacs, homeassistant

## Verification
- ✅ Both repositories are not archived
- ✅ Both have the 'hacs' topic
- ✅ Both have valid `hacs.json` files
- ✅ Both have valid `manifest.json` and `__init__.py` files
- ✅ Entries are properly sorted alphabetically (case-insensitive)
- ✅ Passed `scripts/is_sorted.py` validation