### PR TITLE
Add HDAnywhere MHUB integration

### DIFF
--- a/integration
+++ b/integration
@@ -1231,6 +1231,7 @@
   "marq24/ha-senec-v3",
   "marq24/ha-tibber-pulse-local",
   "marq24/ha-waterkotte",
+  "marsh4200/mhub",
   "martinarva/dynamic_energy_cost",
   "martindell/ha-entity-notes",
   "MartinDybal/TapHome-HomeAssistant",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <>
Link to successful HACS action (without the `ignore` key): <>
Link to successful hassfest action (if integration): <>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->

This integration provides local control of HDAnywhere MHUB HDMI matrix devices (power, routing, source selection) as media_player entities in Home Assistant.


Adds the HDAnywhere MHUB Home Assistant integration to the HACS default store.

Link to current release:
https://github.com/marsh4200/mhub/releases/tag/v0.0.2

Link to successful HACS action (without the ignore key):
https://github.com/marsh4200/mhub/actions/workflows/hacs.yml

Link to successful hassfest action (if integration):
https://github.com/marsh4200/mhub/actions/workflows/hassfest.yml