### PR TITLE
Add mallewski/ha-multical_21 to integration list

### DIFF
--- a/integration
+++ b/integration
@@ -1285,6 +1285,7 @@
   "Makhuta/homeassistant-duolingo",
   "Makr91/ha_easgen",
   "malicaeus/Wigle-Stats-HA",
+  "mallewski/ha-multical_21",
   "Mallonbacka/custom-component-cloudwatch",
   "Mallonbacka/custom-component-digitransit",
   "mampfes/ha_bayernluefter",


### PR DESCRIPTION
Custom integration for Kamstrup Multical 21 ultrasonic water meter

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [ ] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [ ] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [ ] The actions are passing without any disabled checks in my repository.
- [ ] I've added a link to the action run on my repository below in the links section.
- [ ] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <>
Link to successful HACS action (without the `ignore` key): <>
Link to successful hassfest action (if integration): <>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->