### PR TITLE
Add spagonic/ha-hi3510 (Hi3510 IP Camera)

### DIFF
--- a/integration
+++ b/integration
@@ -1835,6 +1835,7 @@
   "soulripper13/hass-waviot",
   "soulripper13/speedtest_rt_ru",
   "soundstorm/aha_trash",
+  "spagonic/ha-hi3510",
   "SpanPanel/span",
   "spatecon/orcommconnect",
   "speedy3wk/ha-optoma-projector",


### PR DESCRIPTION
## Repository
https://github.com/spagonic/ha-hi3510

## Description
Home Assistant custom integration for IP cameras using the **Hi3510/HiSilicon CGI protocol** (`/cgi-bin/hi3510/param.cgi`).

This protocol is used by hundreds of camera models from brands like SV3C, Ctronics, Dericam, INSTAR, Wansview, Tenvis, Wanscam, Sricam, and many others. The cameras use CamHi/HiP2P/Ctronics mobile apps.

## Features
- RTSP streaming and JPEG snapshots
- Image controls (brightness, contrast, saturation, sharpness, flip, mirror)
- Infrared mode, ONVIF toggle, SD recording
- OSD overlay text and position management
- Motion detection via SD card alarm files
- Audio volume control, reboot
- Network discovery (automatic scan)
- English and Italian translations

## Checklist
- [x] Repository is public
- [x] Has a release (v1.2.0)
- [x] hassfest action passes
- [x] HACS validation action passes
- [x] Has description and topics
- [x] Issues are enabled
- [x] Brand PR submitted: https://github.com/home-assistant/brands/pull/9945