### PR TITLE
Add dmoo500/ha-swissweather-card plugin

### DIFF
--- a/plugin
+++ b/plugin
@@ -111,6 +111,7 @@
   "dimagoltsman/refreshable-picture-card",
   "dmatik/switcher-boiler-card",
   "dmulcahey/zha-network-card",
+  "dmoo500/ha-swissweather-card",
   "dnguyen800/air-visual-card",
   "domodom30/mealie-card",
   "dooz127/swipe-glance-card",


### PR DESCRIPTION
## Checklist

- [x] I am the owner of the repository being submitted
- [x] The repository has a description
- [x] The repository has issues enabled
- [x] The repository has topics defined
- [x] The repository has a README
- [x] The repository has a hacs.json file
- [x] The hacs.json file has a name key
- [x] The repository has at least one release

## Repository

https://github.com/dmoo500/ha-swissweather-card

**Type:** Plugin (Lovelace card)
**Country:** CH

**Description:** Home Assistant Lovelace card recreating the MeteoSwiss app experience – Swiss weather, forecasts & UV index. Built with TypeScript and Lit.