### PR TITLE
Add othorg/wit-901-wifi-ha-integration to integration list

### DIFF
--- a/integration
+++ b/integration
@@ -1501,6 +1501,7 @@
   "osk2/wafflecity-custom-component",
   "osohotwateriot/osoenergy_community",
   "OStrama/weishaupt_modbus",
+  "othorg/wit-901-wifi-ha-integration",
   "OtisPresley/control4-mediaplayer",
   "OtisPresley/snmp-switch-manager",
   "oven-lab/tuya_cloud_map_extractor",
@@ -2171,6 +2172,5 @@
   "zubir2k/homeassistant-esolatgps",
   "zubir2k/homeassistant-esolattakwim",
   "zulufoxtrot/ha-zyxel",
-  "zupancicmarko/JellyHA",
-  "Zwer2k/ha-pca301"
+  "zupancicmarko/JellyHA"
 ]


### PR DESCRIPTION
Adds `othorg/wit-901-wifi-ha-integration` to the HACS default `integration` list.

Repository checks:
- Public repository
- `hacs.json` present
- CI and tests passing
- Tagged releases available
- README with installation instructions