### PR TITLE
Add pledou/ha-enocean-hacs

### DIFF
--- a/integration
+++ b/integration
@@ -1483,6 +1483,7 @@
   "pkarimov/jukeaudio_ha",
   "plamish/xcomfort",
   "Platzii/homeassistant-evcnet",
+  "pledou/ha-enocean-hacs",
   "plmilord/Hass.io-custom-component-ikamand",
   "plmilord/Hass.io-custom-component-spaclient",
   "plmilord/Hass.io-custom-component-superior-propane",


### PR DESCRIPTION
## Integration Information

**Repository**: https://github.com/pledou/ha-enocean-hacs
**Category**: Integration
**Latest Release**: v1.0.1

## Description

EnOcean Extended is a custom Home Assistant integration that extends the core EnOcean integration with:

- Extended EnOcean Equipment Profile (EEP) support including VentilAirSec ventilation units
- Dynamic EEP parsing with proper enum handling
- Support for multiple platforms (sensors, binary sensors, switches, lights, buttons, numbers, selects)
- Config flow with automatic serial port detection
- Uses the enhanced [enocean-extended](https://pypi.org/project/enocean-extended/) library

## HACS Validation

✅ All HACS validation checks pass:
- Valid hacs.json manifest
- GitHub topics configured (home-assistant, hacs, home-assistant-integration, enocean)
- Integration uses existing 'enocean' domain and inherits official branding
- Latest release tagged (v1.0.1)
- Config flow implemented
- Documentation available in README

## Testing

Integration has been tested with:
- Home Assistant 2024.1.0+
- EnOcean devices ventilation units
- Serial communication via USB dongles

This integration is ready for inclusion in HACS default repositories.