### PR TITLE
Add axelpaul/leitir-ha

### DIFF
--- a/integration
+++ b/integration
@@ -175,6 +175,7 @@
   "aunefyren/bluesound_alt",
   "avishorp/sync_group",
   "avlemos/dobiss",
+  "axelpaul/leitir-ha",
   "ayavilevich/homeassistant-dlink-presence",
   "aykutvr/smartcosa-home-assistant-integration",
   "azerty9971/xtend_tuya",


### PR DESCRIPTION
## Repository

https://github.com/axelpaul/leitir-ha

## Description

Home Assistant integration for Leitir - Iceland's public library system. Track your library loans, see due dates, and renew books directly from Home Assistant.

## Checklist

- [x] Repository is public
- [x] Repository has a description
- [x] Repository has topics
- [x] Repository has issues enabled
- [x] Repository has a hacs.json file
- [x] Repository has a valid manifest.json
- [x] HACS Action passes
- [x] Hassfest passes
- [x] Repository has a release