### PR TITLE
feat: Add jrhubott/adaptive-cover-pro integration

### DIFF
--- a/integration
+++ b/integration
@@ -1033,6 +1033,7 @@
   "jpawlowski/hass.tibber_prices",
   "jrfernandes/ontario_energy_board",
   "jrgim/Zaragoza_tram",
+  "jrhubott/adaptive-cover-pro",
   "jrmattila/ha-elenia",
   "jscruz/sensor.carbon_intensity_uk",
   "jseidl/magic-areas",


### PR DESCRIPTION
Adds `jrhubott/adaptive-cover-pro` to the HACS default integrations list.

Adaptive Cover Pro is a Home Assistant custom integration that automatically
controls vertical blinds, horizontal awnings, and tilted/venetian blinds based
on the sun's position.

- Repository: https://github.com/jrhubott/adaptive-cover-pro
- Current version: v2.7.10
- Category: Integration

Alphabetically inserted between `jrgim/Zaragoza_tram` and `jrmattila/ha-elenia`.