### PR TITLE
Add smartpricing/homeassistant-smartpms

### DIFF
--- a/integration
+++ b/integration
@@ -1788,6 +1788,7 @@
   "slydiman/sscpoe",
   "smarthomeblack/npc",
   "smarthomeblack/zalo_bot",
+  "smartpricing/homeassistant-smartpms",
   "SmartyVan/hass-geolocator",
   "Smiley73/ha-scheduler",
   "smkrv/ha-text-ai",


### PR DESCRIPTION
## New integration

**Repository:** https://github.com/smartpricing/homeassistant-smartpms

**Description:** SmartPMS integration for Home Assistant - exposes room occupancy status (free/occupied/blocked) from the SmartPMS property management system as sensors.

**Checklist:**
- [x] Repository is public
- [x] `hacs.json` present
- [x] `manifest.json` with version
- [x] GitHub release with tag
- [x] LICENSE (MIT)
- [x] README.md
- [x] Config flow support