### PR TITLE
Add SpanPanel/span-card to plugin index

### DIFF
--- a/plugin
+++ b/plugin
@@ -467,6 +467,7 @@
   "soestin/hass_periodic_card_reload",
   "sonite/particle-cloud-card",
   "sopelj/lovelace-kanji-clock-card",
+  "SpanPanel/span-card",
   "stefmde/HomeAssistant-TwitchFollowedLiveStreamsCard",
   "studiobts/device-pulse-table-card",
   "studiobts/device-pulse-timeline-card",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository. (N/A: this is a plugin/dashboard card)
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/SpanPanel/span-card/releases/tag/v0.8.5>  
Link to successful HACS action (without the `ignore` key): <https://github.com/SpanPanel/span-card/actions/runs/22839183406>  
Link to successful hassfest action (if integration): <N/A - plugin repository>

## Notes

This adds `SpanPanel/span-card` to the default HACS `plugin` index.

`SpanPanel/span-card` is a Lovelace dashboard card for the already listed default HACS integration `SpanPanel/span`, and both repositories are maintained under the same organization.

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->