### PR TITLE
Add Shaffer-Softworks/hyperhdr-ha

### DIFF
--- a/integration
+++ b/integration
@@ -1760,6 +1760,7 @@
   "sh00t2kill/linktap_local_http_component",
   "sh00t2kill/petoneer_custom_component",
   "Sha-Darim/brandriskute",
+  "Shaffer-Softworks/hyperhdr-ha",
   "shadow578/homeassistant_sma-ennexos",
   "shaiu/technicolor",
   "sHedC/homeassistant-leakbot",


### PR DESCRIPTION
Adds [HyperHDR](https://github.com/Shaffer-Softworks/hyperhdr-ha) to the HACS default integration list.

- **Repository:** https://github.com/Shaffer-Softworks/hyperhdr-ha
- **Latest release:** https://github.com/Shaffer-Softworks/hyperhdr-ha/releases/latest
- **CI:** https://github.com/Shaffer-Softworks/hyperhdr-ha/actions