### PR TITLE
Adds new integration [salvatore-disavio/ha-popup-blueprints]

### DIFF
--- a/integration
+++ b/integration
@@ -1659,6 +1659,7 @@
   "rytilahti/homeassistant-upnp-availability",
   "rzulian/lutron_lip",
   "salihinsaealal/home-assistant-tnb-calculator",
+  "salvatore-disavio/ha-popup-blueprints",
   "SamAthanas/user-rbac",
   "samjsmart/ha-zone4",
   "samoswall/polaris-mqtt",


### PR DESCRIPTION
Add salvatore-disavio/ha-popup-blueprints

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [X] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [X] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [X] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [X] The actions are passing without any disabled checks in my repository.
- [X] I've added a link to the action run on my repository below in the links section.
- [X] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/salvatore-disavio/ha-popup-blueprints/releases/tag/v1.1.3
>
Link to successful HACS action (without the `ignore` key): <https://github.com/salvatore-disavio/ha-popup-blueprints/actions/runs/21518087296>
Link to successful hassfest action (if integration): <https://github.com/salvatore-disavio/ha-popup-blueprints/actions/runs/21517981825> 

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->

This repository provides a minimal wrapper integration whose sole purpose
is to distribute Home Assistant blueprints via HACS and allow automatic updates.

No entities, services, or platforms are added.

Brand assets have been added to the Home Assistant brands repository
to comply with the validation requirements for default HACS integrations.