### PR TITLE
Add kbroadbent/home-assistant-gabb

### DIFF
--- a/integration
+++ b/integration
@@ -1091,6 +1091,7 @@
   "Kartax/home-assistant-binance",
   "KartoffelToby/better_thermostat",
   "kattcrazy/tuya_unsupported_sensors",
+  "kbroadbent/home-assistant-gabb",
   "kclif9/hassactronneo",
   "kcoffau/AUS_BOM_Space_Weather_Alert_System",
   "kcofoni/ha-netro-watering",


### PR DESCRIPTION
Gabb Wireless integration for Home Assistant — exposes device location tracking and battery level for Gabb kids' smartwatch/phone devices.

Repository: https://github.com/kbroadbent/home-assistant-gabb