### PR TITLE
Add Ariston Boiler Card plugin

### DIFF
--- a/.github/workflows/hacs.yml
+++ b/.github/workflows/hacs.yml
@@ -1,0 +1,14 @@
+name: HACS
+
+on:
+  push:
+    tags:
+      - '*'
+  workflow_dispatch:
+
+jobs:
+  hacs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: hacs/integration@2.0.5


### PR DESCRIPTION
Fix HACS workflow: use correct integration action version 2.0.5

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

This PR adds Ariston Boiler Card, a custom Lovelace plugin for Home Assistant, to the HACS frontend catalog.

Repo: https://github.com/DJTech84/boiler-card  
Link to current release: https://github.com/DJTech84/boiler-card/releases/tag/v1.0.1  
Link to successful HACS action (without the `ignore` key): https://github.com/DJTech84/boiler-card/actions/runs/21841004246



<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->