### PR TITLE
Add PersephoneKarnstein/ha-seedtime

### DIFF
--- a/integration
+++ b/integration
@@ -1433,6 +1433,7 @@
   "peribeir/homeassistant-rademacher",
   "perosb/power_max_tracker",
   "perosb/qvantum_custom_component",
+  "PersephoneKarnstein/ha-seedtime",
   "persuader72/silla-prism-integration",
   "PeteRager/lennoxs30",
   "petergridge/irrigation-V5",


### PR DESCRIPTION
Interactive SVG garden plan from Seedtime.us for Home Assistant.

**Repository:** https://github.com/PersephoneKarnstein/ha-seedtime
**Brands PR:** home-assistant/brands#9466