### PR TITLE
Add skyer/home-assistant-tylo-sauna

### DIFF
--- a/integration
+++ b/integration
@@ -1590,6 +1590,7 @@
   "Skarbo/hass-scinan-thermostat",
   "skircr115/ha-verizonFiOS",
   "skodaconnect/homeassistant-myskoda",
+  "skyer/home-assistant-tylo-sauna",
   "Slalamander/Home-Assistant-Eetlijst",
   "slashback100/presence_simulation",
   "slesinger/HomeAssistant-BMR",


### PR DESCRIPTION
Adds the Tylo Sauna integration repository to the HACS default list.\n\n- Repository: https://github.com/skyer/home-assistant-tylo-sauna\n- Category: Integration\n- Latest release: v0.3.3 (includes tylo_sauna.zip for HACS)