### PR TITLE
Remove CodeFoodPixels/robovac from integrations

### DIFF
--- a/integration
+++ b/integration
@@ -363,7 +363,6 @@
   "cnecrea/smsto",
   "cnstudio/Taipower-Bimonthly-Energy-Cost-homeassistant",
   "cobryan05/ha-color-notify",
-  "CodeFoodPixels/robovac",
   "codyc1515/ha-yeelock",
   "CoMPaTech/stromer",
   "CompitHomeAssistant/HomeAssistant",


### PR DESCRIPTION
Removed 'CodeFoodPixels/robovac' from the integration list.

I no longer have time to support this integration. I've requested the current fork owner to add it here, but for now my repo needs to be removed.