### PR TITLE
Adds new plugin [wilsto/sensor-monitor-card]

### DIFF
--- a/plugin
+++ b/plugin
@@ -543,6 +543,7 @@
   "weirdtangent/pulse-photo-card",
   "WickedGhost/avinor-flight-card",
   "wilsto/pool-monitor-card",
+  "wilsto/sensor-monitor-card",
   "wiltodelta/homeassistant-sugartv-card",
   "WJDDesigns/Ultra-Card",
   "WJDDesigns/Ultra-Vehicle-Card",


### PR DESCRIPTION
## Checklist

- [x] I have read the [adding a new repository](https://hacs.xyz/docs/publish/include#adding-to-hacs-default) page.
- [x] The repository meets the requirements from the [publish](https://hacs.xyz/docs/publish/start) section on the HACS documentation website.
- [x] The [validate action](https://github.com/wilsto/sensor-monitor-card/actions/runs/22258764068) (including [HACS Action](https://github.com/hacs/action)) is successful.
- [x] There is [a release](https://github.com/wilsto/sensor-monitor-card/releases/tag/v1.1.0) published in the repository.
- [x] The title of this PR is `Adds new plugin [wilsto/sensor-monitor-card]`.
- [x] I am the owner of this repository.

## Links

- **Repository:** https://github.com/wilsto/sensor-monitor-card
- **Release:** https://github.com/wilsto/sensor-monitor-card/releases/tag/v1.1.0
- **HACS Validate:** https://github.com/wilsto/sensor-monitor-card/actions/runs/22258764068

## Description

Sensor Monitor Card is a generic custom Lovelace card for Home Assistant that displays any user-defined sensor with visual indicators and color-coded thresholds. Unlike domain-specific cards, users configure their own sensors, min/max values, and color ranges.

**Features:**
- Fully user-configurable sensors (any HA entity)
- Custom thresholds and color ranges per sensor
- 18 languages supported
- Configurable display (compact/full mode)
- Built with Lit 3, fully tested (63 unit tests)