### PR TITLE
Adds new plugin [maglerod/andy-stats-clock]

### DIFF
--- a/plugin
+++ b/plugin
@@ -299,7 +299,7 @@
   "MadSnuif/hockeynl-card",
   "MagicMicky/lovelace-calendar-heatmap-card",
   "maglerod/andy-quickboard-card",
-  "maglerod/andy-segment-display-card",
+  "maglerod/andy-segment-display-card",  
   "maglerod/andy-stats-clock",
   "maglerod/andy-temperature-card",
   "Makin-Things/bom-radar-card",


### PR DESCRIPTION
### Andy Stats Clock 

A fully dynamic, multi-layer circular statistics clock for Home Assistant. Visualize prices, consumption, temperature, trends and sensor history in a stunning 12h/24h radial layout with animated hands and unlimited configurable rings

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [X] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [X] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [X] The actions are passing without any disabled checks in my repository.
- [X] I've added a link to the action run on my repository below in the links section.
- [X] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/maglerod/andy-stats-clock/releases/tag/v1.0.4>
Link to successful HACS action (without the `ignore` key): <https://github.com/maglerod/andy-stats-clock/actions/runs/20948495287>
Link to successful hassfest action (if integration): <>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->