### PR TITLE
Add MQTT-Remote-Buttons-Remap to integration list

### DIFF
--- a/integration
+++ b/integration
@@ -641,6 +641,7 @@
   "elden1337/hass-peaqnext",
   "ElectroceanTech/HomeAssistant",
   "Elijaht-dev/ovh_ipv6",
+  "elik745i/MQTT-Remote-Buttons-Remap",
   "elsbrock/cowboy-ha",
   "Elwinmage/ha-reefbeat-component",
   "emanuelegreco29/Ksenia_Lares_4.0-HASS_Addon",


### PR DESCRIPTION
## Checklist

- [x] I am the owner or a major contributor of the repository.
- [x] The repository is public and hosted on GitHub.
- [x] The repository can be added to HACS as a custom repository.
- [x] The repository includes the HACS validation workflow.
- [x] The repository includes Hassfest.
- [x] The repository has at least one GitHub release.
- [x] I added the repository to the correct category file in alphabetical order.
- [x] This PR is editable by HACS maintainers.

## Repository

- Repository: https://github.com/elik745i/MQTT-Remote-Buttons-Remap
- Category: integration

## Notes

- This integration provides config-flow based remapping of MQTT-discovered ESP32 remote button actions to Home Assistant entities.