### PR TITLE
Add dzerik/melitta-barista-card

### DIFF
--- a/plugin
+++ b/plugin
@@ -124,6 +124,7 @@
   "DTekNO/lovelace-meteogram-card",
   "dvb6666/homed-zigbee-networkmap",
   "dylandoamaral/uptime-card",
+  "dzerik/melitta-barista-card",
   "Edward13ruf/nationalrail-status-card",
   "Edward13ruf/tfl-status-card",
   "elax46/custom-brand-icons",


### PR DESCRIPTION
**Repository:** https://github.com/dzerik/melitta-barista-card
**Category:** Plugin (Lovelace card)

Custom Lovelace card for the [Melitta Barista Smart](https://github.com/dzerik/melitta-barista-ha) integration.

- Recipe select dropdown + brew button
- Machine state with color-coded badge
- BLE connection indicator
- Progress bar during brewing/cleaning
- Action alerts, cancel button
- Auto-detection of Melitta devices
- Theme-aware (light/dark)
- Built with Lit + TypeScript