### PR TITLE
Add owanvik/ha-nodvarsel

### DIFF
--- a/integration
+++ b/integration
@@ -1407,6 +1407,7 @@
   "OtisPresley/control4-mediaplayer",
   "OtisPresley/snmp-switch-manager",
   "oven-lab/tuya_cloud_map_extractor",
+  "owanvik/ha-nodvarsel",
   "p0l0/hapetwalk",
   "pail23/stiebel_eltron_isg_component",
   "pajeronda/xai_conversation",


### PR DESCRIPTION
## Checklist
- [x] I am the owner or a major contributor to the repository
- [x] The repository is not used for testing/alpha/beta
- [x] The repository does not override a default/core integration
- [x] The repository has a proper description
- [x] Issues are enabled on the repository
- [x] Topics are defined on the repository
- [x] The repository is not archived
- [x] The repository has at least one release
- [x] The repository passes HACS Action validation
- [x] The repository passes Hassfest validation
- [x] Brand PR submitted: https://github.com/home-assistant/brands/pull/9438

## Repository
**URL:** https://github.com/owanvik/ha-nodvarsel
**Category:** Integration
**Description:** Custom integration for Norwegian emergency alerts (Nødvarsel) from nodvarsel.no. Monitors active alerts via RSS feed and creates sensors in Home Assistant.