### PR TITLE
Add bobsilesia/oblamatik

### DIFF
--- a/integration
+++ b/integration
@@ -268,6 +268,7 @@
   "blindlight86/HA_USR-R16",
   "bm1549/home-assistant-frigidaire",
   "bobbesnl/growatt_thor",
+  "bobsilesia/oblamatik",
   "BobTheShoplifter/HomeAssistant-Posten",
   "bodyscape/cielo_home",
   "boot-nyxpoint/prana-wifi",


### PR DESCRIPTION
Adds bobsilesia/oblamatik to the default HACS repository.