### PR TITLE
Add Stromkalkulator integration

### DIFF
--- a/integration
+++ b/integration
@@ -664,6 +664,7 @@
   "franc6/ics_calendar",
   "freakshock88/hass-populartimes",
   "fredck/lightener",
+  "fredrik-lindseth/Stromkalkulator",
   "FredrikM97/hass-surepetcare",
   "frenck/spook",
   "freol35241/ltss",


### PR DESCRIPTION
## Repository

https://github.com/fredrik-lindseth/Stromkalkulator

## Checklist

- [x] I am the owner (or a major contributor) to the repository I want to add
- [x] I have read the [general requirements](https://hacs.xyz/docs/publish/start)
- [x] I have read the [integration requirements](https://hacs.xyz/docs/publish/integration)
- [x] I have read the [include requirements](https://hacs.xyz/docs/publish/include)
- [x] The repository has a valid `hacs.json` file
- [x] The repository uses GitHub releases (not just tags)
- [x] The repository has been added to [home-assistant/brands](https://github.com/home-assistant/brands/pull/9262) ✅ MERGED

## Description

Strømkalkulator is a Home Assistant integration that calculates actual electricity prices in Norway, including:
- Grid tariffs (energiledd + kapasitetsledd)
- Government taxes (forbruksavgift, Enova)
- Electricity subsidy (strømstøtte)
- Norgespris (fixed price alternative)

The integration provides a single sensor for Home Assistant's Energy Dashboard that shows your true cost per kWh.

## Why should this be included?

- Solves a real problem for Norwegian Home Assistant users
- No equivalent functionality in Home Assistant core
- Well documented with tests and CI
- Country-specific (Norway only)