### PR TITLE
Add advanced energy card to plugin list

### DIFF
--- a/plugin
+++ b/plugin
@@ -411,6 +411,7 @@
   "queimadus/last-changed-element",
   "r-renato/ha-card-waze-travel-time",
   "r-renato/ha-card-weather-conditions",
+  "ratava/advanced-energy-card"
   "rautesamtr/thermal_comfort_icons",
   "rccoleman/lovelace-lamarzocco-config-card",
   "redkanoon/embedded-view-card",


### PR DESCRIPTION
Addded ratava/advanced-energy-card

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [X ] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [X ] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [ X] The actions are passing without any disabled checks in my repository.
- [ X] I've added a link to the action run on my repository below in the links section.
- [ X] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/ratava/advanced-energy-card/releases/tag/1.0.24>
Link to successful HACS action (without the `ignore` key): <https://github.com/ratava/advanced-energy-card/actions/runs/21499637743>
Link to successful hassfest action (if integration): <>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->