### PR TITLE
Update integration - added ebus_direct

### DIFF
--- a/integration
+++ b/integration
@@ -336,6 +336,7 @@
   "cedricziel/ha-matter-binding-helper",
   "cedricziel/ha-sunlit",
   "cermakjn/ha-fellow-stagg-ekg-pro",
+  "Ces1254/home_assistant_ebus_direct",
   "chaimchaikin/molad-ha",
   "CharlesGillanders/homeassistant-alphaESS",
   "CharlesP44/Beem_Energy",


### PR DESCRIPTION
ebus_direct is a HA integration designed to connect directly to ebusd via the native TCP link.

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: https://github.com/Ces1254/home_assistant_ebus_direct/releases/tag/v1.0.2
Link to successful HACS action (without the `ignore` key): https://github.com/Ces1254/home_assistant_ebus_direct/actions/runs/22565159146/job/65359687549
Link to successful hassfest action (if integration): https://github.com/Ces1254/home_assistant_ebus_direct/actions/runs/22565159113/job/65359687447

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->