### PR TITLE
Add MathewUlanowski/ha-rainsoft

### DIFF
--- a/integration
+++ b/integration
@@ -1283,6 +1283,7 @@
   "MateoGreil/homeassistant-comwatt",
   "matfroh/abl_emh1_modbus",
   "matfroh/sax_battery_ha",
+  "MathewUlanowski/ha-rainsoft",
   "mathieu-mp/homeassistant-intex-spa",
   "matt-richardson/home-assistant-firefly-cloud",
   "matt-richardson/home-assistant-qustodio",


### PR DESCRIPTION
## New integration

**Repository:** https://github.com/MathewUlanowski/ha-rainsoft

**Description:** RainSoft water softener integration for Home Assistant via the RainSoft Remind portal.

**Checklist:**
- [x] `hacs.json` present
- [x] `manifest.json` with version
- [x] MIT License
- [x] Repository description set
- [x] Repository topics: `hacs`, `home-assistant`, `home-assistant-custom-component`
- [x] GitHub Release (v1.1.0)
- [x] CI pipeline (lint, hassfest, tests)