### PR TITLE
Add new repository 'mattxcz/cez' to integration

### DIFF
--- a/integration
+++ b/integration
@@ -1278,6 +1278,7 @@
   "MatthewOnTour/BUT_blinds_time_control",
   "MattieGit/qube_heatpump",
   "mattrayner/pod-point-home-assistant-component",
+  "mattxcz/cez",
   "mawinkler/astroweather",
   "MaxensF/personal_weather_station",
   "Maxou44/ha-tiko-component",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->

## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [X] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [X] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [X] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [X] The actions are passing without any disabled checks in my repository.
- [X] I've added a link to the action run on my repository below in the links section.
- [X] I've created a new release of the repository after the validation actions were run successfully.

This integration is ready for inclusion in HACS default repository.

## Links

Link to current release: <https://github.com/MattXcz/CEZ/releases/tag/v1.0.6>  
Link to successful HACS action (without the `ignore` key): <https://github.com/MattXcz/CEZ/actions/runs/22527591153/job/65261922261>  
Link to successful hassfest action (if integration): <https://github.com/MattXcz/CEZ/actions/runs/22527591163/job/65261922210>  

### Repository: https://github.com/MattXcz/CEZ/

## Description

Custom Home Assistant integration providing energy tariffs for the largest energy supplier in the Czech Republic.

## Category

integration