### PR TITLE
Adds new plugin [acato/ha-joule]

### DIFF
--- a/plugin
+++ b/plugin
@@ -6,6 +6,7 @@
   "Aasikki/comic-card",
   "abmantis/ozw-network-visualization-card",
   "abualy/philips-tv-remote-card",
+  "acato/ha-joule",
   "adamf83/lovelace-my-rail-commute-card",
   "adizanni/floor3d-card",
   "aex351/home-assistant-neerslag-card",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/acato/ha-joule/releases/tag/card-v0.5.0>
Link to successful HACS action (without the `ignore` key): <https://github.com/acato/ha-joule/actions/runs/22170131291>
Link to successful hassfest action (if integration): <>