### PR TITLE
Add NerdySoftPaw/hacs-publictransport

### DIFF
--- a/integration
+++ b/integration
@@ -1319,6 +1319,7 @@
   "NemesisRE/sensor.plex_recently_added",
   "NemoN/ha-intex-swg",
   "NeoHuncho/vikunja-voice-assistant",
+  "NerdySoftPaw/hacs-publictransport",
   "netsoft-ruidias/ha-custom-component-coverflex",
   "netsoft-ruidias/ha-custom-component-myedenred",
   "netsoft-ruidias/ha-custom-component-precoscombustiveis",


### PR DESCRIPTION
## Summary
Adding **Public Transport Departures** integration for real-time departure information from multiple European public transport networks:
- VRR (Verkehrsverbund Rhein-Ruhr, Germany)
- KVV (Karlsruher Verkehrsverbund, Germany)
- HVV (Hamburger Verkehrsverbund, Germany)
- Trafiklab (Sweden)
- NTA (National Transport Authority, Ireland)

## Repository
https://github.com/NerdySoftPaw/hacs-publictransport

## Features
- Real-time departure information with delays
- Smart setup wizard with autocomplete
- Fuzzy matching for stop search
- Binary sensor for delay detection
- Multiple transport types (train, subway, tram, bus, ferry)

## Checklist
- [x] I am the owner of this repository
- [x] The repository has valid releases
- [x] The repository meets all HACS requirements
- [x] The HACS Action passes successfully
- [x] The integration is added to home-assistant/brands