### PR TITLE
Add DawidSu/hass-shelly-schedule

### DIFF
--- a/integration
+++ b/integration
@@ -515,6 +515,7 @@
   "davidepalleschi/zepp2hass",
   "davidrapan/ha-solarman",
   "DawidPietrykowski/keemple-ha",
+  "DawidSu/hass-shelly-schedule",
   "daxingplay/home-assistant-mercury-switch",
   "daxingplay/home-assistant-vaillant-plus",
   "db1996/homeassistant_runelite",


### PR DESCRIPTION
## Integration: Shelly Schedule

Adds `DawidSu/hass-shelly-schedule` to the HACS default integration list.

**Checklist:**
- [x] `hacs.json` vorhanden
- [x] `manifest.json` mit `version`, `domain`, `documentation`
- [x] GitHub Release `v1.0.0` vorhanden
- [x] Repository public
- [x] HA minimum version: 2024.4.0