### PR TITLE
Add cm-makes/aurum-ha

### DIFF
--- a/integration
+++ b/integration
@@ -390,6 +390,7 @@
   "ClusterM/localtuya_rc",
   "ClusterM/skykettle-ha",
   "CM000n/qss",
+  "cm-makes/aurum-ha",
   "Cmajda/ha_cez_distribuce",
   "Cmajda/ha_golemio",
   "CMGeorge/homeassistant_sabiana_smart_energy",


### PR DESCRIPTION
## New Integration

**Repository:** https://github.com/cm-makes/aurum-ha
**Category:** Integration

### What does it do?
AURUM is a solar surplus optimizer for Home Assistant. It automatically distributes photovoltaic excess power to household devices based on priority, battery SOC awareness, and program detection (washer/dishwasher).

### Checklist
- [x] Public GitHub repository
- [x] Description and topics set
- [x] `hacs.json` with name
- [x] `manifest.json` with all required fields
- [x] GitHub release (v1.0.0)
- [x] Hassfest validation passing
- [x] HACS validation passing
- [x] Brand icon included
- [x] Issues enabled
- [x] README with documentation