### PR TITLE
Add cubinet-code/parqet-homeassistant-companion

### DIFF
--- a/plugin
+++ b/plugin
@@ -63,6 +63,7 @@
   "ciotlosm/lovelace-thermostat-dark-card",
   "Clooos/Bubble-Card",
   "Codegnosis/givtcp-battery-card",
+  "cubinet-code/parqet-homeassistant-companion",
   "custom-cards/beer-card",
   "custom-cards/bignumber-card",
   "custom-cards/button-card",


### PR DESCRIPTION
## Add Parqet Home Assistant Companion

**Repository:** https://github.com/cubinet-code/parqet-homeassistant-companion  
**Category:** plugin (frontend / Lovelace card)

### What it does

A Lovelace custom card that connects to [Parqet](https://parqet.com) — a portfolio tracking platform — and displays real-time portfolio data directly on a Home Assistant dashboard.

Two card types:
- **`parqet-companion-card`** — full tabbed card with Performance, Holdings, and Activities views
- **`parqet-kpi-card`** — compact single-metric tile (total value, XIRR, returns, dividends…) for grid dashboards

Authentication via OAuth 2.0 PKCE. No secrets stored on the server.

### Checklist

- [x] `hacs.json` present with `name` and `filename`
- [x] JS release asset attached to latest release (v0.3.6)
- [x] Not a pre-release
- [x] `README.md` present
- [x] Repository is public and not a fork
- [x] Description and topics set on GitHub