### PR TITLE
Adds new integration [aspenrt78/button-builder]

### DIFF
--- a/integration
+++ b/integration
@@ -178,6 +178,7 @@
   "asantaga/wiserHomeAssistantPlatform",
   "asev/homeassistant-helios",
   "Ashus/hass-openwrt-wakeonlan",
+  "aspenrt78/button-builder",
   "astrandb/miele",
   "astrandb/sentio",
   "astrandb/teracom_hass",


### PR DESCRIPTION
## Description

Adds Button Builder (spenrt78/button-builder) to the HACS default integration list.

## Repository Info

- **Repo**: https://github.com/aspenrt78/button-builder
- **Type**: Integration (custom_component)
- **Name**: Button Builder
- **Description**: Visual drag-and-drop builder for Home Assistant \custom:button-card\ YAML configurations, served as a panel inside HA.

## Checklist

- [x] \hacs.json\ present and valid
- [x] \custom_components/button_builder/\ folder with \__init__.py\ and \manifest.json\
- [x] GitHub releases with version tags (current: v2.2.8)
- [x] Public repository