### PR TITLE
Adds new integration [SmartCircuits-GmbH/WattWaechter_HA_Integration]

### DIFF
--- a/integration
+++ b/integration
@@ -1810,6 +1810,7 @@
   "SLG/home-assistant-whatpulse",
   "sli-cka/karakeep-homeassistant",
   "slydiman/sscpoe",
+  "SmartCircuits-GmbH/WattWaechter_HA_Integration",
   "smarthomeblack/npc",
   "smarthomeblack/zalo_bot",
   "SmartyVan/hass-geolocator",


### PR DESCRIPTION
## Summary

Add [WattWächter Plus](https://github.com/SmartCircuits-GmbH/WattWaechter_HA_Integration) — a Home Assistant integration for WattWächter smart meter energy monitoring devices by SmartCircuits GmbH.

### Features
- Auto-discovery via mDNS/Zeroconf
- Smart meter sensors (energy, power, voltage, current, frequency, power factor)
- Per-phase monitoring (L1, L2, L3)
- OTA firmware updates from Home Assistant
- Dynamic OBIS code detection

### Checklist
- [x] `hacs.json` with name and HA version
- [x] `manifest.json` with all required keys
- [x] GitHub release (v0.1.0)
- [x] Repository description and topics set
- [x] Issues enabled
- [x] HACS validation workflow passing
- [x] Hassfest validation passing
- [x] Brand icons (icon.png, icon@2x.png, logo.png, logo@2x.png)
- [x] Apache 2.0 license
- [x] Comprehensive README