### PR TITLE
Add iosue-iulianus/homeassistant-pipboy-theme to themes

### DIFF
--- a/theme
+++ b/theme
@@ -47,6 +47,7 @@
   "home-assistant-community-themes/teal",
   "home-assistant-community-themes/vaporwave-pink",
   "houtknots/UglyChristmas-Theme",
+  "iosue-iulianus/homeassistant-pipboy-theme",
   "JOHLC/transparentblue",
   "JuanMTech/google-theme",
   "JuanMTech/google_dark_theme",


### PR DESCRIPTION
## Description

A Fallout Pip-Boy / Vault-Tec terminal aesthetic theme for Home Assistant, featuring phosphor CRT effects, scanlines, vignette, and monospace terminal typography.

Two variants included:
- **Pip-Boy** — phosphor green on near-black
- **Pip-Boy Amber** — burnt orange-gold on warm near-black

## Repository

https://github.com/iosue-iulianus/homeassistant-pipboy-theme

## Checklist

- [x] `hacs.json` present with `name` and `homeassistant` fields
- [x] Themes located in `themes/` directory
- [x] GitHub Actions HACS validation workflow passing
- [x] Repository has description and topics set
- [x] Repository is public

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: https://github.com/iosue-iulianus/homeassistant-pipboy-theme/releases/tag/v1.0.1
Link to successful HACS action (without the ignore key): https://github.com/iosue-iulianus/homeassistant-pipboy-theme/actions/runs/23115407806/job/67139988501
Link to successful hassfest action (if integration): <>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->