### PR TITLE
Add wooniot/ha-digitalstrom-smart

### DIFF
--- a/integration
+++ b/integration
@@ -2105,6 +2105,7 @@
   "WJDDesigns/ultra-card-connect",
   "wlcrs/huawei_solar",
   "wolffshots/hass-audiobookshelf",
+  "wooniot/ha-digitalstrom-smart",
   "Woulve/phonetrack",
   "Wouter0100/homeassistant-nanokvm",
   "wrodie/ha_behringer_mixer",


### PR DESCRIPTION
## Add [digitalSTROM Smart](https://github.com/wooniot/ha-digitalstrom-smart)

Zone-based, event-driven Home Assistant integration for **digitalSTROM** home automation systems.

### Why this integration?
- **Scene-based control** - one command controls all devices in a zone (minimal bus load)
- **Real-time event subscription** - instant state updates, no polling
- **Local and cloud** connection support
- ~0.4 requests/min vs ~50+ requests/min with traditional polling

### Features
- Zone-based lights with brightness
- Zone-based covers (blinds/shades)
- Scene activation (dS presets)
- Temperature sensors per zone
- Energy monitoring
- Pause/Resume for dS Configurator use

Developed by [Woon IoT BV](https://wooniot.nl) - professional digitalSTROM installers.