### PR TITLE
Add othorg WIT integration and RV card to HACS default lists

### DIFF
--- a/integration
+++ b/integration
@@ -1501,6 +1501,7 @@
   "osk2/wafflecity-custom-component",
   "osohotwateriot/osoenergy_community",
   "OStrama/weishaupt_modbus",
+  "othorg/wit-901-wifi-ha-integration",
   "OtisPresley/control4-mediaplayer",
   "OtisPresley/snmp-switch-manager",
   "oven-lab/tuya_cloud_map_extractor",
@@ -2171,6 +2172,5 @@
   "zubir2k/homeassistant-esolatgps",
   "zubir2k/homeassistant-esolattakwim",
   "zulufoxtrot/ha-zyxel",
-  "zupancicmarko/JellyHA",
-  "Zwer2k/ha-pca301"
+  "zupancicmarko/JellyHA"
 ]

--- a/plugin
+++ b/plugin
@@ -386,6 +386,7 @@
   "Nyaran/myjdownloader-card",
   "ofekashery/vertical-stack-in-card",
   "omachala/ha-treemap-card",
+  "othorg/rv-level-ha-lovelace-card",
   "OtisPresley/snmp-switch-manager-card",
   "ownbee/bootstrap-grid-card",
   "pacemaker82/Compact-Power-Card",
@@ -565,6 +566,5 @@
   "yohaybn/lovelace-aliexpress-package-card",
   "ytilis/hass-progress-bar-feature",
   "zanac/temperature-heatmap-card",
-  "zanna-37/hass-swipe-navigation",
-  "zeronounours/lovelace-energy-entity-row"
+  "zanna-37/hass-swipe-navigation"
 ]


### PR DESCRIPTION
This PR adds two repositories to HACS default:

- Integration: `othorg/wit-901-wifi-ha-integration`
- Plugin: `othorg/rv-level-ha-lovelace-card`

Checklist:
- [x] Public repositories
- [x] `hacs.json` present
- [x] CI passing
- [x] Tagged releases available
- [x] README with installation instructions
