### PR TITLE
Add pulse-card to plugin dependencies

### DIFF
--- a/plugin
+++ b/plugin
@@ -199,6 +199,7 @@
   "hasl-sensor/lovelace-hasl-departure-card",
   "hasl-sensor/lovelace-hasl-traffic-status-card",
   "hepter/ha-tplink-router-card",
+  "hiall-fyi/pulse-card",
   "homeassistant-extras/adguard-card",
   "homeassistant-extras/device-card",
   "homeassistant-extras/ohm-assistant",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/hiall-fyi/pulse-card/releases/tag/v0.1.0>
Link to successful HACS action (without the `ignore` key): <https://github.com/hiall-fyi/pulse-card/actions/runs/23264771140>
Link to successful hassfest action (if integration): N/A (plugin)
