### PR TITLE
Adds new integration [simplytoast1/Notify-for-HomeAssistant]

### DIFF
--- a/integration
+++ b/integration
@@ -1820,6 +1820,7 @@
   "sillyfrog/Automate-Pulse-v2",
   "sillymoi/homeassistant-infometric",
   "silvanfischer/tuya_sensors",
+  "simplytoast1/Notify-for-HomeAssistant",
   "sir-Unknown/ha_City-Visitor-Parking",
   "sirkirby/unifi-network-rules",
   "Skarbo/hass-scinan-thermostat",


### PR DESCRIPTION
## Link to the repository

https://github.com/simplytoast1/Notify-for-HomeAssistant

## Link to the latest release

https://github.com/simplytoast1/Notify-for-HomeAssistant/releases/tag/v1.0.2

## Link to CI action runs

https://github.com/simplytoast1/Notify-for-HomeAssistant/actions

## What does the integration do?

Notify! Alerts is a custom integration that enables push notifications from Home Assistant to iOS/Android devices via the Notify webhook API. It provides a native HA notification service with UI-based configuration, rich notifications (custom icons, grouping), and multi-device support.