### PR TITLE
Add pentafive/8311-ha-bridge

### DIFF
--- a/integration
+++ b/integration
@@ -1430,6 +1430,7 @@
   "pcourbin/imaprotect",
   "pdw-mb/tsmart_ha",
   "Pehesi97/intelbras-amt-home-assistant",
+  "pentafive/8311-ha-bridge",
   "peribeir/homeassistant-rademacher",
   "perosb/power_max_tracker",
   "perosb/qvantum_custom_component",


### PR DESCRIPTION
https://github.com/pentafive/8311-ha-bridge
https://github.com/pentafive/8311-ha-bridge/releases/tag/v2.0.0
https://github.com/pentafive/8311-ha-bridge/actions/runs/21014162635

XGS-PON fiber ONU monitoring for Home Assistant. Tracks optical RX/TX power levels, temperatures, PON link status, and diagnostics for devices running [8311 community firmware](https://github.com/up-n-atom/8311).