### PR TITLE
Add adiami14/homeassistant-auto-updater

### DIFF
--- a/integration
+++ b/integration
@@ -35,6 +35,7 @@
   "adamf83/my-rail-commute",
   "adammcdonagh/home-assistant-powervault",
   "adamoutler/anycubic-homeassistant",
+  "adiami14/homeassistant-auto-updater",
   "adonixis/ufanet_intercom_ha",
   "aegjoyce/custom-ambilight",
   "aesoftsolutions/Home-Assistant-custom-components-GTT",
@@ -2244,4 +2245,3 @@
   "zupancicmarko/JellyHA",
   "Zwer2k/ha-pca301"
 ]
-adiami14/homeassistant-auto-updater

--- a/integration
+++ b/integration
@@ -2244,3 +2244,4 @@
   "zupancicmarko/JellyHA",
   "Zwer2k/ha-pca301"
 ]
+adiami14/homeassistant-auto-updater


### PR DESCRIPTION
## Description

Add `adiami14/homeassistant-auto-updater` to the HACS default integration list.

## Checklist

- [x] I am the owner/main contributor of this repository
- [x] The repository is not for testing or personal use only
- [x] The repository does NOT contain code that overrides a built-in Home Assistant integration
- [x] All required checks pass (hassfest, HACS action, releases, brand icons)

## Repository

- **Repository:** https://github.com/adiami14/homeassistant-auto-updater
- **Category:** integration

## What does this integration do?

Auto Updater automatically schedules and installs Home Assistant updates (Core, OS, Supervisor, Add-ons, HACS) at a configurable time and on selected days of the week. It creates a backup before updating, sends persistent HA notifications and optional mobile push notifications with a summary of what was updated, and can optionally restart HA after updates complete.
