### PR TITLE
Add wizz666/homeassistant-ai-hub and wizz666/homeassistant-smhi-brandrisk

### DIFF
--- a/integration
+++ b/integration
@@ -2143,6 +2143,8 @@
   "wimpie70/ramses_extras",
   "wisedeer2022/ha_wisecloud_home",
   "wizmo2/zidoo-player",
+  "wizz666/homeassistant-ai-hub",
+  "wizz666/homeassistant-smhi-brandrisk",
   "WJDDesigns/ultra-card-connect",
   "WLANThermo-nano/homeassistant",
   "wlcrs/huawei_solar",


### PR DESCRIPTION
## New integrations

### AI Hub (`wizz666/homeassistant-ai-hub`)
Centralized API key manager for Home Assistant. Enter Groq, Anthropic, OpenAI, OpenRouter and Ollama keys once — synced automatically to all AI-powered integrations.

- Config flow UI
- Keys stored securely in HA config entries
- Auto-syncs to `input_text` entities
- No dependencies, no YAML editing required

### SMHI Brandrisk (`wizz666/homeassistant-smhi-brandrisk`)
Fire risk and weather warning sensors for Sweden, powered by SMHI open data APIs.

- FWI fire weather index (class 1–6)
- SNOW1g frozen precipitation risk (year-round)
- IBW weather warnings (Yellow/Orange/Red)
- Config flow with coordinate validation
- Multiple locations supported
- Swedish and English translations
- Data: SMHI Open Data (CC BY 4.0)