### PR TITLE
Add belgium_energy_costs integration

### DIFF
--- a/integration
+++ b/integration
@@ -239,6 +239,7 @@
   "Beat2er/homeassistant-trmnl-battery",
   "Bebbssos/ha-defa-power",
   "beecho01/material-symbols",
+  "ddebaets/belgium-energy-costs",
   "bemfa/behome",
   "beMoD/homeassistant-hyperliquid",
   "ben8p/home-assistant-bunq-balance-sensors",


### PR DESCRIPTION
Add Belgium Energy Costs integration for tracking complete energy costs in Belgium

New integration for tracking complete energy costs in Belgium.

**Repository:** https://github.com/ddebaets/belgium-energy-costs
**Release:** v5.2.0
**HACS Action:** https://github.com/ddebaets/belgium-energy-costs/actions/runs/12820854

Combines variable ENGIE prices with regional fixed costs for accurate total cost tracking.

Features:
- 40+ sensors for consumption, costs, and projections
- Brussels (SIBELGA) fully supported
- Energy Dashboard compatible
- Production ready and tested

All 8 HACS validation checks passed.