### PR TITLE
Add Kirorus/neptun4hass

### DIFF
--- a/integration
+++ b/integration
@@ -1089,6 +1089,7 @@
   "KiraPC/ha-switchbot-remote",
   "kirei/hass-chargeamps",
   "kirill-k2/hass-guk-krasnodar",
+  "Kirorus/neptun4hass",
   "klacol/homeassistant-clage_homeserver",
   "klaptafel/ha-previous-state-tracker",
   "klatka/nc-talk-bot-component",


### PR DESCRIPTION
## Summary\n- add  to the HACS default integration list\n\n## Repository\n- https://github.com/Kirorus/neptun4hass\n\n## Validation\n- integration list remains alphabetically sorted