### PR TITLE
Add jaycollett/OpenIRBlaster

### DIFF
--- a/integration
+++ b/integration
@@ -874,6 +874,7 @@
   "jasonwragg/home-assistant-readynaslocal",
   "jasperslits/haithowifi",
   "JayBlackedOut/hass-nhlapi",
+  "jaycollett/OpenIRBlaster",
   "jaydeethree/Home-Assistant-weatherdotcom",
   "jayjojayson/hass-victron-vrm-api",
   "jazzz/ha-evocarshare",


### PR DESCRIPTION
## Repository
https://github.com/jaycollett/OpenIRBlaster

## Latest Release
https://github.com/jaycollett/OpenIRBlaster/releases/latest

## CI Actions
https://github.com/jaycollett/OpenIRBlaster/actions

## Description
OpenIRBlaster is a Home Assistant custom integration for learning, storing, and replaying infrared remote control codes using ESPHome-based hardware.

## Requirements Checklist
- [x] Repository is public and works as a HACS custom repository
- [x] GitHub Actions (HACS + Hassfest) passing without errors
- [x] Official GitHub release created after successful actions
- [x] Entry added alphabetically to the integration list
- [x] I am the owner/major contributor of this repository
- [x] Repository has a description
- [x] Issues are enabled
- [x] Repository topics are defined

## Key Features
- Learn IR codes from any remote with one button press
- Store unlimited codes with names, tags, and notes
- Replay codes via Home Assistant button entities
- Full automation support for smart home integration
- Multi-device support for managing multiple IR blasters
- Local control via ESPHome (no cloud dependency)

## Use Cases
- Control TVs, air conditioners, fans, projectors, and other IR devices
- Build unified dashboards for IR-controlled devices
- Create automations (e.g., "turn off AC when leaving home")
- Enable voice control through Home Assistant

## Technical Details
- **Integration Type:** Device
- **IoT Class:** Local push
- **Dependencies:** ESPHome integration
- **Hardware:** ESP8266/ESP32 based with included firmware
- **Documentation:** Complete README, hardware guide, and build instructions
- **License:** MIT

The integration includes pre-compiled firmware binary and complete hardware documentation for easy adoption.