### PR TITLE
Add DTekNO/norway_alerts to integration list

### DIFF
--- a/integration
+++ b/integration
@@ -558,6 +558,7 @@
   "DSorlov/http_agent",
   "DSorlov/snmp_printer",
   "DSorlov/swemail",
+  "DTekNO/norway_alerts",
   "dudanov/hassio-ftms",
   "duhow/hass-aigues-barcelona",
   "duhow/hass-cover-time-based",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
Adds norway_alerts integration to HACS. A custom component for Home Assistant that displays geohazard alerts from NVE and met.no

## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x ] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x ] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x ] The actions are passing without any disabled checks in my repository.
- [x ] I've added a link to the action run on my repository below in the links section.
- [x ] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: https://github.com/DTekNO/norway_alerts/releases/tag/v2.2.0
Link to successful HACS action (without the `ignore` key): https://github.com/DTekNO/norway_alerts/actions/runs/21743099383/job/62722556393
Link to successful hassfest action (if integration): https://github.com/DTekNO/norway_alerts/actions/runs/21743099372/job/62722556367

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->