### PR TITLE
Add Backup Monitor integration

### DIFF
--- a/integration
+++ b/integration
@@ -1834,6 +1834,7 @@
   "SpanPanel/span",
   "spatecon/orcommconnect",
   "speedy3wk/ha-optoma-projector",
+  "spezzuti/backup-monitor",
   "SplinterHead/ha-honeygain",
   "sprocket-9/hacs-nuvo-serial",
   "spuky/lunatone-dali-integration",


### PR DESCRIPTION
Adds Backup Monitor integration for monitoring backup providers.

Supports:
- Backrest
- Duplicati

Repository:
https://github.com/spezzuti/backup_monitor