### PR TITLE
Add PowderK/Energierechner-HA

### DIFF
--- a/integration
+++ b/integration
@@ -1621,6 +1621,7 @@
   "Poshy163/HomeAssistant-Sharesight",
   "postlund/dlink_hnap",
   "Pouzor/freebox_player",
+  "PowderK/Energierechner-HA",
   "ppaglier/voltalis-homeassistant",
   "prairiesnpr/hass-tdameritrade",
   "prestomation/resmed_myair_sensors",


### PR DESCRIPTION
## Add new integration: Energierechner

**Repository:** https://github.com/PowderK/Energierechner-HA

### What does this integration do?

Energierechner is a Home Assistant integration that calculates electricity costs with dynamic tariff periods, day/night tariffs and flexible time-range aggregation.

**Features:**
- Multiple tariff periods (e.g. to track price increases over time)
- Day/night tariff support with configurable times
- Sensors for: Today, Yesterday, Current Week, Previous Week, Current Month, Last Month, Current Year, Last Year
- PV feed-in support (revenue tracking)
- Monthly balance calculation (advance payment vs actual costs)
- Every metric as its own sensor entity (optimal for dashboards)
- Full UI configuration (no YAML required)

**Checklist:**
- [x] The repository uses [a supported structure](https://hacs.xyz/docs/publish/include)
- [x] A [GitHub release](https://github.com/PowderK/Energierechner-HA/releases) is available with the correct format
- [x] The integration is unique and not already in the list
- [x] The repository has a valid `manifest.json`
- [x] The repository has a `hacs.json`