### PR TITLE
Adds new integration [dzerik/xiaomi_airpurifier_ng]

### DIFF
--- a/integration
+++ b/integration
@@ -601,6 +601,7 @@
   "dvd-dev/hilo",
   "dwainscheeren/dwains-lovelace-dashboard",
   "dylandoamaral/trakt-integration",
+  "dzerik/xiaomi_airpurifier_ng",
   "earendil06/Windy-Webcams",
   "EarthGoodness/egi",
   "ebertek/ssm",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/dzerik/xiaomi_airpurifier_ng/releases/tag/v3.1.0>
Link to successful HACS action (without the `ignore` key): <https://github.com/dzerik/xiaomi_airpurifier_ng/actions/runs/22874522470>
Link to successful hassfest action (if integration): <https://github.com/dzerik/xiaomi_airpurifier_ng/actions/runs/22874522470>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->