### PR TITLE
Add Fellow Aiden integration

### DIFF
--- a/integration
+++ b/integration
@@ -1323,6 +1323,7 @@
   "netsoft-ruidias/ha-custom-component-myedenred",
   "netsoft-ruidias/ha-custom-component-precoscombustiveis",
   "netsoft-ruidias/ha-custom-component-sodexo",
+  "NewsGuyTor/FellowAiden-HomeAssistant",
   "nexhome-org/nexhome-homeassistant-component",
   "nfeuerhelm/ha-proj-viewsonic",
   "ngocjohn/lunar-phase",


### PR DESCRIPTION
## Checklist

- [x] I am the owner, or a major contributor to the repository I want to add.
- [x] I have read the HACS documentation [Publishing](https://hacs.xyz/docs/publish/start) pages.
- [x] The repository I want to add does have a version tag (zip file downloads without versions are not supported).
- [x] The repository I want to add is **not** using alpha/beta as the only versions (alpha/beta is fine to be used in addition to releases).
- [x] The repository I want to add has at least a `name` key in `hacs.json`.

## Submission Details

- **Repository**: https://github.com/NewsGuyTor/FellowAiden-HomeAssistant
- **Category**: Integration
- **Description**: Home Assistant integration for Fellow Aiden coffee brewers

### Features
- Real-time sensor data (water usage, brew counts, timing)
- Binary sensors for brewing status, lid position, water level
- Brew profile management (create, list, delete)
- Schedule management
- Custom services for automation