### PR TITLE
Add luizof/mega_s4_ha_integration

### DIFF
--- a/integration
+++ b/integration
@@ -1243,6 +1243,7 @@
   "lufton/ha_telegram_client",
   "luis-garza/movistar_rft8115vw",
   "lukegackle/Home-Assistant-User-Info-Integration",
+  "luizof/mega_s4_ha_integration",
   "luuuis/hass_wibeee",
   "lymanepp/ha-epson-workforce",
   "M1R4G376/New_bestway_spa",


### PR DESCRIPTION
## Checklist

- [x] I am the owner of the repository.
- [x] I have read the [requirements](https://hacs.xyz/docs/publish/start/).
- [x] I have read the [inclusion requirements](https://hacs.xyz/docs/publish/include/).
- [x] The repository has a description on GitHub.
- [x] The repository has topics defined on GitHub.
- [x] The repository has a README.
- [x] The repository has a valid `hacs.json` file.
- [x] The repository has a valid `manifest.json` file with `issue_tracker`.
- [x] The repository has releases (not just tags).
- [x] The repository has brand images (`icon.png` and `logo.png`).
- [x] The [Hassfest](https://github.com/luizof/mega_s4_ha_integration/actions/workflows/hassfest.yaml) action passes.
- [x] The [HACS Validation](https://github.com/luizof/mega_s4_ha_integration/actions/workflows/hacs.yaml) action passes.
- [x] This does not override a core integration.
- [x] This is not for alpha or beta testing of a core integration.

## What does the integration do?

This custom integration adds [MEGA S4 Object Storage](https://mega.io/objectstorage) as a backup location for Home Assistant (2025.1+).

MEGA S4 is an S3-compatible object storage service. The official Home Assistant AWS S3 integration explicitly blocks non-Amazon endpoints (`amazonaws.com` domain check), so it cannot be used with MEGA S4.

This integration implements the native `BackupAgent` interface and integrates seamlessly with Home Assistant's built-in backup system (automatic backups, retention policies, etc.).

### Features
- Native BackupAgent for HA 2025.1+ backup system
- All MEGA S4 regions supported (Amsterdam, Bettembourg, Montreal, Vancouver)
- Multipart upload for large backups (>20 MiB)
- Path-style S3 addressing with SigV4 signatures
- Optional prefix/folder support
- English and Portuguese (Brazil) translations

### Repository
https://github.com/luizof/mega_s4_ha_integration