### PR TITLE
Add Vent-Axia Svara BLE integration

### DIFF
--- a/integration
+++ b/integration
@@ -543,6 +543,7 @@
   "Desmond-Dong/zhipuai",
   "devinslick/home-assistant-fmd",
   "dext0r/yandex_smart_home",
+  "dfanica/vent-axia-svara-ble",
   "dgomes/ha_erse",
   "dgomes/ha_generic_water_heater",
   "dhover/ha-cumulusmx",


### PR DESCRIPTION
## Checklist

- [x] The repository is publicly available
- [x] The repository follows the HACS requirements
- [x] I have a working release
- [x] I have tested my repository in HACS
- [x] I have added my repository to the correct category alphabetically

## Repository

dfanica/vent-axia-svara-ble

## Category

integration

## Description

Unofficial Home Assistant integration for Vent-Axia Svara fans over Bluetooth Low Energy (BLE).