### PR TITLE
Add CRCinAU/zonetouch3 to integration

### DIFF
--- a/integration
+++ b/integration
@@ -417,6 +417,7 @@
   "craibo/ha_strava",
   "crankynetman/ha-cumtd",
   "Crazy-Duck/home-assistant-fiftyfive",
+  "CRCinAU/zonetouch3",
   "CreasolTech/home-assistant-creasol-dombus",
   "CubicPill/china_southern_power_grid_stat",
   "CumpsD/home-assistant-leo-ntp",


### PR DESCRIPTION
## Checklist

- [X] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [X] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [X] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [X] The actions are passing without any disabled checks in my repository.
- [X] I've added a link to the action run on my repository below in the links section.
- [X] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: https://github.com/CRCinAU/zonetouch3/releases/tag/v1.1.0
Link to successful HACS action (without the `ignore` key): https://github.com/CRCinAU/zonetouch3/actions/runs/23799418030/job/69355343155
Link to successful hassfest action (if integration): https://github.com/CRCinAU/zonetouch3/actions/runs/23799418030/job/69355343325

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->