### PR TITLE
Add BikerSentinel integration

### DIFF
--- a/integration
+++ b/integration
@@ -2169,6 +2169,7 @@
   "weiangongsi/ddns",
   "Weissnix4711/hass-listenbrainz",
   "weltenwort/home-assistant-rct-power-integration",
+  "werkey/bikersentinel",
   "wernerhp/ha.integration.load_shedding",
   "werthdavid/homeassistant-pulsatrix-local-mqtt",
   "wez/govee-lan-hass",


### PR DESCRIPTION
Add werkey/bikersentinel to the HACS integration list.

BikerSentinel is a data analysis engine for Home Assistant dedicated to motorcycle riding conditions. It combines rider physical parameters, machine characteristics, and meteorological data to generate safety scores and indicators.

Features:
- Biker Score (0-10) calculation
- Safety status indicators  
- Device grouping support
- Runtime ratio adjustment
- Multi-instance support
- French localization

Requires Home Assistant 2024.1.0 or later.

Repository: https://github.com/werkey/bikersentinel
Release: https://github.com/werkey/bikersentinel/releases/tag/v2.0.0