### PR TITLE
Add nimbus-weather-card

### DIFF
--- a/plugin
+++ b/plugin
@@ -341,7 +341,7 @@
   "mathoudebine/homeassistant-browser-control-card",
   "mattieha/select-list-card",
   "mawinkler/astroweather-card",
-  "maxfok/nimbus-weather-card",
+  "maxfok/nimbus-weather-card", 
   "maxwroc/battery-state-card",
   "maxwroc/github-flexi-card",
   "maybetaken/ha-makeskyblue-mppt-card",


### PR DESCRIPTION
This PR adds the Nimbus Weather Card to the default HACS plugins list.

Repository: https://github.com/maxfok/nimbus-weather-card
[nimbus_weather_card_preview.html](https://github.com/user-attachments/files/26144591/nimbus_weather_card_preview.html)


The card is an Apple Weather‑inspired custom card for Home Assistant with particle effects, moon phases, and dynamic backgrounds.