### PR TITLE
Add acato/temperature-bar-card

### DIFF
--- a/plugin
+++ b/plugin
@@ -6,6 +6,7 @@
   "Aasikki/comic-card",
   "abmantis/ozw-network-visualization-card",
   "abualy/philips-tv-remote-card",
+  "acato/temperature-bar-card",
   "adamf83/lovelace-my-rail-commute-card",
   "adizanni/floor3d-card",
   "aex351/home-assistant-neerslag-card",


### PR DESCRIPTION
## Checklist

- [x] I am the owner, or a major contributor to the repository I want to add.
- [x] The repository has a description.
- [x] The repository has topics set.
- [x] The repository has a `hacs.json` file.
- [x] The repository meets the [plugin requirements](https://www.hacs.xyz/docs/publish/plugin/).

## Repository

https://github.com/acato/temperature-bar-card

## What does the repository do?

A custom Lovelace card that displays temperature sensor entities as colored bars with configurable gradient color backgrounds, thresholds, and support for both Fahrenheit and Celsius units.

## Why should it be added?

Provides a visual way to monitor multiple temperature sensors at a glance with intuitive color-coded bars, filling a gap for temperature-focused dashboard cards.