### PR TITLE
Add Stromkalkulator integration

### DIFF
--- a/integration
+++ b/integration
@@ -664,6 +664,7 @@
   "franc6/ics_calendar",
   "freakshock88/hass-populartimes",
   "fredck/lightener",
+  "fredrik-lindseth/Stromkalkulator",
   "FredrikM97/hass-surepetcare",
   "frenck/spook",
   "freol35241/ltss",


### PR DESCRIPTION
## Checklist

- [ ] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [ ] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [ ] The actions are passing without any disabled checks in my repository.
- [ ] I've added a link to the action run on my repository below in the links section.
- [ ] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/fredrik-lindseth/Stromkalkulator/releases/tag/v0.31.1>
Link to successful HACS action (without the `ignore` key): <https://github.com/fredrik-lindseth/Stromkalkulator/actions/runs/21761680236>
Link to successful hassfest action (if integration): <https://github.com/fredrik-lindseth/Stromkalkulator/actions/runs/21761680223>