### PR TITLE
Add TheScubadiver/FileTrack

### DIFF
--- a/integration
+++ b/integration
@@ -2019,6 +2019,7 @@
   "TheNoctambulist/hass-airtouch",
   "TheRealFalseReality/Aquarium-AI-Homeassistant",
   "TheRealWaldo/thermal",
+  "TheScubadiver/FileTrack",
   "ThermIQ/thermiq_mqtt-ha",
   "thermozona/thermozona",
   "thetic/hass-consumable-tracker",


### PR DESCRIPTION
Add new integration: FileTrack

https://github.com/TheScubadiver/FileTrack

FileTrack is a Home Assistant integration that scans a folder and exposes its contents as a `fileList` attribute on a sensor entity. Maintained fork of the archived files integration by TarheelGrad1998.