### PR TITLE
Add MCP Assist

### DIFF
--- a/integration
+++ b/integration
@@ -1194,6 +1194,7 @@
   "MiguelAngelLV/ha-tarifa-20td",
   "MiguelTVMS/e-redes-smart-metering-plus-hass",
   "mike81gr/deddie-metering",
+  "mike-nott/mcp-assist",
   "mikelawrence/senseme-hacs",
   "milanhin/sdac_elia",
   "mill1000/midea-ac-py",


### PR DESCRIPTION
Adds MCP Assist - a Home Assistant conversation agent using Model Context Protocol for efficient entity discovery.

Repository: https://github.com/mike-nott/mcp-assist
Branding: Merged in home-assistant/brands PR #8728

MCP Assist achieves 95% token reduction by using MCP tools for dynamic entity discovery instead of sending full entity lists to LLMs.