### PR TITLE
Add mastalir1980/ha-2N-intercom to integration list

### DIFF
--- a/integration
+++ b/integration
@@ -1248,6 +1248,7 @@
   "Martinvdm/garbage-nissewaard-homeassistant",
   "masaccio/ha-kingspan-watchman-sensit",
   "mash2k3/qingping_cgs1",
+  "mastalir1980/ha-2N-intercom",
   "Master13011/Mailcow-HA",
   "Master13011/SNCF-API-HA",
   "Master13011/vacances-scolaire-HA",


### PR DESCRIPTION
- Repository: https://github.com/mastalir1980/ha-2N-intercom
- Domain: 2n_intercom
- HACS: integration

Checklist
- [x] I've read the publishing documentation.
- [x] I've added the HACS action to my repository.
- [x] (For integrations only) I've added the hassfest action to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

Links
Link to current release: https://github.com/mastalir1980/ha-2N-intercom/releases/tag/v1.0.0 Link to successful HACS action (without the ignore key): https://github.com/mastalir1980/ha-2N-intercom/actions/runs/22259668985 Link to successful hassfest action (if integration): https://github.com/mastalir1980/ha-2N-intercom/actions/runs/22259668977

