### PR TITLE
Adds new plugin [amitfin/oref-alert-card]

### DIFF
--- a/plugin
+++ b/plugin
@@ -15,6 +15,7 @@
   "amaximus/pollen-hu-card",
   "amaximus/transmission-card",
   "amitfin/lovelace-daily-schedule-card",
+  "amitfin/oref-alert-card",
   "AmoebeLabs/flex-horseshoe-card",
   "AmoebeLabs/swiss-army-knife-card",
   "Anonym-tsk/lovelace-starline-card",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: https://github.com/amitfin/oref-alert-card/releases/tag/v1.0.0
Link to successful HACS action (without the `ignore` key): https://github.com/amitfin/oref-alert-card/actions/runs/22443438533/job/64991519093
Link to successful hassfest action (if integration): <>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->