### PR TITLE
Add pentafive/pskr-ha-bridge

### DIFF
--- a/integration
+++ b/integration
@@ -1430,6 +1430,7 @@
   "pcourbin/imaprotect",
   "pdw-mb/tsmart_ha",
   "Pehesi97/intelbras-amt-home-assistant",
+  "pentafive/pskr-ha-bridge",
   "peribeir/homeassistant-rademacher",
   "perosb/power_max_tracker",
   "perosb/qvantum_custom_component",


### PR DESCRIPTION
https://github.com/pentafive/pskr-ha-bridge
https://github.com/pentafive/pskr-ha-bridge/releases/tag/v2.4.0
https://github.com/pentafive/pskr-ha-bridge/actions/runs/21603413874

PSK Reporter amateur radio propagation monitoring for Home Assistant. Tracks FT8, FT4, WSPR, and other digital modes with real-time per-band statistics and feed health monitoring.