### PR TITLE
Adds new integration [thomasgriebner/retention_cleaner]

### DIFF
--- a/integration
+++ b/integration
@@ -1710,6 +1710,7 @@
   "thevoltagesource/LennoxiComfort",
   "thisisthetechie/home-assistant-sickgear",
   "thomas-svrts/blossom_be",
+  "thomasgriebner/retention_cleaner"
   "ThomasHFWright/kippy-homeassistant",
   "ThomasLomas/ha-starlinghomehub",
   "thomasloven/hass-browser_mod",


### PR DESCRIPTION
Add new integration for Retention Cleaner

## Checklist
- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links
Link to current release: https://github.com/thomasgriebner/retention_cleaner/releases/tag/v1.0.4  
Link to successful HACS action (without the `ignore` key): https://github.com/thomasgriebner/retention_cleaner/actions/runs/20642618957/job/59276349806  
Link to successful hassfest action (if integration): https://github.com/thomasgriebner/retention_cleaner/actions/runs/20642618957/job/59276349804#logs