### PR TITLE
Add vda-solutions/vda-ir-control

### DIFF
--- a/integration
+++ b/integration
@@ -1802,6 +1802,7 @@
   "Vaskivskyi/ha-asusrouter",
   "Vaskivskyi/ha-chroma",
   "vasqued2/ha-teamtracker",
+  "vda-solutions/vda-ir-control",
   "Vegetronix-Inc/ha-vegehub",
   "veista/exsys_usb_hub",
   "veista/nilan",


### PR DESCRIPTION
## Integration Details

- **Repository:** https://github.com/vda-solutions/vda-ir-control
- **Category:** Integration
- **Description:** Control IR devices (TVs, AV receivers, cable boxes) using ESP32 boards

## What it does

VDA IR Control is a Home Assistant integration for controlling multiple IR devices using ESP32 microcontrollers. Designed for commercial venues like bars and restaurants that need to control many devices from a central location.

**Features:**
- Multi-board management (multiple ESP32 controllers)
- IR learning from original remotes
- Community IR profile repository
- REST API for automation
- Companion Lovelace cards for management and control

## Checklist

- [x] Repository has `hacs.json` file
- [x] Repository has releases with valid version tags
- [x] Repository has `manifest.json` with required fields
- [x] Integration is functional and tested
- [x] Documentation in README