### PR TITLE
Add szajbergyerek/ha-ship24

### DIFF
--- a/integration
+++ b/integration
@@ -1940,6 +1940,7 @@
   "syssi/xiaomi_fan",
   "syssi/xiaomi_raw",
   "syssi/xiaomiplug",
+  "szajbergyerek/ha-ship24",
   "T-leco/investing_portfolio",
   "t0mer/manish-custom-notifier",
   "t0mer/matterbridge-custom-notifier",


### PR DESCRIPTION
## Proposed change

Add [Ship24 Package Tracker](https://github.com/szajbergyerek/ha-ship24) to the default HACS integration list.

## Checklist

- [x] I have read the [HACS requirements](https://hacs.xyz/docs/publish/requirements)
- [x] The repository is public
- [x] The repository has a description
- [x] The repository has a valid hacs.json
- [x] The repository has a valid manifest.json
- [x] The repository has at least one release (v1.0.9)
- [x] Brand PR submitted: https://github.com/home-assistant/brands/pull/10000