### PR TITLE
Add madslundt/huligennem_ha

### DIFF
--- a/integration
+++ b/integration
@@ -1277,6 +1277,7 @@
   "macxq/foxess-ha",
   "MadOne/hass_gira_iot_api",
   "madpilot/hass-amber-electric",
+  "madslundt/huligennem_ha",
   "maeek/ha-aux-cloud",
   "magiczoom2/HA-Leneda-Power",
   "maginawin/ha-azoula-smart",


### PR DESCRIPTION
## Add madslundt/huligennem_ha

**Repository:** https://github.com/madslundt/huligennem_ha

**Description:** HULiGENNEM — Danish children's podcasts and live radio for Home Assistant

**Checklist:**
- [x] Repository is public
- [x] Has a description
- [x] Has a `hacs.json` file
- [x] Has a `manifest.json` with `documentation` URL
- [x] Has a `README.md`
- [x] Has a `LICENSE` file
- [x] Has at least one release (`v1.0.1`)
- [x] Integration type: `service`, IoT class: `cloud_polling`