### PR TITLE
Add ARPOBOT-BLOOMIN8/eink_canvas_home_assistant_component

### DIFF
--- a/integration
+++ b/integration
@@ -144,6 +144,7 @@
   "Archef2000/homeassistant-upsplus",
   "ardevd/ha-bobcatminer",
   "ardevd/ha-dimo",
+  "ARPOBOT-BLOOMIN8/eink_canvas_home_assistant_component",
   "arevindh/ha-tinxy-cloud",
   "arifwn/homeassistant-whatspie-integration",
   "ArikShemesh/ha-simple-timer",


### PR DESCRIPTION
## Add to HACS default repository

- **Repository**: https://github.com/ARPOBOT-BLOOMIN8/eink_canvas_home_assistant_component
- **Category**: Integration
- **Description**: BLOOMIN8 E-Ink Canvas integration for Home Assistant

### Checklist
- [x] I am the owner of this repository
- [x] The repository has been added to home-assistant/brands
- [x] The repository has a valid hacs.json
- [x] The repository passes HACS validation
- [x] The repository has at least one release