### PR TITLE
Adds jtubb/HA-Pylontech-BMS

### DIFF
--- a/integration
+++ b/integration
@@ -951,6 +951,7 @@
   "jseidl/magic-areas",
   "jsheputis/home-assistant-lifetime-fitness",
   "jtbgroup/kodi-media-sensors",
+  "jtubb/HA-Pylontech-BMS",
   "juacas/honor_x3",
   "juacas/zte_tracker",
   "jugla/battery_consumption",


### PR DESCRIPTION
## Checklist
- [x] The repository has a description
- [x] The repository has topics
- [x] The repository has a version tag (v1.2.2)
- [x] Hassfest passes: https://github.com/jtubb/HA-Pylontech-BMS/actions/runs/21114184917

## Repository
https://github.com/jtubb/HA-Pylontech-BMS

## Description
A Home Assistant integration for monitoring Pylontech (SOK) BMS battery systems via RS485 serial connection. Provides entities for battery voltage, current, state of charge, cell temperatures, cell voltages, and system status for multi-pack battery configurations.

## Features
- Multi-pack battery support (1-16+ packs)
- Real-time monitoring of pack voltage, current, power, and SOC
- Individual cell voltage and temperature sensors
- Delta V monitoring for cell balance
- Cycle count tracking
- Alarm and warning state reporting

🤖 Generated with [Claude Code](https://claude.com/claude-code)