### PR TITLE
Add hoizi89/pv_management and hoizi89/pv_management_fix

### DIFF
--- a/integration
+++ b/integration
@@ -794,6 +794,8 @@
   "Hoffmann77/ha-dwd-precipitation",
   "Hogster/BPS",
   "hoizi89/advanced_switches",
+  "hoizi89/pv_management",
+  "hoizi89/pv_management_fix",
   "hokiebrian/eia_hourly_demand",
   "hollowpnt92/lubelogger-ha",
   "home-assistant-HomeWhiz/home-assistant-HomeWhiz",


### PR DESCRIPTION
## New Integrations

Adding two PV management integrations for Home Assistant:

### 1. [hoizi89/pv_management](https://github.com/hoizi89/pv_management)
**PV Management for Variable/Spot Electricity Tariffs**

Optimized for spot-price tariffs (aWATTar, smartENERGY, Tibber) with intelligent battery management:
- Auto-Charge: Automatically charge battery when electricity is cheap
- Discharge Control: Save battery for expensive hours
- EPEX Spot Integration: Uses current market prices
- Solcast Integration: Considers PV forecast
- 5-level consumption recommendation (traffic light)
- Amortization calculation

### 2. [hoizi89/pv_management_fix](https://github.com/hoizi89/pv_management_fix)
**PV Management for Fixed-Price Tariffs**

Simplified version for fixed-price tariffs (no battery management needed):
- Amortization calculation with fixed price
- Energy tracking (self-consumption, feed-in)
- Savings statistics (daily/monthly/yearly)
- Optional: Spot price comparison

Both integrations:
- ✅ Valid `hacs.json`
- ✅ Valid `manifest.json`
- ✅ At least one release
- ✅ Good documentation
- ✅ MIT License