### PR TITLE
Add calendar-card-plus to plugin list

### DIFF
--- a/plugin
+++ b/plugin
@@ -547,6 +547,7 @@
   "WJDDesigns/Ultra-Vehicle-Card",
   "wrodie/mixer-card",
   "xBourner/area-card-plus",
+  "xBourner/calendar-card-plus",
   "xBourner/header-position-card",
   "xBourner/status-card",
   "xplanes/ha-plant-diary-card",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: https://github.com/xBourner/calendar-card-plus/releases/tag/v0.0.3
Link to successful HACS action (without the `ignore` key): https://github.com/xBourner/calendar-card-plus/actions/runs/22352084699/job/64681586842

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->