### PR TITLE
Add DawidSu/hass-shelly-schedule

### DIFF
--- a/integration
+++ b/integration
@@ -515,6 +515,7 @@
   "davidepalleschi/zepp2hass",
   "davidrapan/ha-solarman",
   "DawidPietrykowski/keemple-ha",
+  "DawidSu/hass-shelly-schedule",
   "daxingplay/home-assistant-mercury-switch",
   "daxingplay/home-assistant-vaillant-plus",
   "db1996/homeassistant_runelite",


### PR DESCRIPTION
## Integration: Shelly Schedule

Adds `DawidSu/hass-shelly-schedule` to the HACS default integration list.

- `hacs.json` present
- `manifest.json` with `version`, `domain`, `documentation`
- GitHub Release `v1.0.0` available
- Repository public
- HA minimum version: 2024.4.0