### PR TITLE
Adds new plugin [alexhopeoconnor/bom-local-card]

### DIFF
--- a/plugin
+++ b/plugin
@@ -8,6 +8,7 @@
   "abualy/philips-tv-remote-card",
   "adizanni/floor3d-card",
   "aex351/home-assistant-neerslag-card",
+  "alexhopeoconnor/bom-local-card",
   "alexpfau/calendar-card-pro",
   "amaximus/bkk-stop-card",
   "amaximus/fkf-garbage-collection-card",


### PR DESCRIPTION
Adding a new custom card for displaying Australian Bureau of Meteorology (BOM) rain radar data.
https://github.com/alexhopeoconnor/bom-local-card

## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/alexhopeoconnor/bom-local-card/releases/tag/v0.1.4>
Link to successful HACS action (without the `ignore` key): <https://github.com/alexhopeoconnor/bom-local-card/actions/runs/20335321626>
Link to successful hassfest action (if integration): <>