### PR TITLE
Add PersephoneKarnstein/ha-citizen-incidents

### DIFF
--- a/integration
+++ b/integration
@@ -1433,6 +1433,7 @@
   "peribeir/homeassistant-rademacher",
   "perosb/power_max_tracker",
   "perosb/qvantum_custom_component",
+  "PersephoneKarnstein/ha-citizen-incidents",
   "persuader72/silla-prism-integration",
   "PeteRager/lennoxs30",
   "petergridge/irrigation-V5",


### PR DESCRIPTION
Live Citizen.com incident reports on the Home Assistant map.

**Repository:** https://github.com/PersephoneKarnstein/ha-citizen-incidents
**Brands PR:** home-assistant/brands#9466