### PR TITLE
Add BMW Wallbox (OCPP) integration

### DIFF
--- a/integration
+++ b/integration
@@ -890,6 +890,7 @@
   "jobvk/Home-Assistant-Windcentrale",
   "joemcc-90/leeds-bins-hass",
   "joggs/home_assistant_ebeco",
+  "JoaoPedroBelo/bmw-wallbox-ha",
   "johannesWen/KEBA-Heat-Pump-Modbus-Integration",
   "john-lazarus/HomeAssistant-SolisCloudMonitoring",
   "JohNan/homeassistant-wellbeing",


### PR DESCRIPTION
## BMW Wallbox (OCPP)

**Repository:** https://github.com/JoaoPedroBelo/bmw-wallbox-ha

Home Assistant integration for BMW-branded Delta Electronics wallboxes using OCPP 2.0.1 protocol.

### Features
- Real-time monitoring (power, energy, current, voltage)
- Smart control (start/stop/pause charging, dynamic current limits)
- 37 sensors including per-phase measurements
- Full Energy Dashboard integration
- Local control via OCPP 2.0.1 WebSocket Secure

### Hardware Support
- BMW-branded Delta Electronics wallboxes (Model: EIAW-E22KTSE6B04)
- Potentially other OCPP 2.0.1 compatible wallboxes

### Validation
✅ Repository passes HACS validation  
✅ Manifest.json valid  
✅ Documentation complete  
✅ MIT License  
✅ Active maintenance (v1.4.1 released)

### Links
- Documentation: https://github.com/JoaoPedroBelo/bmw-wallbox-ha#readme
- Issue Tracker: https://github.com/JoaoPedroBelo/bmw-wallbox-ha/issues
- Releases: https://github.com/JoaoPedroBelo/bmw-wallbox-ha/releases

Thank you for reviewing!