### PR TITLE
Add Time Spinner Card

### DIFF
--- a/plugin
+++ b/plugin
@@ -539,5 +539,7 @@
   "ytilis/hass-progress-bar-feature",
   "zanac/temperature-heatmap-card",
   "zanna-37/hass-swipe-navigation",
-  "zeronounours/lovelace-energy-entity-row"
+  "zeronounours/lovelace-energy-entity-row",
+  "diestrohs/time-spinner-card"
 ]
+


### PR DESCRIPTION
This PR adds the Time Spinner Card to the default HACS repositories.

Repository: https://github.com/diestrohs/time-spinner-card

Features:
- iOS-Style Time Picker with smooth scroll behavior
- Fully customizable (icon, color, name, etc.)
- Flexible minute increments (1, 5, 10, 15, 30 minutes)
- Visual Editor support
- Dark/Light theme support
- Modern Lit-based Web Components
- Support for input_datetime and time entities