### PR TITLE
Add trcyberoptic/hoval-connect-api

### DIFF
--- a/integration
+++ b/integration
@@ -1968,6 +1968,7 @@
   "Toxo666/ha_froeling_modbus",
   "travisghansen/hass-pfsense",
   "trevorwarwick/minidspshd",
+  "trcyberoptic/hoval-connect-api",
   "tronikos/google_assistant_sdk_custom",
   "tronikos/nest_legacy",
   "troykelly/homeassistant-au-nsw-covid",


### PR DESCRIPTION
## Repository

https://github.com/trcyberoptic/hoval-connect-api

## Description

**Hoval Connect** — Home Assistant custom integration for the Hoval Connect IoT platform. Provides climate, fan, sensor, binary sensor, and select entities for Hoval HVAC systems (heating and ventilation circuits).

## Checklist

- [x] I am the owner of the repository
- [x] The repository has a valid `hacs.json`
- [x] GitHub Actions (HACS Action, Hassfest) pass without errors or ignores
- [x] At least one release published
- [x] Repository has description and topics
- [x] Brand submitted and merged in [home-assistant/brands#9607](https://github.com/home-assistant/brands/pull/9607)