### PR TITLE
Add Beatify custom integration

### DIFF
--- a/integration
+++ b/integration
@@ -1283,6 +1283,7 @@
   "metbril/home-assistant-brandstofprijzen",
   "mguyard/hass-diagral",
   "mguyard/hass-iopool",
+  "mholzi/beatify",
   "michaellunzer/Home-Assistant-Custom-Component-Fortnite",
   "MichaelPihlblad/flowerhub_homeassistant_integration",
   "MichelFR/ha_ghostfolio",


### PR DESCRIPTION
## Summary

Add [Beatify](https://github.com/mholzi/beatify) to the HACS default integration list.

## What is Beatify?

🎵 **Beatify** is an open-source multiplayer music trivia game for Home Assistant. Players scan a QR code, listen to a song via their smart speaker, and guess the release year.

- **Speaker support:** Music Assistant, Sonos, Alexa
- **Multiplayer:** Real-time WebSocket-based gameplay
- **Tech:** Python custom component + vanilla JS frontend

## Checklist

- [x] I am the repository owner (@mholzi)
- [x] Repository is public: https://github.com/mholzi/beatify
- [x] Entry is alphabetically sorted in `integration`
- [x] **HACS Action** passes (validate.yml — green on `main`)
- [x] **Hassfest** passes (validate.yml — green on `main`)
- [x] Stable release exists: [v2.6.0](https://github.com/mholzi/beatify/releases/tag/v2.6.0)
- [x] Added to [home-assistant/brands](https://github.com/home-assistant/brands/pull/9164) (merged 2026-02-05)
- [x] `hacs.json` contains `name`
- [x] `manifest.json` is valid (domain: `beatify`, iot_class: `local_push`)
- [x] Repository has description, topics and issues enabled
- [x] PR is submitted from personal account, not an organization
- [x] Branch created from `master` (not using master directly)

## Links

- Repository: https://github.com/mholzi/beatify
- Latest release: https://github.com/mholzi/beatify/releases/tag/v2.6.0
- Brands PR: https://github.com/home-assistant/brands/pull/9164
- Documentation: https://github.com/mholzi/beatify#readme
