### PR TITLE
Add gbroeckling/padspanHA

### DIFF
--- a/integration
+++ b/integration
@@ -723,6 +723,7 @@
   "garbled1/homeassistant_ecowitt",
   "GarthDB/ha-wattbox",
   "gazoodle/gecko-home-assistant",
+  "gbroeckling/padspanHA",
   "gcobb321/icloud3",
   "gcorgnet/sensor.emby_upcoming_media",
   "geappliances/geappliances-integration",


### PR DESCRIPTION
## New Integration

**Repository:** [gbroeckling/padspanHA](https://github.com/gbroeckling/padspanHA)
**Category:** Integration
**Domain:** `padspan_ha`

### Description

PadSpan HA is a Home Assistant integration for BLE (Bluetooth Low Energy) presence detection and indoor positioning. It provides:

- Multi-scanner BLE presence tracking with RSSI-based distance estimation
- Room-level presence detection using HA Area Registry
- Device tracking entities, binary presence sensors, and distance sensors
- Visual floor plan mapping with SVG overlays
- Calibration tools for improving positioning accuracy
- Email alerts on room transitions
- Full frontend panel with multiple views (Follow, Overview, Objects, Maps, Settings, etc.)

### Checklist

- [x] Repository has `hacs.json` with proper configuration
- [x] Repository has a valid `manifest.json` in `custom_components/padspan_ha/`
- [x] Repository is publicly accessible
- [x] Integration has a release with a tag