### PR TITLE
Add PersephoneKarnstein/ha-estrannaise

### DIFF
--- a/integration
+++ b/integration
@@ -1433,6 +1433,7 @@
   "peribeir/homeassistant-rademacher",
   "perosb/power_max_tracker",
   "perosb/qvantum_custom_component",
+  "PersephoneKarnstein/ha-estrannaise",
   "persuader72/silla-prism-integration",
   "PeteRager/lennoxs30",
   "petergridge/irrigation-V5",


### PR DESCRIPTION
Estradiol level tracking with pharmacokinetic modeling for Home Assistant.

**Repository:** https://github.com/PersephoneKarnstein/ha-estrannaise
**Brands PR:** home-assistant/brands#9466