### PR TITLE
Add new integration 'lavalex2003/emaktab'

### DIFF
--- a/integration
+++ b/integration
@@ -1040,6 +1040,7 @@
   "LarsK1/hass_solvis_control",
   "laszlojakab/homeassistant-dijnet",
   "laszlojakab/homeassistant-easycontrols",
+  "lavalex2003/emaktab",
   "LavermanJJ/home-assistant-solarfocus",
   "lbbrhzn/ocpp",
   "ledimestari/homeassistant-precious-metals",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added links to the action runs on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release:  
https://github.com/lavalex2003/emaktab/releases/tag/v1.0.5

Link to successful HACS action (without the `ignore` key):  
https://github.com/lavalex2003/emaktab/actions/runs/20880617755

Link to successful hassfest action (if integration):  
https://github.com/lavalex2003/emaktab/actions/runs/20880647593
