### PR TITLE
Add usersaynoso/ha-cudy-router

### DIFF
--- a/integration
+++ b/integration
@@ -2042,6 +2042,7 @@
   "untitledlt/ha-miesto-plauciai",
   "urbanframe/sunlight-intensity",
   "user2684/imou_life",
+  "usersaynoso/ha-cudy-router",
   "v1ack/lelight",
   "vakio-ru/vakio_atmosphere",
   "vakio-ru/vakio_base_smart",


### PR DESCRIPTION
## Summary
- add `usersaynoso/ha-cudy-router` to the HACS default integration list

## Validation
- repository includes HACS and Hassfest workflows
- release `v1.2.4` is published
