### PR TITLE
Add othorg/rv-level-ha-lovelace-card to plugin list (single line)

### DIFF
--- a/plugin
+++ b/plugin
@@ -386,6 +386,7 @@
   "Nyaran/myjdownloader-card",
   "ofekashery/vertical-stack-in-card",
   "omachala/ha-treemap-card",
+  "othorg/rv-level-ha-lovelace-card",
   "OtisPresley/snmp-switch-manager-card",
   "ownbee/bootstrap-grid-card",
   "pacemaker82/Compact-Power-Card",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [ x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [ x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [ x] The actions are passing without any disabled checks in my repository.
- [ x] I've added a link to the action run on my repository below in the links section.
- [ x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: https://github.com/othorg/rv-level-ha-lovelace-card/releases/tag/v0.6.1
Link to successful HACS action (without the `ignore` key): https://github.com/othorg/rv-level-ha-lovelace-card/actions/workflows/ci.yml
Link to successful hassfest action (if integration): N/A (plugin)

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->