### PR TITLE
Adds new integration [teh-hippo/ha-porkbun]

### DIFF
--- a/integration
+++ b/integration
@@ -1916,6 +1916,7 @@
   "tcarwash/home-assistant_noaa-space-weather",
   "tdragon/reef-pi-hass-custom",
   "tefinger/hass-brematic",
+  "teh-hippo/ha-porkbun",
   "tehlers/ha-drooff-fireplus",
   "TekniskSupport/home-assistant-resrobot",
   "tetele/hvac_group",


### PR DESCRIPTION
## Checklist

- [x] I am the owner or a major contributor to this repository.
- [x] I have read and agree to the [inclusion requirements](https://hacs.xyz/docs/publish/include/).
- [x] The repository passes all [HACS Action](https://github.com/hacs/action) checks without ignores.
- [x] The repository passes [Hassfest](https://github.com/home-assistant/actions#hassfest).
- [x] The repository has a GitHub release (not just a tag).
- [x] Brand assets are included in the repository.

## What does this integration do?

**Porkbun DDNS** — automatically updates Porkbun DNS records with your current public IP address, running as a Home Assistant service integration.

Repository: https://github.com/teh-hippo/ha-porkbun