### PR TITLE
Adds new plugin [acato/ha-joule]

### DIFF
--- a/plugin
+++ b/plugin
@@ -6,6 +6,7 @@
   "Aasikki/comic-card",
   "abmantis/ozw-network-visualization-card",
   "abualy/philips-tv-remote-card",
+  "acato/ha-joule",
   "adamf83/lovelace-my-rail-commute-card",
   "adizanni/floor3d-card",
   "aex351/home-assistant-neerslag-card",


### PR DESCRIPTION
## acato/ha-joule — ChefSteps Joule Sous Vide (Lovelace card)

`custom:joule-sous-vide-card` — a Lovelace card for the ChefSteps Joule Sous Vide integration. Displays current temperature, target temperature stepper, cook time stepper, °F/°C unit toggle, and Start/Stop button in one panel.

**Latest release:** https://github.com/acato/ha-joule/releases/tag/card-v0.5.0
**CI run:** https://github.com/acato/ha-joule/actions/runs/22169819033