### PR TITLE
Add integration: Hava Durumu

### DIFF
--- a/integration
+++ b/integration
@@ -30,6 +30,7 @@
   "aegjoyce/custom-ambilight",
   "aex351/home-assistant-neerslag-app",
   "agittins/bermuda",
+  "ahamitd/hava-durumu",
   "airalab/altruist-homeassistant-integration",
   "airalab/homeassistant-robonomics-integration",
   "AkA57/liveboxtvuhd",


### PR DESCRIPTION
## Integration Information

- **Name**: Hava Durumu
- **Description**: Turkish Meteorological Service (MGM) weather integration for Home Assistant
- **Repository**: https://github.com/ahamitd/hava-durumu
- **Category**: Integration

## Features

- Real-time weather data from Turkish Meteorological Service (MGM)
- 5-day forecast with min/max temperatures
- Hourly forecasts
- 12 different sensors (humidity, wind, pressure, precipitation, alerts, etc.)
- Weather alerts with automatic notifications
- Configurable update interval (5-60 minutes)
- Turkish and English language support

## Checklist

- [x] I am the owner/major contributor of this repository
- [x] Repository has releases (v1.2.0)
- [x] Repository has a README with installation instructions
- [x] Repository has a LICENSE file (MIT)
- [x] Repository has proper manifest.json
- [x] Repository has hacs.json with required fields
- [x] Repository has info.md for HACS store
- [x] Integration passes validation

## Additional Information

This integration provides weather data for all cities and districts in Turkey using official MGM API. It includes comprehensive weather alerts, multiple sensors, and a user-friendly configuration flow.