### PR TITLE
Add dmckeown257/kklocks

### DIFF
--- a/integration
+++ b/integration
@@ -543,6 +543,7 @@
   "delphiki/hass-pronote",
   "delphiki/hass-tarif-edf",
   "DeLuca21/ynab-ha",
+  "dmckeown257/kklocks",
   "Dennis90BW/ha-power-helper",
   "denov/home-assistant-apex-neptune",
   "denpamusic/homeassistant-plum-ecomax",


### PR DESCRIPTION
## What this PR does
Adds  to the HACS integration default list.

## Repository
https://github.com/dmckeown257/kklocks

## Notes
This is a Home Assistant custom integration for Veise / KK Home smart locks.