### PR TITLE
Add jelmer/HA-Thames-Water

### DIFF
--- a/integration
+++ b/integration
@@ -1,4 +1,3 @@
-Insert at index 959, between jellespijker/home-assistant-ultimaker and Jems22/ha_star_rennes
 [
   "0jety0/emaux_spv150",
   "0xAHA/airtouch4_advanced",


### PR DESCRIPTION
## Summary

Add [jelmer/HA-Thames-Water](https://github.com/jelmer/HA-Thames-Water) to the default HACS integration list.

This is a Home Assistant integration for monitoring Thames Water consumption data via their API.