### PR TITLE
Add Fork U repositories to default lists

### DIFF
--- a/plugin
+++ b/plugin
@@ -455,6 +455,8 @@
   "silentbil/silent-bus",
   "silentbil/silent-image-slider",
   "silentbil/silent-remotes-card",
+  "silasmariusz/fork_u-house_card",
+  "silasmariusz/fork_u-weather_aware_2",
   "silvanocerza/light-card-hue-feature",
   "silviokennecke/ha-public-transport-connection-card",
   "skydarc/Venus-OS-Dashboard",

--- a/theme
+++ b/theme
@@ -79,6 +79,7 @@
   "ricardoquecria/caule-themes-pack-1",
   "robinwittebol/whatsapp-theme",
   "seangreen2/slate_theme",
+  "silasmariusz/Bubble_Theme_2026",
   "SnakeFist007/ha_vastayan_bond",
   "Stormrage-DJ/ha_theme_star_wars_dark",
   "Stormrage-DJ/ha_theme_star_wars_light",


### PR DESCRIPTION
- add fork_u-weather_aware_2 and fork_u-house_card to plugin catalog
- add Bubble_Theme_2026 to theme catalog

## Checklist
- [x] I've read the publishing documentation.
- [x] I've added the HACS action to my repository.
- [x] N/A – this is not a Home Assistant integration, so hassfest is not required.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links
Link to current release:
- Fork U – Weather Aware v1.0.4 (https://github.com/silasmariusz/fork_u-weather_aware_2/releases/tag/v1.0.4)
- Fork U – House Card v1.0.0 (https://github.com/silasmariusz/fork_u-house_card/releases/tag/v1.0.0)
- Bubble Theme 2026 v0.666-stable1 (https://github.com/silasmariusz/Bubble_Theme_2026/releases/tag/v0.666-stable1)

Link to successful HACS action (without the `ignore` key):
- Fork U – Weather Aware (Validate run #15) – https://github.com/silasmariusz/fork_u-weather_aware_2/actions/runs/21901840803
- Fork U – House Card (Validate run #9) – https://github.com/silasmariusz/fork_u-house_card/actions/runs/21889559204
- Bubble Theme 2026 (Validate run #8) – https://github.com/silasmariusz/Bubble_Theme_2026/actions/runs/21902503687

Link to successful hassfest action (if integration):
- No

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->