### PR TITLE
Add Hevy Workout Tracker

### DIFF
--- a/integration
+++ b/integration
@@ -524,7 +524,7 @@
   "dingo35/ha-SmartEVSEv3",
   "dinki/view_assist_integration",
   "dirkgroenen/hass-evse-load-balancer",
-  "DisplacedForest/hevy_hacs",
+  "DisplacedForest/ha-hevy-tracker",
   "DiUS/homeassistant-powersensor",
   "djansen1987/SAJeSolar",
   "djbios/home-assistant-cat-scale",


### PR DESCRIPTION
## Add to default repository

**Repository:** https://github.com/DisplacedForest/hevy_hacs

**What does the integration do?**
Hevy Workout Tracker is a Home Assistant integration that provides rich workout sensor data from the Hevy fitness app — including per-exercise tracking with personal records, muscle group recovery monitoring, weekly volume analysis, routine rotation detection, and 30-day workout history.

**Checklist:**

- [x] I have read the [publishing documentation](https://www.hacs.xyz/docs/publish/integration/)
- [x] I have added the [HACS action](https://www.hacs.xyz/docs/publish/action/) to my repository: [Latest run](https://github.com/DisplacedForest/hevy_hacs/actions/workflows/validate.yml)
- [x] I have added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository: [Latest run](https://github.com/DisplacedForest/hevy_hacs/actions/workflows/validate.yml)
- [x] All actions pass without any disabled/ignored checks
- [x] I have a release published: [v1.0.0](https://github.com/DisplacedForest/hevy_hacs/releases/tag/v1.0.0)
- [x] The release was created after the validation actions were added
- [ ] My integration is registered in [home-assistant/brands](https://github.com/home-assistant/brands): [PR #9558](https://github.com/home-assistant/brands/pull/9558) (pending merge)