### PR TITLE
Add new integration for systemair-modbus

### DIFF
--- a/integration
+++ b/integration
@@ -814,6 +814,7 @@
   "houzzkit/houzzkit-ai-ha",
   "Howard0000/home-assistant-norsk-tidevann",
   "Howard0000/home-assistant-sikom",
+  "Howard0000/home-assistant-systemair-modbus",
   "HrGaertner/HA-vent-optimization",
   "hsakoh/ha-switchbot-kvs-camera",
   "hsk-dk/home-assistant-thermex",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->

## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [ ] The actions are passing without any disabled checks in my repository.
- [ ] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release:  
https://github.com/Howard0000/home-assistant-systemair-modbus/releases/tag/v0.1.0

Link to successful HACS action (without the `ignore` key):  
N/A – blocked by pending brands PR https://github.com/home-assistant/brands/pull/9363

Link to successful hassfest action (if integration):  
N/A – blocked by pending brands PR https://github.com/home-assistant/brands/pull/9363

---

**Note about CI:**  
Brand icons for this integration are submitted in `home-assistant/brands` PR #9363 and are currently pending review:  
https://github.com/home-assistant/brands/pull/9363  

The integration itself is functional and released (v0.1.0). Once the brands PR is merged, CI will pass and icons will appear.

Repository:  
https://github.com/Howard0000/home-assistant-systemair-modbus
