### PR TITLE
Add liquidmasl/lovelace-arr-media-card to plugin

### DIFF
--- a/plugin
+++ b/plugin
@@ -289,6 +289,7 @@
   "levonisyas/clockpro-card",
   "levonisyas/floor3dpro-card",
   "levonisyas/overlaypro-card",
+  "liquidmasl/lovelace-arr-media-carrd",
   "ljmerza/fitbit-card",
   "ljmerza/github-card",
   "ljmerza/harmony-remote-card",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: https://github.com/Liquidmasl/lovelace-arr-media-carrd/releases/tag/v1.3.3 
Link to successful HACS action (without the `ignore` key): [<>](https://github.com/Liquidmasl/lovelace-arr-media-carrd/actions/runs/23194390223/job/67398687080)
Link to successful hassfest action (if integration): <>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->