### PR TITLE
Adds new plugin [jtubb/generator-hmi-card]

### DIFF
--- a/plugin
+++ b/plugin
@@ -250,6 +250,7 @@
   "joseluis9595/lovelace-navbar-card",
   "jtbgroup/kodi-playlist-card",
   "jtbgroup/kodi-search-card",
+  "jtubb/generator-hmi-card",
   "junalmeida/homeassistant-minimalistic-area-card",
   "junkfix/config-editor-card",
   "junkfix/numberbox-card",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/jtubb/generator-hmi-card/releases/tag/v2.2.1>
Link to successful HACS action (without the `ignore` key): <https://github.com/jtubb/generator-hmi-card/actions/runs/21104809930>
Link to successful hassfest action (if integration): <N/A - this is a plugin>