### PR TITLE
Add costantinoai/bring-widget-hacs

### DIFF
--- a/integration
+++ b/integration
@@ -346,6 +346,7 @@
   "connorgallopo/leslies-pool",
   "connorgallopo/Superior-Plus-Propane",
   "corporategoth/ha-powerpetdoor",
+  "costantinoai/bring-widget-hacs",
   "cowboyrushforth/home-assistant-molekule",
   "craibo/ha-red-energy-au",
   "craibo/ha_strava",


### PR DESCRIPTION
## Summary
Add Bring! Shopping Card integration to HACS default repository.

## Integration Details
- **Repository**: https://github.com/costantinoai/bring-widget-hacs
- **Domain**: `bring_shopping`
- **Name**: Bring! Shopping Card
- **Description**: A beautiful, modern shopping list card for Bring! - fully integrated with Home Assistant

## Features
- Beautiful Lovelace card that adapts to Home Assistant theme
- Real product images from Bring CDN with emoji fallback
- Multiple lists support with dropdown selector
- Drag & drop reordering
- Native Home Assistant todo entities for automations
- Visual config editor

## Checklist
- [x] Repository is public on GitHub
- [x] Repository has a description
- [x] Repository has topics set
- [x] Repository has issues enabled
- [x] At least one release exists (v1.0.2)
- [x] Hassfest validation passes
- [x] Brands PR submitted: https://github.com/home-assistant/brands/pull/8929