### PR TITLE
Add Feberdin/ecoflow-powerocean-ha

### DIFF
--- a/integration
+++ b/integration
@@ -677,6 +677,7 @@
   "FaserF/ha-kadermanager",
   "Favio25/Kronoterm-homeassistant",
   "FeatherKing/ha-matriocontrol",
+  "Feberdin/ecoflow-powerocean-ha",
   "feihuasimeng1993/linkedgo_bridge",
   "felippepuhle/tholz-hass-integration",
   "FernandoZueet/messages_store",


### PR DESCRIPTION
## Summary
Adds `Feberdin/ecoflow-powerocean-ha` to the integration list for HACS default repository inclusion.

## Repository
- https://github.com/Feberdin/ecoflow-powerocean-ha

## Checklist
- Public repository
- `custom_components/ecoflow_powerocean` structure
- `manifest.json` with required fields
- `hacs.json` present in root
- GitHub releases available
- Validation workflows (`hacs` + `hassfest`) configured
