### PR TITLE
Add strecklecsuk/water_softener

### DIFF
--- a/integration
+++ b/integration
@@ -1863,6 +1863,7 @@
   "stoppegp/ha-dwd-precipitation-forecast",
   "Strixx76/mold_risk_index",
   "Strixx76/samsungwam",
+  "strecklecsuk/water_softener",
   "stuartp44/haduco",
   "stuartp44/hambrewclient",
   "studiobts/home-assistant-device-pulse",


### PR DESCRIPTION
## Description

Adds the Water Softener Manager integration to the HACS default store.

- Tracks resin ion-exchange capacity in liters
- Detects regeneration cycles automatically (dual-sensor and single-sensor modes)
- Estimates next regeneration date based on 7-day consumption average
- Custom Lovelace card with animated SVG tank and visual editor
- Multi-device support (multiple softeners)
- Configurable notifications

## Checklist

- [x] Repository is public
- [x] hacs.json is present and valid
- [x] manifest.json with all required fields (v1.3.0)
- [x] config_flow: true
- [x] services.yaml documented
- [x] brand/ assets included
- [x] GitHub Actions: HACS validation passing
- [x] GitHub Actions: hassfest passing
- [x] LICENSE (MIT)
- [x] README.md