### PR TITLE
Add strecklecsuk/water_softener

### DIFF
--- a/integration
+++ b/integration
@@ -1861,6 +1861,7 @@
   "stockhausenj/ha-stt-parasail",
   "stockhausenj/ha-tts-parasail",
   "stoppegp/ha-dwd-precipitation-forecast",
+  "strecklecsuk/water_softener",
   "Strixx76/mold_risk_index",
   "Strixx76/samsungwam",
   "strecklecsuk/water_softener",


### PR DESCRIPTION
## Description

Adds the Water Softener Manager integration to the HACS default store.

- Tracks resin ion-exchange capacity in liters
- Detects regeneration cycles automatically (dual-sensor and single-sensor modes)
- Estimates next regeneration date based on 7-day consumption average
- Custom Lovelace card with animated SVG tank and visual editor
- Multi-device support (multiple softeners)
- Configurable notifications

## Checklist

- [x] Repository is public
- [x] hacs.json is present and valid
- [x] manifest.json with all required fields (v1.3.0)
- [x] config_flow: true
- [x] services.yaml documented
- [x] brand/ assets included
- [x] GitHub Actions: HACS validation passing
- [x] GitHub Actions: hassfest passing
- [x] LICENSE (MIT)
- [x] README.md