### PR TITLE
Add jaycollett/OpenIRBlaster

### DIFF
--- a/integration
+++ b/integration
@@ -874,6 +874,7 @@
   "jasonwragg/home-assistant-readynaslocal",
   "jasperslits/haithowifi",
   "JayBlackedOut/hass-nhlapi",
+  "jaycollett/OpenIRBlaster",
   "jaydeethree/Home-Assistant-weatherdotcom",
   "jayjojayson/hass-victron-vrm-api",
   "jazzz/ha-evocarshare",


### PR DESCRIPTION
## Description
OpenIRBlaster is a Home Assistant custom integration for learning, storing, and replaying infrared remote control codes using ESPHome-based hardware.

## Repository
https://github.com/jaycollett/OpenIRBlaster

## Requirements Checklist
- [x] Repository is public
- [x] GitHub Actions (HACS + Hassfest) passing
- [x] GitHub release created (v1.0.0)
- [x] Repository has description
- [x] Issues are enabled
- [x] Topics defined
- [x] Entry added alphabetically to integration list
- [x] I am the owner/major contributor

## Key Features
- Learn IR codes from any remote with one button press
- Store unlimited codes with names, tags, and notes
- Replay codes via Home Assistant button entities
- Full automation support
- Multi-device support
- Local control via ESPHome (no cloud)

## Use Cases
- Control TVs, ACs, fans, projectors, and other IR devices
- Build unified IR control dashboards
- Create automations (e.g., "turn off AC when leaving")
- Enable voice control through HA

## Technical Details
- Integration type: Device
- IoT class: Local push
- Dependencies: ESPHome integration
- Includes pre-compiled firmware binary
- Complete hardware guide and documentation
- MIT licensed

Thank you for considering this submission!