### PR TITLE
Add Voice Satellite Card to plugin list

### DIFF
--- a/plugin
+++ b/plugin
@@ -259,6 +259,7 @@
   "junkfix/numberbox-card",
   "JurajNyiri/PlexMeetsHomeAssistant",
   "jwillmer/tariff-chart",
+  "jxlarrea/Voice-Satellite-Card-for-Home-Assistant",
   "kalkih/mini-graph-card",
   "kalkih/mini-media-player",
   "kalkih/simple-weather-card",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [ ] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [ ] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [ ] The actions are passing without any disabled checks in my repository.
- [ ] I've added a link to the action run on my repository below in the links section.
- [ ] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/jxlarrea/Voice-Satellite-Card-for-Home-Assistant/releases/tag/v1.16>
Link to successful HACS action (without the `ignore` key): <https://github.com/jxlarrea/Voice-Satellite-Card-for-Home-Assistant/actions/runs/21805890253>
Link to successful hassfest action (if integration): <>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->