### PR TITLE
Add Cangos655/vehicle-card

### DIFF
--- a/plugin
+++ b/plugin
@@ -48,6 +48,7 @@
   "Brianfit/calvin-card-ha",
   "Brianfit/xkcd-card-ha",
   "brunosabot/streamline-card",
+  "Cangos655/vehicle-card",
   "cataseven/Alarm-and-Security-Card",
   "cataseven/google-map-card",
   "cataseven/Navigate-Anywhere",


### PR DESCRIPTION
## Checklist

- [x] I have read and followed the [submission guidelines](https://hacs.xyz/docs/publish/plugin)
- [x] The repository is public
- [x] The repository has a description
- [x] The repository has a README
- [x] The repository has a LICENSE file (MIT)
- [x] `hacs.json` is present with `name`, `render_readme`, `content_in_root`
- [x] A GitHub release exists with the JS file as asset
- [x] The HACS validation action passes without `ignore` keys

## Repository

**https://github.com/Cangos655/vehicle-card**

**Category:** Plugin (Lovelace frontend card)

**Description:** Home Assistant Lovelace custom card for vehicle status — battery level with vertical bar, charge status, estimated range, fuel level, climate toggle, odometer. Works with any vehicle brand. Fully configurable via visual editor.

**Latest release:** https://github.com/Cangos655/vehicle-card/releases/tag/v1.1.1

**HACS validation action (passing):** https://github.com/Cangos655/vehicle-card/actions