### PR TITLE
Add denisvinciguerra/ha-unifi-cellular

### DIFF
--- a/integration
+++ b/integration
@@ -512,6 +512,7 @@
   "delphiki/hass-pronote",
   "delphiki/hass-tarif-edf",
   "DeLuca21/ynab-ha",
+  "denisvinciguerra/ha-unifi-cellular",
   "Dennis90BW/ha-power-helper",
   "denov/home-assistant-apex-neptune",
   "denpamusic/homeassistant-plum-ecomax",


### PR DESCRIPTION
## New integration: UniFi Cellular

Custom integration for UniFi 5G Max Outdoor (MBB) devices. Exposes cellular signal metrics (RSRP, RSRQ, SNR, band), multi-SIM support, data usage, and WAN health as HA sensor entities.

- Repository: https://github.com/denisvinciguerra/ha-unifi-cellular
- Latest release: https://github.com/denisvinciguerra/ha-unifi-cellular/releases/tag/v0.1.0
- CI/Actions: https://github.com/denisvinciguerra/ha-unifi-cellular/actions