### PR TITLE
Adds new integration [n-IA-hane/esphome-intercom]

### DIFF
--- a/integration
+++ b/integration
@@ -1402,6 +1402,7 @@
   "myTselection/smartschool_ha",
   "myTselection/telenet_telemeter",
   "N0ciple/hass-kef-connector",
+  "n-IA-hane/intercom-api",
   "Nailik/blanco_unit",
   "Nailik/vogels_motion_mount_ble",
   "natekspencer/ha-atmo",

--- a/integration
+++ b/integration
@@ -1570,6 +1570,7 @@
   "myTselection/pixometer",
   "myTselection/smartschool_ha",
   "myTselection/telenet_telemeter",
+  "n-IA-hane/esphome-intercom",
   "N0ciple/hass-kef-connector",
   "Nailik/blanco_unit",
   "Nailik/vogels_motion_mount_ble",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/n-IA-hane/esphome-intercom/releases/tag/v2026.6.0>
Link to successful HACS action (without the `ignore` key): <https://github.com/n-IA-hane/esphome-intercom/actions/runs/26641865827>
Link to successful hassfest action (if integration): <https://github.com/n-IA-hane/esphome-intercom/actions/runs/26641865767>

## Reviewer update

This PR has been updated after the previous review:

- The repository entry now uses the canonical name: `n-IA-hane/esphome-intercom`.
- The entry is sorted correctly in the `integration` list.
- The previously referenced issue has been closed: <https://github.com/n-IA-hane/esphome-intercom/issues/25>.
- The current release is now `v2026.6.0`.
- The repository documents the current minimum versions:
  - Home Assistant Core `2026.5.0` or newer
  - ESPHome `2026.5.x` or newer
- HACS validation and hassfest both pass on the release commit.

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->
