### PR TITLE
Add jinx-22/avalon_nano3s to integration list

### DIFF
--- a/integration
+++ b/integration
@@ -939,6 +939,7 @@
   "jibrilsharafi/homeassistant-energyme",
   "jihao/rokid-webhook-hass",
   "jimmybonesde/envertech_solar",
+  "jinx-22/avalon_nano3s",
   "jippi/hass-nordnet",
   "jirutka/hass-smarwi",
   "jjjonesjr33/petlibro",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [X] The actions are passing without any disabled checks in my repository.
- [X] I've added a link to the action run on my repository below in the links section.
- [X] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/jinx-22/avalon_nano3s/releases/tag/v1.0.0.0>
Link to successful HACS action (without the `ignore` key): <https://github.com/jinx-22/avalon_nano3s/actions/runs/22020008326/job/63627516342>
Link to successful hassfest action (if integration): <https://github.com/jinx-22/avalon_nano3s/actions/runs/22008525486/job/63628569351>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->