### PR TITLE
Update integration

### DIFF
--- a/integration
+++ b/integration
@@ -276,7 +276,6 @@
   "blaineventurine/simple_inventory",
   "blakeblackshear/frigate-hass-integration",
   "blear/hasslife",
-  "blindlight86/HA_USR-R16",
   "bm1549/home-assistant-frigidaire",
   "bobbesnl/growatt_thor",
   "bobsilesia/oblamatik",


### PR DESCRIPTION

I removed the link to https://github.com/blindlight86/HA_USR-R16 because the repository has been unmaintained for 4 years and is no longer compatible with Home Assistant version 2025.6+. Issue #6 regarding this breakage was ignored, and PR #7 (which I submitted to fix it) was closed without consideration. Therefore, I am proposing to replace it with my up-to-date repository: ha-usr-r16-component (See PR #6441).

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: https://github.com/Elwinmage/ha-usr-r16-component/releases/tag/v2.0.0
Link to successful HACS action (without the `ignore` key): https://github.com/Elwinmage/ha-usr-r16-component/actions/runs/23376293036
Link to successful hassfest action (if integration): https://github.com/Elwinmage/ha-usr-r16-component/actions/runs/23376293036

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->