### PR TITLE
Add nimbus-weather-card

### DIFF
--- a/plugin
+++ b/plugin
@@ -341,7 +341,7 @@
   "mathoudebine/homeassistant-browser-control-card",
   "mattieha/select-list-card",
   "mawinkler/astroweather-card",
-  "maxfok/nimbus-weather-card",
+  "maxfok/nimbus-weather-card", 
   "maxwroc/battery-state-card",
   "maxwroc/github-flexi-card",
   "maybetaken/ha-makeskyblue-mppt-card",


### PR DESCRIPTION
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!  
Make sure to check out the guide here: [https://hacs.xyz/docs/publish/start](https://hacs.xyz/docs/publish/start)

## Checklist
- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository (if integration).
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links
Link to current release: https://github.com/maxfok/nimbus-weather-card/releases/tag/v1.0.0  
Link to successful HACS action (without the `ignore` key): https://github.com/maxfok/nimbus-weather-card/actions/runs/23373157710

---

This PR adds the Nimbus Weather Card to the default HACS plugins list.

Repository: https://github.com/maxfok/nimbus-weather-card

- [Latest release](https://github.com/maxfok/nimbus-weather-card/releases/tag/v1.0.0)
- [CI action run](https://github.com/maxfok/nimbus-weather-card/actions/runs/23373157710)