### PR TITLE
Add pentafive/8311-ha-bridge

### DIFF
--- a/integration
+++ b/integration
@@ -1430,6 +1430,7 @@
   "pcourbin/imaprotect",
   "pdw-mb/tsmart_ha",
   "Pehesi97/intelbras-amt-home-assistant",
+  "pentafive/8311-ha-bridge",
   "peribeir/homeassistant-rademacher",
   "perosb/power_max_tracker",
   "perosb/qvantum_custom_component",


### PR DESCRIPTION
https://github.com/pentafive/8311-ha-bridge

XGS-PON fiber ONU monitoring for Home Assistant. Tracks optical RX/TX power levels, temperatures, PON link status, and diagnostics for devices running [8311 community firmware](https://github.com/up-n-atom/8311) (BFW Solutions WAS-110, Potron GP7001X).

- [x] Repository has releases
- [x] Repository has hacs.json manifest
- [x] Repository has valid manifest.json
- [x] Repository follows HACS structure requirements
- [x] Repository is public
- [x] Active maintenance