### PR TITLE
Adds new plugin [jtubb/generator-hmi-card]

### DIFF
--- a/plugin
+++ b/plugin
@@ -250,6 +250,7 @@
   "joseluis9595/lovelace-navbar-card",
   "jtbgroup/kodi-playlist-card",
   "jtbgroup/kodi-search-card",
+  "jtubb/generator-hmi-card",
   "junalmeida/homeassistant-minimalistic-area-card",
   "junkfix/config-editor-card",
   "junkfix/numberbox-card",


### PR DESCRIPTION
## New Plugin Submission

**Repository:** https://github.com/jtubb/generator-hmi-card

**Description:** ISA-101 compliant Human Machine Interface (HMI) card for Home Assistant, designed for Genmon generator monitoring systems.

### Features
- ISA-101 high performance HMI design with industrial gray theme
- Status indicators for engine state, utility power, and transfer switch
- Analog bar displays for voltage, frequency, and battery
- Maintenance status with smart Genmon format parsing
- Control buttons with state-aware enable/disable
- Configurable device name for flexible entity mapping

### Checklist
- [x] Repository has a valid `hacs.json` file
- [x] Repository has a `README.md` with installation instructions
- [x] Repository has a valid license (`LICENSE` file)
- [x] Repository has at least one release with a tag