### PR TITLE
Add new integration 'caveman2024/sossen-ha'

### DIFF
--- a/integration
+++ b/integration
@@ -351,6 +351,7 @@
   "cauld/spotify-voice-assistant",
   "cavefire/Bose-Homeassistant",
   "cavefire/hass-openid",
+  "caveman2024/sossen-ha",
   "cazeaux/ha-iracing",
   "cdnninja/yoto_ha",
   "cedricziel/ha-matter-binding-helper",


### PR DESCRIPTION
- [x] I have read the [publishing documentation](https://hacs.xyz/docs/publish/include)
- [x] HACS Action is installed and passing
- [x] Hassfest is installed and passing
- Release: https://github.com/caveman2024/sossen-ha/releases/tag/v1.0.3
- HACS Action: https://github.com/caveman2024/sossen-ha/actions
- Hassfest: https://github.com/caveman2024/sossen-ha/actions