### PR TITLE
Add japoneris/Home-assitant-Ventusky to integration

### DIFF
--- a/integration
+++ b/integration
@@ -930,6 +930,7 @@
   "jampez77/Yodel",
   "JanGiese/notion_todo",
   "jannis3005/hass-abrp",
+  "japoneris/Home-assitant-Ventusky",
   "Jarauvi/beny_wifi",
   "jarcovlieger/brink-hrv-modbus",
   "jaroschek/home-assistant-myuplink",


### PR DESCRIPTION
Weather app

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [p] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository. => I tried, but now for the new version of home assistant, this is no more necessary: https://github.com/home-assistant/brands/pull/9828#issuecomment-3962920227
- [x] The actions are passing without any disabled checks in my repository. (up to the brand image, see above, in my local setup everything OK, image showing up)
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/Japoneris/Home-assitant-Ventusky/releases/tag/v1.0.0.0-html>

Link to successful HACS action (without the `ignore` key): 
https://github.com/Japoneris/Home-assitant-Ventusky/actions/runs/22477771479/job/65108378165

Link to successful hassfest action (if integration): <>
https://github.com/Japoneris/Home-assitant-Ventusky/actions/runs/22477771463
<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->

Please have a look at https://developers.home-assistant.io/blog/2026/02/24/brands-proxy-api/ for image icon, as this is the only check that fails due to the HACS pipeline