### PR TITLE
Add pentafive/wspr-ha-bridge

### DIFF
--- a/integration
+++ b/integration
@@ -1430,6 +1430,7 @@
   "pcourbin/imaprotect",
   "pdw-mb/tsmart_ha",
   "Pehesi97/intelbras-amt-home-assistant",
+  "pentafive/wspr-ha-bridge",
   "peribeir/homeassistant-rademacher",
   "perosb/power_max_tracker",
   "perosb/qvantum_custom_component",


### PR DESCRIPTION
https://github.com/pentafive/wspr-ha-bridge
https://github.com/pentafive/wspr-ha-bridge/releases/tag/v1.2.0
https://github.com/pentafive/wspr-ha-bridge/actions/runs/21342140355

WSPR spot data bridge for Home Assistant. Tracks weak-signal propagation transmissions and receptions with per-band metrics, distance statistics, and propagation scores.