### PR TITLE
Add joklee/ha_daikin_altherma4_modbus to integration

### DIFF
--- a/integration
+++ b/integration
@@ -1000,6 +1000,7 @@
   "johnnybegood/ha-ksenia-lares",
   "johnvoipguy/Traeger-WiFire",
   "Johnwulp/rad-afval",
+  "joklee/ha_daikin_altherma4_modbus",
   "joleys/niko-home-control-II",
   "jonandel/ha-hildebrandglow-dcc",
   "jonasbkarlsson/ev_smart_charging",


### PR DESCRIPTION
- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: https://github.com/joklee/ha_daikin_altherma4_modbus/releases/tag/0.5.0
Link to successful HACS action (without the `ignore` key): https://github.com/joklee/ha_daikin_altherma4_modbus/actions/runs/22735607796
Link to successful hassfest action (if integration): https://github.com/joklee/ha_daikin_altherma4_modbus/actions/runs/22735607832