### PR TITLE
Add cryptotomte/ev-load-balancer

### DIFF
--- a/integration
+++ b/integration
@@ -409,6 +409,7 @@
   "crankynetman/ha-cumtd",
   "Crazy-Duck/home-assistant-fiftyfive",
   "CreasolTech/home-assistant-creasol-dombus",
+  "cryptotomte/ev-load-balancer",
   "CubicPill/china_southern_power_grid_stat",
   "CumpsD/home-assistant-leo-ntp",
   "Currency-One/walutomat-ha",


### PR DESCRIPTION
## New integration

**Repository:** https://github.com/cryptotomte/ev-load-balancer

**Description:** Dynamic load balancing for EV chargers in Home Assistant. Measures current per phase at the main fuse and adjusts the charger's output power in real time to prevent the fuse from tripping. Supports phase switching (1↔3 phase), failsafe modes and charger profiles. MVP: go-e Gemini flex.