### PR TITLE
Add phismith91/luxorliving

### DIFF
--- a/integration
+++ b/integration
@@ -1582,6 +1582,7 @@
   "Phil-Barker/hass-bosch-ebike",
   "Phil7989/advanced_snapshot",
   "philrenda/precipitation-radial-card",
+  "phismith91/luxorliving",
   "Pho3niX90/solis_modbus",
   "phoinixgrr/sigma_connect_ha",
   "physje/waterinfo",


### PR DESCRIPTION
## Checklist

- [x] Repository is public
- [x] Repository has a description
- [x] Repository has topics set (`homeassistant`, `hacs-integration`)
- [x] `validate-hacs` passes without `continue-on-error` or `ignore`
- [x] `validate-hassfest` passes
- [x] Stable release available: v1.1.3

## Integration info

- **Repository:** phismith91/luxorliving
- **Domain:** `luxor_living`
- **Name:** LUXORliving
- **Description:** Home Assistant integration for Theben LUXORliving KNX systems via the BAOS IP1 gateway
- **Validate run:** https://github.com/phismith91/luxorliving/actions/runs/23436993238