### PR TITLE
Add NylonDiamond/wrist-assistant-hacs

### DIFF
--- a/integration
+++ b/integration
@@ -1396,6 +1396,7 @@
   "nowocain/PhotoFrameCast",
   "nstrelow/ha_philips_android_tv",
   "nyffchanium/argoclima-integration",
+  "NylonDiamond/wrist-assistant-hacs",
   "nzrutman/hello_fairy_ble",
   "odya/hass-ina219-ups-hat",
   "ofalvai/home-assistant-candy",


### PR DESCRIPTION
## Add to HACS default integration list

**Repository**: https://github.com/NylonDiamond/wrist-assistant-hacs
**Category**: Integration
**Domain**: `wrist_assistant`

### What it does

[Wrist Assistant](https://github.com/NylonDiamond/wrist-assistant-hacs) is a Home Assistant custom integration that adds a long-poll delta-sync API endpoint (`POST /api/watch/updates`) for the Wrist Assistant Apple Watch app. It enables near-real-time entity state updates over HTTP without WebSockets.

### Checklist

- [x] Repository is public
- [x] Has a valid `hacs.json`
- [x] Has a valid `manifest.json`
- [x] HACS validation action passes
- [x] Has a README with installation instructions
- [x] Has a release (`v0.1.0`)
- [x] Brands PR submitted: home-assistant/brands#9544