### PR TITLE
Adds new integration [costantinoai/bring-shopping-card]

### DIFF
--- a/integration
+++ b/integration
@@ -346,6 +346,7 @@
   "connorgallopo/leslies-pool",
   "connorgallopo/Superior-Plus-Propane",
   "corporategoth/ha-powerpetdoor",
+  "costantinoai/bring-shopping-card",
   "cowboyrushforth/home-assistant-molekule",
   "craibo/ha-red-energy-au",
   "craibo/ha_strava",


### PR DESCRIPTION
## New Integration checklist

- [x] The integration is not core integration, i.e., it is not part of core Home Assistant
- [x] The integration is not an alpha or beta testing integration that overrides core integrations
- [x] I am the owner or a major contributor to the repository
- [x] I have read and understood the [submission requirements](https://hacs.xyz/docs/publish/include/)
- [x] The repository does not use "HACS" in its name
- [x] The repository has been added to the [Home Assistant brands repository](https://github.com/home-assistant/brands): https://github.com/home-assistant/brands/pull/8929

## Links

- **Repository**: https://github.com/costantinoai/bring-shopping-card
- **Latest Release**: https://github.com/costantinoai/bring-shopping-card/releases/tag/v1.0.3
- **CI Actions**: https://github.com/costantinoai/bring-shopping-card/actions

## Integration Details

- **Domain**: `bring_shopping`
- **Name**: Bring! Shopping Card
- **Description**: A beautiful, modern shopping list card for Bring! - fully integrated with Home Assistant

## Features

- Beautiful Lovelace card that adapts to Home Assistant theme
- Real product images from Bring CDN with emoji fallback
- Multiple lists support with dropdown selector
- Drag & drop reordering
- Native Home Assistant todo entities for automations
- Visual config editor