### PR TITLE
Adds new plugin [wilsto/air-quality-card]

### DIFF
--- a/plugin
+++ b/plugin
@@ -542,6 +542,7 @@
   "weedpump/timeline-card",
   "weirdtangent/pulse-photo-card",
   "WickedGhost/avinor-flight-card",
+  "wilsto/air-quality-card",
   "wilsto/pool-monitor-card",
   "wiltodelta/homeassistant-sugartv-card",
   "WJDDesigns/Ultra-Card",


### PR DESCRIPTION
## Checklist

- [x] I have read the [adding a new repository](https://hacs.xyz/docs/publish/include#adding-to-hacs-default) page.
- [x] The repository meets the requirements from the [publish](https://hacs.xyz/docs/publish/start) section on the HACS documentation website.
- [x] The [validate action](https://github.com/wilsto/air-quality-card/actions/runs/22258767775) (including [HACS Action](https://github.com/hacs/action)) is successful.
- [x] There is [a release](https://github.com/wilsto/air-quality-card/releases/tag/v0.1.0) published in the repository.
- [x] The title of this PR is `Adds new plugin [wilsto/air-quality-card]`.
- [x] I am the owner of this repository.

## Links

- **Repository:** https://github.com/wilsto/air-quality-card
- **Release:** https://github.com/wilsto/air-quality-card/releases/tag/v0.1.0
- **HACS Validate:** https://github.com/wilsto/air-quality-card/actions/runs/22258767775

## Description

Air Quality Card is a custom Lovelace card for Home Assistant that monitors indoor air quality sensors (CO2, PM2.5, PM10, VOC, HCHO, NO2, O3, radon, humidity, temperature, etc.). It provides visual indicators with color-coded status based on WHO/EPA standards.

**Features:**
- 14 air quality sensors with color-coded thresholds
- 18 languages supported
- Configurable display (compact/full mode)
- Built with Lit 3, fully tested (63 unit tests)