### PR TITLE
Adds new integration [Koky05/ha-sonicare-battery]

### DIFF
--- a/integration
+++ b/integration
@@ -1145,6 +1145,7 @@
   "kodi1/songpal_m",
   "kodi1/tvh_rec",
   "koenhendriks/ha-eplucon",
+  "Koky05/ha-sonicare-battery",
   "KoljaWindeler/ics",
   "KoljaWindeler/kaco",
   "KoljaWindeler/ytube_music_player",


### PR DESCRIPTION
## Checklist

- [x] I am the owner, or a major contributor to the repository I want to add.
- [x] The repository I want to add is a custom integration (it has a `manifest.json` file).
- [x] The repository has a `hacs.json` file.
- [x] There are releases in the repository (not just tags).
- [x] The repository has a description.
- [x] The repository has topics.
- [x] The HACS Action runs and completes without errors.
- [x] The Hassfest Action runs and completes without errors.

## Links

- **Repository:** https://github.com/Koky05/ha-sonicare-battery
- **Release:** https://github.com/Koky05/ha-sonicare-battery/releases/tag/v1.1.0
- **HACS & Hassfest CI (passing):** https://github.com/Koky05/ha-sonicare-battery/actions/runs/23583039198

## What does the integration do?

Reads battery level from Philips Sonicare toothbrushes via Bluetooth LE using the standard Battery Service (0x180F). Event-driven architecture — only connects when the toothbrush is detected during brushing sessions. Includes state restoration, auto-discovery, rate limiting, and English/Slovak translations.