### PR TITLE
remove archived project [dahlb/ha_kia_hyundai]

### DIFF
--- a/integration
+++ b/integration
@@ -405,7 +405,6 @@
   "dahlb/ha_blueair",
   "dahlb/ha_carrier",
   "dahlb/ha_hatch",
-  "dahlb/ha_kia_hyundai",
   "daikin-br/ha-custom-integration",
   "dala318/ev_load_balancing",
   "dala318/nordpool_planner",


### PR DESCRIPTION
I saw there is a script to remove archived projects but I wanted to be proactive.  

Thanks for all you do for the community.

dahlb/ha_kia_hyundai has been archived due to a hostile api provider.