### PR TITLE
Add Tycho-MEC/apc-pdu to integration list

### DIFF
--- a/integration
+++ b/integration
@@ -1968,6 +1968,7 @@
   "twrecked/hass-momentary",
   "twrecked/hass-virtual",
   "tybritten/ical-sensor-homeassistant",
+  "Tycho-MEC/apc-pdu",
   "tykeal/homeassistant-rental-control",
   "tykovec/home-assistant-tritius",
   "TypQxQ/Sigenergy-Local-Modbus",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: https://github.com/Tycho-MEC/apc-pdu/releases/tag/v0.1.1
Link to successful HACS action (without the `ignore` key): https://github.com/Tycho-MEC/apc-pdu/actions/runs/22208831909
Link to successful hassfest action (if integration): https://github.com/Tycho-MEC/apc-pdu/actions/runs/22208831909

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->