### PR TITLE
Add FredM67/ha-emon-config

### DIFF
--- a/integration
+++ b/integration
@@ -671,6 +671,7 @@
   "franc6/ics_calendar",
   "freakshock88/hass-populartimes",
   "fredck/lightener",
+  "FredM67/ha-emon-config",
   "FredrikM97/hass-surepetcare",
   "frenck/spook",
   "freol35241/ltss",


### PR DESCRIPTION
## Repository

https://github.com/FredM67/ha-emon-config

## Description

Home Assistant integration providing a web-based configuration interface for OpenEnergyMonitor emonPi/Tx devices (emonTx4, emonTx5, emonTx6, emonPi3) connected via an ESP32 serial bridge running ESPHome.

## Checklist

- [x] Integration has a `manifest.json` file
- [x] Integration has `hacs.json` file
- [x] HACS validation action passes
- [x] hassfest validation action passes
- [x] Repository has GitHub topics set
- [x] Repository has a description
- [x] Repository has a README