### PR TITLE
Adds new integration [hoizi89/pv_management_fix]

### DIFF
--- a/integration
+++ b/integration
@@ -796,6 +796,7 @@
   "Hoffmann77/ha-dwd-precipitation",
   "Hogster/BPS",
   "hoizi89/advanced_switches",
+  "hoizi89/pv_management_fix",
   "hokiebrian/eia_hourly_demand",
   "hollowpnt92/lubelogger-ha",
   "home-assistant-HomeWhiz/home-assistant-HomeWhiz",


### PR DESCRIPTION
## Summary
- PV Management Fixpreis integration for Home Assistant
- Designed for fixed-price electricity tariffs (e.g. Grünwelt, Energie AG)
- Features: amortization calculation, energy tracking, optional spot price comparison
- Simplified version of pv_management for users without variable/spot tariffs

## Checklist
- [x] The repository has topics applied (`hacs`, `hacs-integration`, `home-assistant`, etc.)
- [x] The repository has a description
- [x] The integration has a valid `manifest.json` file
- [x] The integration has a `hacs.json` file
- [x] There is a release with a valid tag

Repository: https://github.com/hoizi89/pv_management_fix