### PR TITLE
Add ScentAirHABridge

### DIFF
--- a/integration
+++ b/integration
@@ -1820,6 +1820,7 @@
   "sillyfrog/Automate-Pulse-v2",
   "sillymoi/homeassistant-infometric",
   "silvanfischer/tuya_sensors",
+  "simplytoast1/ScentAirHABridge",
   "sir-Unknown/ha_City-Visitor-Parking",
   "sirkirby/unifi-network-rules",
   "Skarbo/hass-scinan-thermostat",


### PR DESCRIPTION
## Repository

https://github.com/simplytoast1/ScentAirHABridge

## Category

integration

## Description

ScentAir custom integration for Home Assistant - allows control of ScentAir scent machines through Home Assistant.