### PR TITLE
Add Terma MOA Blue

### DIFF
--- a/integration
+++ b/integration
@@ -2014,5 +2014,6 @@
   "zubir2k/homeassistant-esolatgps",
   "zubir2k/homeassistant-esolattakwim",
   "zulufoxtrot/ha-zyxel",
-  "Zwer2k/ha-pca301"
+  "Zwer2k/ha-pca301",
+  "johnfromul/terma_moa_blue"
 ]


### PR DESCRIPTION
## Add Terma MOA Blue integration

- [x] I have read the guidelines for contributing
- [x] I verify that this is a fork of the hacs/default repository
- [x] I verify that there is one repository per submission
- [x] I verify that the repository name is correct
- [x] I verify that the repository has a description
- [x] I verify that the repository URL is correct
- [x] I verify that there are topics on the repository

**Repository:** https://github.com/johnfromul/terma_moa_blue  
**Category:** Integration

### Description
Home Assistant integration for Terma MOA Blue electric heating elements via Bluetooth Low Energy.

### Features
- Control heating elements via Bluetooth
- Temperature control (room/element)
- Real-time monitoring
- LED indicator support

### Requirements Met
- [x] MIT License
- [x] README with installation instructions
- [x] Valid hacs.json
- [x] manifest.json with metadata
- [x] Translations (Czech, English)
- [x] Released version v1.0.20

Tested and stable with multiple devices.