### PR TITLE
Adds new plugin [MacSiem/ha-storage-monitor]

### DIFF
--- a/plugin
+++ b/plugin
@@ -315,6 +315,7 @@
   "luixal/lovelace-media-source-image-card",
   "lukevink/lovelace-buien-rain-card",
   "m3tac0de/sofabaton-virtual-remote",
+  "MacSiem/ha-storage-monitor",
   "madmicio/ampli-panel-card",
   "madmicio/channel-pad",
   "madmicio/LG-WebOS-Remote-Control",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/MacSiem/ha-storage-monitor/releases/tag/v4.1.4>
Link to successful HACS action (without the `ignore` key): <https://github.com/MacSiem/ha-storage-monitor/actions/runs/25753165686>
Link to successful hassfest action (if integration): <>
