### PR TITLE
Add new integrations for Axpert inverters and Pylontech batteries

### DIFF
--- a/integration
+++ b/integration
@@ -144,6 +144,8 @@
   "arifwn/homeassistant-whatspie-integration",
   "ArikShemesh/ha-simple-timer",
   "arnoudkooi/ha-hid-usbrelay",
+  "ArnyminerZ/ha-axpert-inverter",
+  "ArnyminerZ/ha-pylon-integration",
   "aronkahrs-us/inumet-weather-ha",
   "aropop/home-assistant-cronicle",
   "artspb/homeassistant-tk-husteblume",


### PR DESCRIPTION
Adds the repositories:
- https://github.com/ArnyminerZ/ha-axpert-inverter
- https://github.com/ArnyminerZ/ha-pylon-integration

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [ ] The actions are passing without any disabled checks in my repository.
  _Waiting for brands to be passed_
- [ ] I've added a link to the action run on my repository below in the links section.
- [ ] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <>
Link to successful HACS action (without the `ignore` key): <>
Link to successful hassfest action (if integration): <>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->