### PR TITLE
Add fre69/homeassistant-multicraft

### DIFF
--- a/integration
+++ b/integration
@@ -660,6 +660,7 @@
   "Foxi352/pollen_lu",
   "Fr3d/camect-ha",
   "franc6/ics_calendar",
+  "fre69/homeassistant-multicraft",
   "freakshock88/hass-populartimes",
   "fredck/lightener",
   "FredrikM97/hass-surepetcare",


### PR DESCRIPTION
## New integration

### Checklist

- [x] I have read the [contribution guidelines](https://hacs.xyz/docs/publish/)
- [x] I have verified that my repository meets all [repository requirements](https://hacs.xyz/docs/publish/include#repository-structure)
- [x] My integration has a valid `manifest.json` file
- [x] My integration has the `hacs.json` file
- [x] My integration passes HACS Action validation
- [x] My integration passes hassfest validation
- [x] The repository is publicly available on GitHub

### Repository links

- **Repository:** https://github.com/fre69/homeassistant-multicraft
- **Latest release:** https://github.com/fre69/homeassistant-multicraft/releases/tag/v1.0.0
- **CI Actions:** https://github.com/fre69/homeassistant-multicraft/actions/runs/21479760097

### Description

Multicraft integration for Home Assistant - Control your Minecraft servers managed by Multicraft panel directly from Home Assistant.

**Features:**
- Switch to start/stop Minecraft servers
- Sensors for server status, online players, max players
- Full UI-based configuration
- Multilingual support (English/French)