### PR TITLE
Add Stromkalkulator integration

### DIFF
--- a/integration
+++ b/integration
@@ -664,6 +664,7 @@
   "franc6/ics_calendar",
   "freakshock88/hass-populartimes",
   "fredck/lightener",
+  "fredrik-lindseth/Stromkalkulator",
   "FredrikM97/hass-surepetcare",
   "frenck/spook",
   "freol35241/ltss",


### PR DESCRIPTION
## Repository

https://github.com/fredrik-lindseth/Stromkalkulator

## Latest Release

https://github.com/fredrik-lindseth/Stromkalkulator/releases/tag/v0.31.0

## CI Action Runs

https://github.com/fredrik-lindseth/Stromkalkulator/actions/runs/21734700239

## Checklist

- [ ] I am the owner (or a major contributor) to the repository I want to add
- [ ] I have read the [general requirements](https://hacs.xyz/docs/publish/start)
- [ ] I have read the [integration requirements](https://hacs.xyz/docs/publish/integration)
- [ ] I have read the [include requirements](https://hacs.xyz/docs/publish/include)
- [ ] The repository has a valid `hacs.json` file
- [ ] The repository uses GitHub releases (not just tags)
- [ ] The repository has been added to [home-assistant/brands](https://github.com/home-assistant/brands/pull/9262) ✅ MERGED

## Description

Strømkalkulator is a Home Assistant integration that calculates actual electricity prices in Norway, including:
- Grid tariffs (energiledd + kapasitetsledd)
- Government taxes (forbruksavgift, Enova)
- Electricity subsidy (strømstøtte)
- Norgespris (fixed price alternative)

The integration provides a single sensor for Home Assistant's Energy Dashboard that shows your true cost per kWh.

## Why should this be included?

- Solves a real problem for Norwegian Home Assistant users
- No equivalent functionality in Home Assistant core
- Well documented with tests and CI
- Country-specific (Norway only)