### PR TITLE
Add Emergency Stop

### DIFF
--- a/integration
+++ b/integration
@@ -1733,7 +1733,7 @@
   "solentlabs/cable_modem_monitor",
   "soloam/ha-pid-controller",
   "sopelj/hass-ember-mug-component",
-  "sotoniak/home-assistant-emergency-stop",
+  "sotoniak/home-assistant-emergency-stop-public",
   "soulripper13/blueprint-studio",
   "soulripper13/hass-speedtest-ookla",
   "soulripper13/hass-waviot",


### PR DESCRIPTION
Adds sotoniak/home-assistant-emergency-stop to the default integration list.