### PR TITLE
Adds new integration [aspenrt78/button-builder]

### DIFF
--- a/integration
+++ b/integration
@@ -178,6 +178,7 @@
   "asantaga/wiserHomeAssistantPlatform",
   "asev/homeassistant-helios",
   "Ashus/hass-openwrt-wakeonlan",
+  "aspenrt78/button-builder",
   "astrandb/miele",
   "astrandb/sentio",
   "astrandb/teracom_hass",


### PR DESCRIPTION
Adds Button Builder to the HACS default integration list.

https://github.com/aspenrt78/button-builder
https://github.com/aspenrt78/button-builder/releases/tag/v2.2.8
https://github.com/aspenrt78/button-builder/actions/runs/22603892833

## Checklist

- [x] The repository is public
- [x] \hacs.json\ is present and valid
- [x] The repository has a GitHub release
- [x] The integration is inside \custom_components/button_builder/\
- [x] \manifest.json\ is present