### PR TITLE
Add pentafive/web888-ha-bridge

### DIFF
--- a/integration
+++ b/integration
@@ -1430,6 +1430,7 @@
   "pcourbin/imaprotect",
   "pdw-mb/tsmart_ha",
   "Pehesi97/intelbras-amt-home-assistant",
+  "pentafive/web888-ha-bridge",
   "peribeir/homeassistant-rademacher",
   "perosb/power_max_tracker",
   "perosb/qvantum_custom_component",


### PR DESCRIPTION
https://github.com/pentafive/web888-ha-bridge
https://github.com/pentafive/web888-ha-bridge/releases/tag/v1.2.1
https://github.com/pentafive/web888-ha-bridge/actions/runs/21736709430

Web-888 SDR receiver monitoring for Home Assistant. Tracks connected users, GPS status/lock, signal-to-noise ratio, per-channel frequency/mode/decodes, CPU temperature, and system health.