### PR TITLE
Add pentafive/pskr-ha-bridge

### DIFF
--- a/integration
+++ b/integration
@@ -1430,6 +1430,8 @@
   "pcourbin/imaprotect",
   "pdw-mb/tsmart_ha",
   "Pehesi97/intelbras-amt-home-assistant",
+  "pentafive/8311-ha-bridge",
+  "pentafive/pskr-ha-bridge",
   "peribeir/homeassistant-rademacher",
   "perosb/power_max_tracker",
   "perosb/qvantum_custom_component",


### PR DESCRIPTION
https://github.com/pentafive/pskr-ha-bridge

PSK Reporter amateur radio propagation monitoring for Home Assistant. Tracks FT8, FT4, WSPR, and other digital modes with real-time per-band statistics (160m-6m) and feed health monitoring.

- [x] Repository has releases
- [x] Repository has hacs.json manifest
- [x] Repository has valid manifest.json
- [x] Repository follows HACS structure requirements
- [x] Repository is public
- [x] Active maintenance