### PR TITLE
Adds new integration [carpenike/homeassistant_adguard_home]

### DIFF
--- a/integration
+++ b/integration
@@ -282,6 +282,7 @@
   "caplaz/micro-weather-station",
   "carohauta/oma-helen-ha-integration",
   "caronc/ha-ultrasync",
+  "carpenike/homeassistant_adguard_home",
   "casungo/osservaprezzi-carburanti-ha",
   "cataseven/Binance-Wallet-Integration-Home-Assistant",
   "cathiele/homeassistant-goecharger",


### PR DESCRIPTION
## Checklist
- [x] I am the owner or a major contributor to this repository
- [x] I have added the repository to the correct category file
- [x] The entry is added in alphabetical order
- [x] The repository has a valid `hacs.json` file
- [x] The repository has GitHub Actions for HACS validation and Hassfest
- [x] The repository has at least one release
- [x] The repository has a description, issues enabled, and topics defined
- [x] I have submitted a PR to home-assistant/brands (PR #8772)

## Repository Information
- **Repository**: https://github.com/carpenike/homeassistant_adguard_home
- **Latest Release**: https://github.com/carpenike/homeassistant_adguard_home/releases/latest
- **CI Actions**: https://github.com/carpenike/homeassistant_adguard_home/actions
- **Name**: AdGuard Home Extended
- **Description**: Extended functionality for AdGuard Home in Home Assistant beyond the official core integration
- **Category**: Integration