### PR TITLE
Adds new integration [JonBasse/ha-maestro-mcz]

### DIFF
--- a/integration
+++ b/integration
@@ -1006,6 +1006,7 @@
   "JonasJoKuJonas/homeassistant-trias",
   "JonasJoKuJonas/homeassistant-WebUntis",
   "JonasPed/homeassistant-eloverblik",
+  "JonBasse/ha-maestro-mcz",
   "jonkristian/wasteplan_trv",
   "jonnybergdahl/HomeAssistant_NewsbinPro_Integration",
   "jonnynch/ha-jemenaoutlook",


### PR DESCRIPTION
## Integration

**Repository:** https://github.com/JonBasse/ha-maestro-mcz
**Release:** https://github.com/JonBasse/ha-maestro-mcz/releases/tag/v1.3.3
**CI:** https://github.com/JonBasse/ha-maestro-mcz/actions

## Description

Home Assistant integration for MCZ pellet stoves via the Maestro cloud platform. Provides real-time monitoring (temperature, power level, fan speed, status) and control (on/off, target temperature, power mode, chrono mode) using WebSocket push for instant updates.

## Checklist

- [x] The integration is available as a GitHub release
- [x] The integration passes HACS validation
- [x] The integration passes hassfest validation
- [x] The integration has a `hacs.json` file
- [x] Brand assets available in home-assistant/brands repository
- [x] The repository has a license (MIT)