### PR TITLE
Add smkrv/ha-weathersense-card

### DIFF
--- a/plugin
+++ b/plugin
@@ -464,6 +464,7 @@
   "silviokennecke/ha-public-transport-connection-card",
   "skydarc/Venus-OS-Dashboard",
   "slipx06/sunsynk-power-flow-card",
+  "smkrv/ha-weathersense-card",
   "snootched/cb-lcars",
   "soestin/hass_periodic_card_reload",
   "sonite/particle-cloud-card",


### PR DESCRIPTION
## Repository

https://github.com/smkrv/ha-weathersense-card

## Description

Custom Lovelace card for the [WeatherSense integration](https://github.com/smkrv/ha-weathersense) — displays climate comfort data with hybrid glass+material design, dynamic color themes (11 comfort levels), 3 display scales, per-metric unit configuration, and 7-language support.

## Category

Plugin (Dashboard)

## Checklist

- [x] Repository is public
- [x] Repository has a description
- [x] Repository has topics
- [x] Repository has `hacs.json`
- [x] Repository has a README
- [x] At least one published release (v2.0.0)
- [x] HACS validation action passes