### PR TITLE
Add jquirke/ha-solshare

### DIFF
--- a/integration
+++ b/integration
@@ -1023,6 +1023,7 @@
   "jozefnad/homeassistant-quick_timer",
   "jozefnad/homeassistant-smartspaclient",
   "jpawlowski/hass.tibber_prices",
+  "jquirke/ha-solshare",
   "jrfernandes/ontario_energy_board",
   "jrgim/Zaragoza_tram",
   "jrmattila/ha-elenia",


### PR DESCRIPTION
## Add jquirke/ha-solshare

Home Assistant custom integration for [Allume Energy SolCentre](https://allumeenergy.com.au) (SolShare) — a shared solar platform for apartment buildings in Australia.

### Checklist

- [x] Repository is public
- [x] `hacs.json` present
- [x] `manifest.json` with all required fields, keys sorted correctly
- [x] Passes HACS Action
- [x] Passes Hassfest
- [x] GitHub Release exists (v1.0.0)
- [x] Brand assets (`icon.png`) present
- [x] README present
- [x] Valid topics set