### PR TITLE
Adds new integration [koosoli/ESPHomeDesigner]

### DIFF
--- a/integration
+++ b/integration
@@ -1126,6 +1126,7 @@
   "kongo09/philips-airpurifier-coap",
   "konnected-io/noonlight-hass",
   "koosoli/ESPHomeDesigner",
+  "koosoli/Leneda-integration",
   "Korkuttum/blynk",
   "Korkuttum/tuya_body_fat_scale",
   "Korkuttum/tuya_heat_pump",

--- a/integration
+++ b/integration
@@ -1125,7 +1125,7 @@
   "kongo09/hass-dell-printer",
   "kongo09/philips-airpurifier-coap",
   "konnected-io/noonlight-hass",
-  "koosoli/Leneda-integration",
+  "koosoli/ESPHomeDesigner",
   "Korkuttum/blynk",
   "Korkuttum/tuya_body_fat_scale",
   "Korkuttum/tuya_heat_pump",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/koosoli/ESPHomeDesigner/releases/tag/v1.0.0-rc.7.1>
Link to successful HACS action (without the `ignore` key): <https://github.com/koosoli/ESPHomeDesigner/actions/runs/22758223822>
Link to successful hassfest action (if integration): <https://github.com/koosoli/ESPHomeDesigner/actions/runs/22758223821>

## Notes

- This is a fresh HACS submission on a clean branch created from the latest upstream master.
- The default-repository change is limited to adding `koosoli/ESPHomeDesigner` to the `integration` list.
- The existing `koosoli/Leneda-integration` entry remains unchanged.
- The integration repository includes both the HACS validation workflow and the hassfest workflow.
- The HACS workflow does not use the `ignore` exemption.
- The current release used for validation is `v1.0.0-rc.7.1`.
