### PR TITLE
Add notion_garden_care

### DIFF
--- a/integration
+++ b/integration
@@ -1463,6 +1463,7 @@
   "peteS-UK/sonyavr",
   "petos/ha-vodarenska",
   "petretiandrea/home-assistant-tapo-p100",
+  "pfalzcraft/notion-garden-care",
   "Petro31/ha-integration-multizone-controller",
   "PhantomPhoton/S3-Compatible",
   "Phil-Barker/hass-bosch-ebike",


### PR DESCRIPTION
## Summary
- Adds [notion-garden-care](https://github.com/pfalzcraft/notion-garden-care) custom integration to the HACS default repository
- Home Assistant integration for garden care management with Notion

🤖 Generated with [Claude Code](https://claude.com/claude-code)