### PR TITLE
Add jsight/ha-pecron

### DIFF
--- a/integration
+++ b/integration
@@ -982,6 +982,7 @@
   "jrmattila/ha-elenia",
   "jscruz/sensor.carbon_intensity_uk",
   "jseidl/magic-areas",
+  "jsight/ha-pecron",
   "jsheputis/home-assistant-lifetime-fitness",
   "jtbgroup/kodi-media-sensors",
   "jtubb/HA-Pylontech-BMS",


### PR DESCRIPTION
Adds the Pecron integration for Home Assistant.

**Repository**: https://github.com/jsight/ha-pecron
**Category**: Integration

Provides monitoring and control for Pecron portable power stations, including battery levels, power input/output, and device states.