### PR TITLE
Add new integration for glyndavidson/MACS

### DIFF
--- a/integration
+++ b/integration
@@ -692,6 +692,7 @@
   "gjohansson-ST/response_as_sensor",
   "gjohansson-ST/sector",
   "glenndehaan/homeassistant-hdfury",
+  "glyndavidson/MACS",
   "gndean/home-assistant-hypervolt-charger",
   "godely/ha-dremel-3d-printer",
   "golles/ha-aquatlantis-ori",


### PR DESCRIPTION
Added M.A.C.S, a playful, expressive, animated companion for Home Assistant. https://github.com/glyndavidson/MACS

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [ ] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [ ] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [ ] The actions are passing without any disabled checks in my repository.
- [ ] I've added a link to the action run on my repository below in the links section.
- [ ] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/glyndavidson/MACS/releases/tag/v1.0.1>
Link to successful HACS action (without the `ignore` key): <https://github.com/glyndavidson/MACS/actions/runs/20921124091>
Link to successful hassfest action (if integration): <https://github.com/glyndavidson/MACS/actions/runs/20921124055>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->