### PR TITLE
Adds new integration [dan-danache/ha-zigbee-map]

### DIFF
--- a/integration
+++ b/integration
@@ -433,6 +433,7 @@
   "dala318/python_poollab",
   "dalinicus/homeassistant-acinfinity",
   "Dams51/Pleinchamp",
+  "dan-danache/ha-zigbee-map",
   "dan-r/HomeAssistant-NissanConnect",
   "danielcherubini/elegoo-homeassistant",
   "danieldiazi/homeassistant-meteogalicia",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: https://github.com/dan-danache/ha-zigbee-map/releases/tag/2.8.1
Link to successful HACS action (without the `ignore` key): https://github.com/dan-danache/ha-zigbee-map/actions/runs/21289230164
Link to successful hassfest action (if integration): https://codeberg.org/dan-danache/ha-zigbee-map/actions/runs/22/jobs/0/attempt/1

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->

Notes:
- The integration source code is hosted on Codeberg @ [dan-danache/ha-zigbee-map](https://codeberg.org/dan-danache/ha-zigbee-map). Github contains only the things related to HACS. That's why the hassfest action is executed on Codeberg.
- The integration is already installable in HACS using custom repository. It was tested by me and the good folks over the [community forum](https://community.home-assistant.io/t/zigbee-map-visualize-your-mesh-network/921489).