### PR TITLE
Add NylonDiamond/homeassistant-wrist-assistant

### DIFF
--- a/integration
+++ b/integration
@@ -1396,6 +1396,7 @@
   "nowocain/PhotoFrameCast",
   "nstrelow/ha_philips_android_tv",
   "nyffchanium/argoclima-integration",
+  "NylonDiamond/homeassistant-wrist-assistant",
   "nzrutman/hello_fairy_ble",
   "odya/hass-ina219-ups-hat",
   "ofalvai/home-assistant-candy",


### PR DESCRIPTION
## Links

- **Repository**: https://github.com/NylonDiamond/homeassistant-wrist-assistant
- **Latest release**: https://github.com/NylonDiamond/homeassistant-wrist-assistant/releases/tag/v0.1.0
- **CI runs**: https://github.com/NylonDiamond/homeassistant-wrist-assistant/actions

## Description

Wrist Assistant is a Home Assistant custom integration that adds a long-poll delta-sync API endpoint (`POST /api/watch/updates`) for the [Wrist Assistant](https://github.com/NylonDiamond/ha-watch) Apple Watch app. It enables near-real-time entity state updates over HTTP without WebSockets.

## Checklist

- [x] The repository has a valid `hacs.json` file
- [x] The repository has a valid `manifest.json` file
- [x] The integration has a valid domain (`wrist_assistant`)
- [x] The repository has a README with installation and usage instructions
- [x] The repository has at least one published release (`v0.1.0`)
- [x] HACS validation action is passing
- [x] The repository does not contain "HACS" in its name
- [x] Brands PR submitted: home-assistant/brands#9544