### PR TITLE
Adds new integration

### DIFF
--- a/integration
+++ b/integration
@@ -550,6 +550,7 @@
   "dphae/bsh",
   "drakhart/ha-super-soco-custom",
   "drc38/Fronius_solarweb",
+  "dreo-team/hass-dreoverse",
   "drlaplace/KVV_Departure_Monitor",
   "droans/mass_queue",
   "droidgren/smhi_season",


### PR DESCRIPTION
Adding Dreo integration from https://github.com/dreo-team/hass-dreoverse
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/dreo-team/hass-dreoverse/releases/tag/v2.2.0>
Link to successful HACS action (without the `ignore` key): <https://github.com/dreo-team/hass-dreoverse/actions/runs/21737370455>
Link to successful hassfest action (if integration): <https://github.com/dreo-team/hass-dreoverse/actions/runs/21390341958>


