### PR TITLE
Add cubinet-code/parqet-homeassistant-companion

### DIFF
--- a/plugin
+++ b/plugin
@@ -63,6 +63,7 @@
   "ciotlosm/lovelace-thermostat-dark-card",
   "Clooos/Bubble-Card",
   "Codegnosis/givtcp-battery-card",
+  "cubinet-code/parqet-homeassistant-companion",
   "custom-cards/beer-card",
   "custom-cards/bignumber-card",
   "custom-cards/button-card",


### PR DESCRIPTION
## Submission

<!-- Links -->
- Repository: https://github.com/cubinet-code/parqet-homeassistant-companion
- Latest release: https://github.com/cubinet-code/parqet-homeassistant-companion/releases/tag/v0.3.6
- CI: https://github.com/cubinet-code/parqet-homeassistant-companion/actions/runs/23183970636

## Checklist

- [x] This is a plugin (Lovelace frontend card)
- [x] `hacs.json` is present and contains `name` and `filename`
- [x] The JS file is attached as a release asset to the latest release
- [x] The latest release is not a pre-release
- [x] `README.md` is present
- [x] Repository is public and not a fork
- [x] Repository description is set
- [x] Topics are set on the repository
- [x] HACS validation passes (see CI link above)

## Description

A Lovelace custom card that connects to [Parqet](https://parqet.com) (a portfolio tracking platform) and displays real-time portfolio data on a Home Assistant dashboard.

Two card types:
- **`parqet-companion-card`** — tabbed card with Performance, Holdings, and Activities views
- **`parqet-kpi-card`** — compact single-metric tile (total value, XIRR, returns, dividends…) for grid dashboards

Authentication via OAuth 2.0 PKCE. No client secret required.