### PR TITLE
Adds new integration [simplytoast1/Notify-for-HomeAssistant]

### DIFF
--- a/integration
+++ b/integration
@@ -1820,6 +1820,7 @@
   "sillyfrog/Automate-Pulse-v2",
   "sillymoi/homeassistant-infometric",
   "silvanfischer/tuya_sensors",
+  "simplytoast1/Notify-for-HomeAssistant",
   "sir-Unknown/ha_City-Visitor-Parking",
   "sirkirby/unifi-network-rules",
   "Skarbo/hass-scinan-thermostat",


### PR DESCRIPTION
## Link to the repository

https://github.com/simplytoast1/Notify-for-HomeAssistant

## Why does HACS need to know about this?

Notify! Alerts is a custom integration that enables push notifications from Home Assistant to iOS/Android devices via the Notify webhook API. It provides a native HA notification service with UI-based configuration, rich notifications (custom icons, grouping), and multi-device support.

## Checklist

- [x] The repository has a valid `hacs.json` file
- [x] The repository has a valid `manifest.json` file with all required fields
- [x] The repository passes HACS Action validation
- [x] The repository passes Hassfest validation
- [x] A GitHub release has been published (v1.0.2)
- [x] Brand icons are included via the new HA 2026.3 `brand/` directory