### PR TITLE
Add Miggets7/HA-Earn-E-P1-Meter

### DIFF
--- a/integration
+++ b/integration
@@ -1320,6 +1320,7 @@
   "microteq/email_notifier",
   "microteq/whatsigram_messenger",
   "midstar/heatmiser_wifi_ha",
+  "Miggets7/HA-Earn-E-P1-Meter",
   "MiguelAngelLV/ha-awtrix",
   "MiguelAngelLV/ha-balance-neto",
   "MiguelAngelLV/ha-gas-station-spain",


### PR DESCRIPTION
## Links

- **Repository:** https://github.com/Miggets7/HA-Earn-E-P1-Meter
- **Latest release:** https://github.com/Miggets7/HA-Earn-E-P1-Meter/releases/tag/1.0.0
- **CI action runs:** https://github.com/Miggets7/HA-Earn-E-P1-Meter/actions

## Description

Home Assistant custom integration for the EARN-E energy monitor. The EARN-E reads your smart meter's P1 port and broadcasts real-time energy data via UDP on the local network. This integration listens for those broadcasts and exposes them as sensor entities in Home Assistant.