### PR TITLE
Add renaudallard/homeassistant_letratag

### DIFF
--- a/integration
+++ b/integration
@@ -1691,6 +1691,7 @@
   "remmob/sht20",
   "remuslazar/homeassistant-carwings",
   "renaudallard/homeassistant_dnsdist",
+  "renaudallard/homeassistant_letratag",
   "ReneNulschDE/ha-mysmartbike",
   "ReneNulschDE/mbapi2020",
   "rexave/hass-orange-internet-on-the-move",


### PR DESCRIPTION
## New integration: DYMO LetraTag

**Repository:** https://github.com/renaudallard/homeassistant_letratag

Custom Home Assistant integration for DYMO LetraTag 200B Bluetooth label printers. BLE protocol fully reverse-engineered from the DYMO LetraTag Connect Android app.

- All HACS and hassfest validations passing
- Brand assets included (icon + logo, 1x and 2x)
- GitHub releases available
- Issues enabled