### PR TITLE
Add Miggets7/HA-Earn-E-P1-Meter

### DIFF
--- a/integration
+++ b/integration
@@ -1320,6 +1320,7 @@
   "microteq/email_notifier",
   "microteq/whatsigram_messenger",
   "midstar/heatmiser_wifi_ha",
+  "Miggets7/HA-Earn-E-P1-Meter",
   "MiguelAngelLV/ha-awtrix",
   "MiguelAngelLV/ha-balance-neto",
   "MiguelAngelLV/ha-gas-station-spain",


### PR DESCRIPTION
## Repository

https://github.com/Miggets7/HA-Earn-E-P1-Meter

## Description

Home Assistant custom integration for the EARN-E energy monitor. The EARN-E reads your smart meter's P1 port and broadcasts real-time energy data via UDP on the local network. This integration listens for those broadcasts and exposes them as sensor entities in Home Assistant.

## Checklist

- [x] The repository has a valid `hacs.json` file
- [x] The integration has a valid `manifest.json` file with `version` key
- [x] There is a published GitHub release
- [x] The repository has a `LICENSE` file
- [x] The repository has a `README.md`
- [x] HACS validation action passes