### PR TITLE
Add simplytoast1/ha-ring-smoke-detectors

### DIFF
--- a/integration
+++ b/integration
@@ -1852,6 +1852,7 @@
   "sillyfrog/Automate-Pulse-v2",
   "sillymoi/homeassistant-infometric",
   "silvanfischer/tuya_sensors",
+  "simplytoast1/ha-ring-smoke-detectors",
   "sir-Unknown/ha_City-Visitor-Parking",
   "sirkirby/unifi-network-rules",
   "Skarbo/hass-scinan-thermostat",


### PR DESCRIPTION
## Checklist

- [x] I am the owner/major contributor of the repository I want to add.
- [x] I have read the [integration requirements](https://hacs.xyz/docs/publish/integration/).
- [x] The integration has a valid `manifest.json` with all required fields.
- [x] The integration has a `hacs.json` file.
- [x] The repository has a `brand/` directory with `icon.png`.
- [x] There is a GitHub release published (`v1.0.0`).
- [x] The HACS Action and hassfest validation both pass.
- [x] The repository has a description, topics, and issues enabled.

## What does the integration do?

HACS custom integration for **Kidde/Ring smart smoke and CO detectors** — the WiFi-only, hubless models that are not supported by the standard Ring integration or homebridge-ring.

These devices are only discoverable via WebSocket (not the REST API), and require a direct WebSocket connection that bypasses the Ring hub requirement. This integration handles the full lifecycle: OAuth authentication, location discovery, WebSocket connection, real-time alarm state monitoring (smoke/CO/battery), and auto-reconnect.

## Link to the repository

https://github.com/simplytoast1/ha-ring-smoke-detectors