### PR TITLE
Add ergo5/hass-energa-my-meter-api

### DIFF
--- a/integration
+++ b/integration
@@ -606,6 +606,7 @@
   "EnzoD86/tuya-smart-ir-ac",
   "epaulsen/energytariff",
   "epoplavskis/homeassistant_salus",
+  "ergo5/hass-energa-my-meter-api",
   "erikkastelec/hass-WEM-Portal",
   "eriknn/ha-pax_ble",
   "ErilovNikita/ha-domru",


### PR DESCRIPTION
## Repository
https://github.com/ergo5/hass-energa-my-meter-api

## Description
Energa My Meter API integration for Home Assistant - reads energy consumption/production data from Energa smart meters in Poland via official mobile API.

## Checklist
- [x] I am the owner/major contributor of this repository
- [x] The repository has HACS Action workflow passing
- [x] The repository has hassfest workflow passing
- [x] The integration is added to home-assistant/brands (#9180)
- [x] hacs.json includes name and country keys
- [x] The repository has at least one release
- [x] The entry is added alphabetically