### PR TITLE
Add plantlab-ai/home-assistant-plantlab

### DIFF
--- a/integration
+++ b/integration
@@ -1633,6 +1633,7 @@
   "pkarimov/jukeaudio_ha",
   "plamish/xcomfort",
   "PlanetCitizen1829381/ha-nsw-beachwatch",
+  "plantlab-ai/home-assistant-plantlab",
   "Platzii/homeassistant-evcnet",
   "plmilord/Hass.io-custom-component-ikamand",
   "plmilord/Hass.io-custom-component-spaclient",


### PR DESCRIPTION
## Links

- Repository: https://github.com/plantlab-ai/home-assistant-plantlab
- Latest release: https://github.com/plantlab-ai/home-assistant-plantlab/releases/tag/v0.1.1
- CI/Actions: https://github.com/plantlab-ai/home-assistant-plantlab/actions/runs/23611666106

## Description

AI-powered cannabis plant health diagnosis for Home Assistant. Captures photos from camera entities or local files, sends them to the PlantLab API, and returns structured diagnosis with conditions, pests, growth stage, and nutrient antagonism analysis.

## Checklist

- [x] The repository has a `hacs.json` file
- [x] The repository has a valid `manifest.json` with `config_flow: true`
- [x] The repository has at least one release (v0.1.1)
- [x] The repository uses `config_flow`
- [x] The integration domain (`plantlab`) matches the repository structure
- [x] Topics include `home-assistant`, `hacs`, `home-assistant-custom-component`
- [x] CI passes (lint + tests + HACS validation)