### PR TITLE
Adds new integration [sxdjt/ha-metar]

### DIFF
--- a/integration
+++ b/integration
@@ -1946,6 +1946,7 @@
   "swartjean/ha-seedboxes-cc",
   "swingerman/ha-dual-smart-thermostat",
   "switch180/RiverLink-SDVoE",
+  "sxdjt/ha-metar",
   "Syonix/ha-wiser-by-feller",
   "syssi/homeassistant-goecharger-mqtt",
   "syssi/nextbike",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/sxdjt/ha-metar/releases/tag/v1.2.1>
Link to successful HACS action (without the `ignore` key): <https://github.com/sxdjt/ha-metar/actions/runs/23467849158>
Link to successful hassfest action (if integration): <https://github.com/sxdjt/ha-metar/actions/runs/23470639751>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->