### PR TITLE
Add Topomation to default integrations list

### DIFF
--- a/integration
+++ b/integration
@@ -1322,6 +1322,7 @@
   "mirko-sommer/homeassistant-rnv",
   "MislavMandaric/home-assistant-vaillant-vsmart",
   "miyosmart/miyocube-homeassistant-custom-component",
+  "mjcumming/topomation",
   "mjcumming/wiim",
   "MKSG-MugunthKumar/ha-chameleon",
   "MKsys1337/MiWiFi-CB0401V2",


### PR DESCRIPTION
## Summary
Add `mjcumming/topomation` to the HACS default `integration` list.

## Validation
- `python3 scripts/is_sorted.py`

## Related
- Home Assistant brands PR: https://github.com/home-assistant/brands/pull/9875
- Local integration branding (HA 2026.3+): `custom_components/topomation/brand/*`
