### PR TITLE
Add adamjacobmuller/homeassistant-moultrie

### DIFF
--- a/integration
+++ b/integration
@@ -29,6 +29,7 @@
   "ad-ha/kidschores-ha",
   "ad-ha/mg-saic-ha",
   "adammcdonagh/home-assistant-powervault",
+  "adamjacobmuller/homeassistant-moultrie",
   "adamoutler/anycubic-homeassistant",
   "adonixis/ufanet_intercom_ha",
   "aegjoyce/custom-ambilight",


### PR DESCRIPTION
## Summary
Adds the Moultrie Mobile trail camera integration for Home Assistant to the HACS default store.

**Repository:** https://github.com/adamjacobmuller/homeassistant-moultrie

## Integration Details
- Moultrie Mobile trail camera integration
- Supports sensors, binary sensors, switches, selects, camera, and buttons
- Azure AD B2C PKCE authentication
- Cloud polling with DataUpdateCoordinator
- 104 tests, HACS validation and hassfest CI passing