### PR TITLE
Added Frickeldave/homeassistant-airflow to plugins

### DIFF
--- a/plugin
+++ b/plugin
@@ -166,6 +166,7 @@
   "francois-le-ko4la/lovelace-entity-progress-card",
   "fratsloos/fr24_card",
   "FredrikM97/mealplan-card",
+  "Frickeldave/homeassistant-airflow",
   "frozenwizard/onlylocklock",
   "fufar/simple-clock-card",
   "gaco79/gcclock-words",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/Frickeldave/homeassistant-airflow/releases/tag/1.0.0>
Link to successful HACS action (without the `ignore` key): <https://github.com/Frickeldave/homeassistant-airflow/actions/runs/23019963590>
Link to successful hassfest action (if integration): <>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->