### PR TITLE
Add new integration 'lavalex2003/emaktab'

### DIFF
--- a/integration
+++ b/integration
@@ -1040,6 +1040,7 @@
   "LarsK1/hass_solvis_control",
   "laszlojakab/homeassistant-dijnet",
   "laszlojakab/homeassistant-easycontrols",
+  "lavalex2003/emaktab",
   "LavermanJJ/home-assistant-solarfocus",
   "lbbrhzn/ocpp",
   "ledimestari/homeassistant-precious-metals",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [ ] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [ ] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the current release of my repository below.
- [x] I've created a new release of the repository.

## Links

Link to current release: https://github.com/lavalex2003/emaktab/releases/tag/v1.0.3

Link to successful HACS action (without the `ignore` key):  
N/A – This repository does not currently use a dedicated HACS GitHub Action workflow.

Link to successful hassfest action (if integration):  
N/A – This repository does not currently use GitHub Actions.  
The integration has been manually validated and successfully installed via HACS.
