### PR TITLE
Add APC Modbus SNMP integration

### DIFF
--- a/integration
+++ b/integration
@@ -21,6 +21,7 @@
   "abhichandra21/ha-flavoroftheday",
   "ablyler/home-assistant-aquahawk",
   "ablyler/home-assistant-bradford-white-connect",
+  "aburow/apc-modbus-snmp-ha",
   "AboveColin/HA-Philips-Pet-Series",
   "absent42/Aqara-Advanced-Lighting",
   "aceindy/Duepi_EVO",


### PR DESCRIPTION
Adds  to the default HACS integration list.