### PR TITLE
Add TSA3000/ha-elprisetjustnu to integration list

### DIFF
--- a/integration
+++ b/integration
@@ -2094,6 +2094,7 @@
   "tronikos/nest_legacy",
   "troykelly/homeassistant-au-nsw-covid",
   "trvqhuy/nestup_evn",
+  "TSA3000/ha-elprisetjustnu",
   "tschamm/boschshc-hass",
   "TTLucian/ha-electrolux",
   "turbokongen/hass-AMS",


### PR DESCRIPTION
## Checklist
- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links
Link to current release: <https://github.com/TSA3000/ha-elprisetjustnu/releases/tag/v0.1.11>
Link to successful HACS action (without the `ignore` key): <https://github.com/TSA3000/ha-elprisetjustnu/actions/runs/23817663644>
Link to successful hassfest action (if integration): <https://github.com/TSA3000/ha-elprisetjustnu/actions/runs/23817663609>