### PR TITLE
Add sginestrini/home-assistant-tada-integration to default Integrations

### DIFF
--- a/integration
+++ b/integration
@@ -1570,6 +1570,7 @@
   "sfortis/openai_tts",
   "sfstar/hass-victron",
   "sftgunner/edinplus-integration",
+  "sginestrini/home-assistant-tada-integration",
   "sh00t2kill/dolphin-robot",
   "sh00t2kill/linktap_local_http_component",
   "sh00t2kill/petoneer_custom_component",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/sginestrini/home-assistant-tada-integration/releases/tag/v0.1.0>
Link to successful HACS action (without the `ignore` key): <>
Link to successful hassfest action (if integration): <https://github.com/sginestrini/home-assistant-tada-integration/actions/runs/20470958312>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->