### PR TITLE
Add golgothen/ha-temp-range-card to plugin list

### DIFF
--- a/plugin
+++ b/plugin
@@ -184,6 +184,7 @@
   "giovannilamarmora/lovelace-material-components",
   "go-hass/go-hass-cards",
   "goggybox/compact-light-card",
+  "golgothen/ha-temp-range-card",
   "grinstantin/todoist-card",
   "guiohm79/custom-gauge-card",
   "guiohm79/dual_gauge",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [X] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [X] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [X] The actions are passing without any disabled checks in my repository.
- [X] I've added a link to the action run on my repository below in the links section.
- [X] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/golgothen/ha-temp-range-card/releases/tag/v1.0.0>
Link to successful HACS action (without the `ignore` key): <https://github.com/Golgothen/ha-temp-range-card/actions/runs/23538187985>
Link to successful hassfest action (if integration): <>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->