### PR TITLE
Add FX6W9WZK/ha-audac

### DIFF
--- a/integration
+++ b/integration
@@ -721,6 +721,7 @@
   "fustom/ariston-remotethermo-home-assistant-v3",
   "futuretense/keymaster",
   "FWeinb/ha-sg-150",
+  "FX6W9WZK/ha-audac",
   "g470258/hass-esplus",
   "g4bri3lDev/munich_public_transport",
   "gabest11/homeassistant-brother_scanner",


### PR DESCRIPTION
## Add to HACS Default

**Repository:** https://github.com/FX6W9WZK/ha-audac

**What is it?**
Home Assistant integration for controlling Audac professional audio devices:
- **MTX48 / MTX88** – Audio matrix with zone control (volume, mute, source, bass, treble, zone coupling)
- **XMP44** – Modular audio system with SourceCon modules (DMP40, TMP40, IMP40, MMP40, FMP40, BMP40, NMP40)

Communicates directly via TCP/IP. Ships with custom Bubble Card-inspired Lovelace cards for both devices.

**Checklist:**
- [x] Repository is public and hosted on GitHub
- [x] Has a valid `hacs.json` with `name`
- [x] Has at least one GitHub release
- [x] Has `manifest.json` with all required keys
- [x] Has brand images (`brand/` directory)
- [x] CI: HACS validation + Hassfest passing
- [x] README has images