### PR TITLE
Add hacs leasing tracker

### DIFF
--- a/integration
+++ b/integration
@@ -658,6 +658,7 @@
   "Flo-Schilli/ha-grohe_smarthome",
   "fondberg/spotcast",
   "Foxi352/pollen_lu",
+  "foxxxhater/hacs_leasing_tracker",
   "Fr3d/camect-ha",
   "franc6/ics_calendar",
   "freakshock88/hass-populartimes",

--- a/plugin
+++ b/plugin
@@ -163,7 +163,7 @@
   "flixlix/energy-period-selector-plus",
   "flixlix/power-flow-card-plus",
   "flyrmyr/system-flow-card",
-  "foxxxhater/hacs_leasing_tracker-card",
+  "foxxxhater/hacs_leasing_tracker_card",
   "francois-le-ko4la/lovelace-entity-progress-card",
   "fratsloos/fr24_card",
   "FredrikM97/mealplan-card",


### PR DESCRIPTION
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/FoxXxHater/hacs_leasing_tracker/releases/tag/v1.1.3-initial>
Link to successful HACS action (without the `ignore` key): <https://github.com/FoxXxHater/hacs_leasing_tracker/actions/runs/21847936632/job/63048012635> (The check only fails because the pull request for entry into the brands is still pending.)
Link to successful hassfest action (if integration): <https://github.com/FoxXxHater/hacs_leasing_tracker/actions/runs/21848409718/job/63049459977>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->

I hope everything is correct. Thanks for your attention.