### PR TITLE
Add Bargemanos/ha-saj-esolar-ble

### DIFF
--- a/integration
+++ b/integration
@@ -209,6 +209,7 @@
   "banter240/tado_hijack",
   "baracudaz/fenix_tft",
   "barban-dev/homeassistant-midea-dehumidifier",
+  "Bargemanos/ha-saj-esolar-ble",
   "barleybobs/homeassistant-ecowater-softener",
   "barneyonline/groq_tts",
   "barneyonline/ha-enphase-ev-charger",


### PR DESCRIPTION
## Checklist

- [x] I am the owner of the repository
- [x] The repository is a custom integration (added to `integration` file)
- [x] The repository has a valid `hacs.json` file
- [x] The repository has a valid `manifest.json` file
- [x] HACS Action passes
- [x] Hassfest passes
- [x] A GitHub release has been published
- [x] The entry is added in alphabetical order

## Repository

https://github.com/Bargemanos/ha-saj-esolar-ble

## Description

SAJ eSolar BLE — Home Assistant integration for SAJ R5 series solar inverters via Bluetooth Low Energy (BLE). Communicates directly with the inverter's DTU (MC20 2G module) using Modbus over BLE.