### PR TITLE
Add GrumpyTanker/Ecowater-Hydrolink-HACS

### DIFF
--- a/integration
+++ b/integration
@@ -701,6 +701,7 @@
   "grimmpp/home-assistant-eltako",
   "gritaro/gigachain",
   "grotan1/denon-avr-3805",
+  "GrumpyTanker/Ecowater-Hydrolink-HACS",
   "gtjadsonsantos/consul",
   "gtjadsonsantos/controlid",
   "gtjadsonsantos/vapix",


### PR DESCRIPTION
## Summary

Adds the [Ecowater-Hydrolink-HACS](https://github.com/GrumpyTanker/Ecowater-Hydrolink-HACS) custom integration.

This integration provides Home Assistant integration for Ecowater Hydrolink water softeners, allowing monitoring and control of Ecowater water softener devices.

## Checklist

- [x] The domain is not in the blocklist
- [x] There are no existing open pull requests for this repository
- [x] My repository follows the requirements from the [HACS Documentation](https://www.hacs.xyz/docs/publish/)
- [x] Link to passing HACS action: https://github.com/GrumpyTanker/Ecowater-Hydrolink-HACS/actions/runs/20320745547
- [x] Link to passing hassfest action: https://github.com/GrumpyTanker/Ecowater-Hydrolink-HACS/actions/runs/20320745537
