### PR TITLE
Add K0rb3nD4ll4S/dibby-wemo-manager

### DIFF
--- a/integration
+++ b/integration
@@ -1,4 +1,3 @@
-K0rb3nD4ll4S/dibby-wemo-manager
 [
   "0jety0/emaux_spv150",
   "0xAHA/airtouch4_advanced",
@@ -1099,6 +1098,7 @@ K0rb3nD4ll4S/dibby-wemo-manager
   "jxlarrea/voice-satellite-card-llm-tools",
   "jyourstone/power_saver",
   "jz-v/ha-melview",
+  "K0rb3nD4ll4S/dibby-wemo-manager",
   "kaechele/napoleon-efire",
   "Kajkac/ZTE-MC-Home-assistant-repo",
   "kalanda/homeassistant-aemet-sensor",

--- a/integration
+++ b/integration
@@ -1,3 +1,4 @@
+K0rb3nD4ll4S/dibby-wemo-manager
 [
   "0jety0/emaux_spv150",
   "0xAHA/airtouch4_advanced",


### PR DESCRIPTION
## Description

Adding **Dibby Wemo** — a full-featured local Wemo integration with a built-in DWM scheduling engine.

### What makes this different from existing Wemo integrations

The existing verified Wemo integrations provide basic device bridging. Dibby Wemo adds a complete **local automation engine** not present in any other HACS Wemo integration:

- **Schedule rules** — turn devices on/off at fixed times or sunrise/sunset on selected days
- **Countdown rules** — auto turn off/on after N minutes of being in a trigger state (fires even if device is already in that state on load)
- **Always On** — health-monitored enforcement, corrects off-state within 10 seconds
- **Away Mode** — randomised on/off simulation within a time window
- **Trigger rules** — IFTTT-style: when device A changes state, control device B
- **Firmware rules** — read/write native Wemo device SQLite rules via FetchRules/StoreRules

All communication is direct local UPnP/SOAP — no Belkin cloud, no account required.

### Checklist

- [x] This is an integration (not a plugin/theme)
- [x] Repository is public: https://github.com/K0rb3nD4ll4S/dibby-wemo-manager
- [x]  present at repo root
- [x]  present with version 2.0.1
- [x]  present
- [x] GitHub releases exist: https://github.com/K0rb3nD4ll4S/dibby-wemo-manager/releases
- [x] No pip dependencies — pure Python stdlib only
- [x] 
- [x] Config flow implemented
