### PR TITLE
Add KadenThomp36/air-quality-card

### DIFF
--- a/plugin
+++ b/plugin
@@ -20,6 +20,7 @@
   "AmoebeLabs/swiss-army-knife-card",
   "Anonym-tsk/lovelace-starline-card",
   "Anrolosia/Shopping-List-with-Grocy-Card",
+  "KadenThomp36/air-quality-card",
   "arallsopp/hass-hue-icons",
   "argaar/comfortable-environment-card",
   "artem-sedykh/mini-climate-card",


### PR DESCRIPTION
## Repository

https://github.com/KadenThomp36/air-quality-card

## Description

A custom Home Assistant Lovelace card for indoor air quality monitoring with:

- **Gradient-colored graphs** for CO2, PM2.5, humidity, and temperature
- **WHO 2021 health thresholds** and ASHRAE standards
- **Celsius / Fahrenheit toggle** — configurable temperature unit
- **Interactive hover/touch** to view historical values
- **Actionable recommendations** (Open Window, Run Air Purifier, etc.)
- **Visual configuration editor** — no YAML required
- Works with IKEA VINDSTYRKA/ALPSTUGA, Aqara, Xiaomi, SenseAir, ESPHome sensors

## Checklist

- [x] Repository has a `hacs.json` file
- [x] Repository has a release with a `.js` asset
- [x] Repository has a `README.md`
- [x] Repository has a `LICENSE` file