### PR TITLE
 Add Wheel of the Year integration

### DIFF
--- a/integration
+++ b/integration
@@ -1335,6 +1335,7 @@
   "moox-it/hass-moox-track",
   "moralmunky/Home-Assistant-Mail-And-Packages",
   "morosanmihail/HA-LondonTfL",
+  "MorningstarOwl/ha-wheel-of-the-year",
   "mossipcams/autosnooze",
   "mr-deamon/publibike_stations",
   "Mr-Groch/ambihue",


### PR DESCRIPTION
Add wheel-of-the-year integration

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [ ] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [ ] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [ ] The actions are passing without any disabled checks in my repository.
- [ ] I've added a link to the action run on my repository below in the links section.
- [ ] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <>
Link to successful HACS action (without the `ignore` key): <>
Link to successful hassfest action (if integration): <>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->