### PR TITLE
Add JaviSoto/homeassistant-quilt

### DIFF
--- a/integration
+++ b/integration
@@ -921,6 +921,7 @@
   "JanGiese/notion_todo",
   "jannis3005/hass-abrp",
   "Jarauvi/beny_wifi",
+  "JaviSoto/homeassistant-quilt",
   "jarcovlieger/brink-hrv-modbus",
   "jaroschek/home-assistant-myuplink",
   "jaruba/ha-samsungtv-tizen",


### PR DESCRIPTION
## Summary
Add the Quilt integration repository to the HACS default integration list.

Repository: https://github.com/JaviSoto/homeassistant-quilt
Category: integration
