### PR TITLE
Add plantlab-ai/home-assistant-plantlab

### DIFF
--- a/integration
+++ b/integration
@@ -1633,6 +1633,7 @@
   "pkarimov/jukeaudio_ha",
   "plamish/xcomfort",
   "PlanetCitizen1829381/ha-nsw-beachwatch",
+  "plantlab-ai/home-assistant-plantlab",
   "Platzii/homeassistant-evcnet",
   "plmilord/Hass.io-custom-component-ikamand",
   "plmilord/Hass.io-custom-component-spaclient",


### PR DESCRIPTION
## Repository

https://github.com/plantlab-ai/home-assistant-plantlab

## Description

AI-powered cannabis plant health diagnosis for Home Assistant. Captures photos from camera entities or local files, sends them to the PlantLab API, and returns structured diagnosis with conditions, pests, growth stage, and nutrient antagonism analysis.

## Checklist

- [x] The repository has a `hacs.json` file
- [x] The repository has a valid `manifest.json`
- [x] The repository has at least one release
- [x] The repository uses `config_flow`
- [x] The integration domain matches the repository
- [x] Topics include `home-assistant`, `hacs`, `home-assistant-custom-component`