### PR TITLE
Add fre69/homeassistant-multicraft

### DIFF
--- a/integration
+++ b/integration
@@ -628,6 +628,7 @@
   "Foxi352/pollen_lu",
   "Fr3d/camect-ha",
   "franc6/ics_calendar",
+  "fre69/homeassistant-multicraft",
   "freakshock88/hass-populartimes",
   "fredck/lightener",
   "FredrikM97/hass-surepetcare",


### PR DESCRIPTION
## Summary
Add Multicraft integration for Home Assistant.

**Repository:** https://github.com/fre69/homeassistant-multicraft

## Checklist
- [x] The repository has HACS validation workflow
- [x] The repository has hassfest validation workflow  
- [x] All validations pass
- [x] Repository is public
- [x] Has manifest.json with proper structure
- [x] Has hacs.json
- [x] Has README with documentation