### PR TITLE
Add luizof/ha_multiroom

### DIFF
--- a/integration
+++ b/integration
@@ -1243,6 +1243,7 @@
   "lufton/ha_telegram_client",
   "luis-garza/movistar_rft8115vw",
   "lukegackle/Home-Assistant-User-Info-Integration",
+  "luizof/ha_multiroom",
   "luuuis/hass_wibeee",
   "lymanepp/ha-epson-workforce",
   "M1R4G376/New_bestway_spa",


### PR DESCRIPTION
## Checklist

- [x] I am the owner of the repository.
- [x] I have read the [requirements](https://hacs.xyz/docs/publish/start/).
- [x] I have read the [inclusion requirements](https://hacs.xyz/docs/publish/include/).
- [x] The repository has a description on GitHub.
- [x] The repository has topics defined on GitHub.
- [x] The repository has a README.
- [x] The repository has a valid `hacs.json` file.
- [x] The repository has a valid `manifest.json` file with `issue_tracker`.
- [x] The repository has releases (not just tags).
- [x] The repository has brand images (`icon.png` and `logo.png`).
- [x] The [Hassfest](https://github.com/luizof/ha_multiroom/actions/workflows/hassfest.yaml) action passes.
- [x] The [HACS Validation](https://github.com/luizof/ha_multiroom/actions/workflows/hacs.yaml) action passes.
- [x] This does not override a core integration.
- [x] This is not for alpha or beta testing of a core integration.

## What does the integration do?

This custom integration adds support for PMR7-based multiroom audio systems in Home Assistant.

It communicates via a text-based TCP protocol (port 1024) with the multiroom device and exposes each of the 6 audio zones as a `media_player` entity with volume control, mute, source selection, and power on/off.

### Features
- 6-zone media player entities
- Volume set / mute / step per zone
- 7 input source selection per zone
- Global power on/off
- Auto-reconnect on connection drop
- Polling via GETALL command (10s interval)
- English and Portuguese (Brazil) translations

### Repository
https://github.com/luizof/ha_multiroom