### PR TITLE
Add PersephoneKarnstein/ha-bluesky-feed

### DIFF
--- a/integration
+++ b/integration
@@ -1433,6 +1433,7 @@
   "peribeir/homeassistant-rademacher",
   "perosb/power_max_tracker",
   "perosb/qvantum_custom_component",
+  "PersephoneKarnstein/ha-bluesky-feed",
   "persuader72/silla-prism-integration",
   "PeteRager/lennoxs30",
   "petergridge/irrigation-V5",


### PR DESCRIPTION
Bluesky social media feed as a Home Assistant Lovelace card.

**Repository:** https://github.com/PersephoneKarnstein/ha-bluesky-feed
**Brands PR:** home-assistant/brands#9466