### PR TITLE
Adds new integration [Dregi56/digital_pendulum]

### DIFF
--- a/integration
+++ b/integration
@@ -512,6 +512,7 @@
   "dhover/ha-iungo",
   "dib0/ha-elro-connects-realtime",
   "diego7marques/ha-aws-cost",
+  "Dregi56/digital_pendulum",
   "DigitallyRefined/ha-cloudflare-speed-test",
   "DigitallyRefined/ha-hwmon_temp",
   "dimagoltsman/ha-proof-dashcam-integration",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->

Adding Digital Pendulum - A speaking clock integration for Home Assistant with Alexa support.

**Repository:** https://github.com/Dregi56/digital_pendulum

**Features:**
- 🕰️ Announces time every hour and half-hour
- 🌍 Multi-language support (IT, EN, FR, DE, ES)
- 🔔 Customizable chimes (12 preset sounds + custom)
- 🏰 Westminster melody at 12:00
- ⏰ Configurable working hours

**Previous PR #5333 was closed due to brands validation. The brands PR has now been merged:**
https://github.com/home-assistant/brands/tree/master/custom_integrations/digital_pendulum

## Checklist
<!-- Do not open a pull request before you have completed all these, it will be closed. -->
- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links
<!-- Do not open a pull request before you have provided all these, it will be closed. -->
Link to current release: <https://github.com/Dregi56/digital_pendulum/releases/tag/v3.0.11>
Link to successful HACS action (without the `ignore` key): <https://github.com/Dregi56/digital_pendulum/actions/runs/21791032031>
Link to successful hassfest action (if integration): <https://github.com/Dregi56/digital_pendulum/actions/runs/21791032031>
<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->