### PR TITLE
Add TheScubadiver/FileTrack

### DIFF
--- a/integration
+++ b/integration
@@ -1909,6 +1909,7 @@
   "TheNoctambulist/hass-airtouch",
   "TheRealFalseReality/Aquarium-AI-Homeassistant",
   "TheRealWaldo/thermal",
+  "TheScubadiver/FileTrack",
   "ThermIQ/thermiq_mqtt-ha",
   "thermozona/thermozona",
   "thetic/hass-consumable-tracker",

--- a/plugin
+++ b/plugin
@@ -484,6 +484,7 @@
   "teuchezh/dynamic-weather-card",
   "TheLuXoR/calendar-week-card",
   "TheRealEiskaffee/brightness-overlay",
+  "TheScubadiver/camera-gallery-card"
   "tholgir/TodoIst-Task-List",
   "thomasloven/lovelace-auto-entities",
   "thomasloven/lovelace-badge-card",


### PR DESCRIPTION
Add new integration: FileTrack

https://github.com/TheScubadiver/FileTrack

FileTrack is a Home Assistant integration that scans a folder and exposes its contents as a `fileList` attribute on a sensor entity. Maintained fork of the archived files integration by TarheelGrad1998.