### PR TITLE
Add Terma MOA Blue

### DIFF
--- a/integration
+++ b/integration
@@ -2014,5 +2014,6 @@
   "zubir2k/homeassistant-esolatgps",
   "zubir2k/homeassistant-esolattakwim",
   "zulufoxtrot/ha-zyxel",
-  "Zwer2k/ha-pca301"
+  "Zwer2k/ha-pca301",
+  "johnfromul/terma_moa_blue"
 ]


### PR DESCRIPTION
## Add Terma MOA Blue integration

**Repository:** https://github.com/johnfromul/terma_moa_blue  
**Category:** Integration

### Description
Home Assistant custom integration for Terma MOA Blue electric heating elements via Bluetooth Low Energy (BLE).

### Features
- Control Terma MOA Blue heating elements directly via Bluetooth
- Temperature control (room 15-30°C, element 30-60°C)
- Real-time temperature monitoring
- LED temperature indicator support
- Full Home Assistant climate entity support

### Requirements Met
- [x] GitHub repository with MIT License
- [x] README with installation instructions
- [x] Valid hacs.json
- [x] manifest.json with proper metadata
- [x] Translations (Czech, English)
- [x] Released versions with tags (v1.0.20)
- [x] Working integration tested with multiple devices

### Technical Details
- Reverse engineered Bluetooth protocol via Frida instrumentation
- Uses bleak and bleak-retry-connector for BLE communication
- Supports multiple heating elements simultaneously
- Fully documented BLE protocol and pairing guide in repository

### Additional Info
Integration has been thoroughly tested with two devices and is stable. Complete protocol analysis and troubleshooting guides included in documentation.