### PR TITLE
Adds new integration [axelpaul/leitir-ha]

### DIFF
--- a/integration
+++ b/integration
@@ -183,6 +183,7 @@
   "aunefyren/bluesound_alt",
   "avishorp/sync_group",
   "avlemos/dobiss",
+  "axelpaul/leitir-ha",
   "ayavilevich/homeassistant-dlink-presence",
   "aykutvr/smartcosa-home-assistant-integration",
   "azerty9971/xtend_tuya",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] (For integrations only) I've added the integration assets to the [Home Assistant Brands repo](https://github.com/home-assistant/brands).
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: https://github.com/axelpaul/leitir-ha/releases/tag/v0.1.0
Link to successful HACS action (without the `ignore` key): https://github.com/axelpaul/leitir-ha/actions/runs/21228353896
Link to successful hassfest action (if integration): https://github.com/axelpaul/leitir-ha/actions/runs/21228353695

## Note

Brand registration PR is merged: https://github.com/home-assistant/brands/pull/9227
