### PR TITLE
Add springflake1337/deye_sun_microinverter integration

### DIFF
--- a/integration
+++ b/integration
@@ -1625,6 +1625,7 @@
   "SpanPanel/span",
   "spatecon/orcommconnect",
   "SplinterHead/ha-honeygain",
+  "springflake1337/deye_sun_microinverter",
   "sprocket-9/hacs-nuvo-serial",
   "spuky/lunatone-dali-integration",
   "spycle/tuneblade",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: https://github.com/springflake1337/deye_sun_microinverter/releases/tag/v1.0.2
Link to successful HACS action (without the `ignore` key): https://github.com/springflake1337/deye_sun_microinverter/actions/runs/20410309234/job/58646078112
Link to successful hassfest action (if integration): https://github.com/springflake1337/deye_sun_microinverter/actions/runs/20410309234/job/58646078102

## Additional Information
The automated HACS brand validation might fail because the brand assets are currently pending review in this Pull Request: https://github.com/home-assistant/brands/pull/8788. All technical requirements for the brands have been met.

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->