### PR TITLE
Add dannyoosterveer/ourgrid

### DIFF
--- a/integration
+++ b/integration
@@ -477,6 +477,7 @@
   "danielrivard/homeassistant-innova",
   "danielsmith-eu/home-assistant-themeparks-integration",
   "danishru/silam_pollen",
+  "dannyoosterveer/ourgrid",
   "danobot/entity-controller",
   "danq8/neo_watcher",
   "darius1907/ha_vmc_helty_flow",


### PR DESCRIPTION
## Add OurGrid integration

**Repository:** https://github.com/dannyoosterveer/ourgrid

### What does this integration do?

OurGrid is a Dutch energy demand response service that rewards users for reducing their power consumption during grid congestion events. This integration connects Home Assistant to the OurGrid platform via its OpenRemote REST API.

**Features:**
- Monitors active grid congestion challenges
- Auto-joins challenges via a button entity
- Exposes challenge start/end times, power limit, and current consumption
- Tracks points, exchange rate, and expected earnings
- Includes blueprints for EV charger and battery automation

### Checklist

- [x] The repository is public on GitHub
- [x] At least one release exists (v1.0.0)
- [x] hacs.json is present with required fields
- [x] README.md with installation and configuration instructions
- [x] manifest.json with all required fields (documentation, issue_tracker, codeowners, version)
- [x] HACS validation workflow present
- [x] hassfest validation workflow present
- [x] Brand icon present
- [x] Issues are enabled
- [x] GitHub topics are set