### PR TITLE
Add spagonic/ha-hi3510

### DIFF
--- a/integration
+++ b/integration
@@ -1835,6 +1835,7 @@
   "soulripper13/hass-waviot",
   "soulripper13/speedtest_rt_ru",
   "soundstorm/aha_trash",
+  "spagonic/ha-hi3510",
   "SpanPanel/span",
   "spatecon/orcommconnect",
   "speedy3wk/ha-optoma-projector",


### PR DESCRIPTION
Add Hi3510 IP Camera integration. Repository: https://github.com/spagonic/ha-hi3510 - Brand PR: https://github.com/home-assistant/brands/pull/9945