### PR TITLE
Add Emergency Stop

### DIFF
--- a/integration
+++ b/integration
@@ -1733,6 +1733,7 @@
   "solentlabs/cable_modem_monitor",
   "soloam/ha-pid-controller",
   "sopelj/hass-ember-mug-component",
+  "sotoniak/home-assistant-emergency-stop-public",
   "soulripper13/blueprint-studio",
   "soulripper13/hass-speedtest-ookla",
   "soulripper13/hass-waviot",


### PR DESCRIPTION
Adds sotoniak/home-assistant-emergency-stop-public to the default integration list.

Required links:
- Latest release: https://github.com/sotoniak/home-assistant-emergency-stop-public/releases/tag/v2.0.4
- Validate (success): https://github.com/sotoniak/home-assistant-emergency-stop-public/actions/runs/21786511730
- Validate with hassfest (success): https://github.com/sotoniak/home-assistant-emergency-stop-public/actions/runs/21772600342