### PR TITLE
Add ha-coinmarketcap to integration list

### DIFF
--- a/integration
+++ b/integration
@@ -48,6 +48,7 @@
   "alandtse/alexa_media_player",
   "alandtse/tesla",
   "ALArvi019/moderntides",
+  "alaschgari/ha-coinmarketcap",
   "albaintor/homeassistant_electrolux_status",
   "albertogeniola/meross-homeassistant",
   "AlbinLind/dawarich-home-assistant",


### PR DESCRIPTION
## Description
I am requesting to add my repository to the HACS default list.

- **Repository URL**: https://github.com/alaschgari/ha-coinmarketcap
- **HACS Compliance**: https://github.com/alaschgari/ha-coinmarketcap/blob/main/hacs.json
- **Latest Release**: https://github.com/alaschgari/ha-coinmarketcap/releases/latest

## Checklist
- [x] I have verified that my repository is compliant with HACS standards.
- [x] I have tested the integration in my own Home Assistant setup.
- [x] The repository contains a valid `hacs.json` file.
- [x] The repository contains a `README.md` file.
- [x] I have published a release/tag for the repository.