### PR TITLE
Adds new integration [assada/govee-cloud]

### DIFF
--- a/blacklist
+++ b/blacklist
@@ -401,7 +401,6 @@
   "tetienne/veolia-custom-component",
   "thebino/rki_covid",
   "TheLastProject/lovelace-media-art-background",
-  "TheOneOgre/govee-cloud",
   "Thomas55555/husqvarna_automower",
   "thomasddn/ha-volvo-cars",
   "thomasloven/lovelace-dummy-entity-row",

--- a/integration
+++ b/integration
@@ -188,6 +188,7 @@
   "asantaga/wiserHomeAssistantPlatform",
   "asev/homeassistant-helios",
   "Ashus/hass-openwrt-wakeonlan",
+  "assada/govee-cloud",
   "astrandb/miele",
   "astrandb/sentio",
   "astrandb/teracom_hass",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/assada/govee-cloud/releases/tag/v0.4.2>
Link to successful HACS action (without the `ignore` key): <https://github.com/assada/govee-cloud/actions/runs/23690984753>
Link to successful hassfest action (if integration): <https://github.com/assada/govee-cloud/actions/runs/23690985304>

## Note

This PR also removes the blacklisted `TheOneOgre/govee-cloud` from the blacklist. The original repository was archived by its maintainer. This fork revives the integration with fixes for recent Govee API changes (March 2026) that broke authentication for all users — see [wez/govee2mqtt#628](https://github.com/wez/govee2mqtt/issues/628) for context.