### PR TITLE
Add BikerSentinel integration

### DIFF
--- a/integration
+++ b/integration
@@ -2169,6 +2169,7 @@
   "weiangongsi/ddns",
   "Weissnix4711/hass-listenbrainz",
   "weltenwort/home-assistant-rct-power-integration",
+  "werkey/bikersentinel",
   "wernerhp/ha.integration.load_shedding",
   "werthdavid/homeassistant-pulsatrix-local-mqtt",
   "wez/govee-lan-hass",


### PR DESCRIPTION
## Add BikerSentinel integration

Add `werkey/bikersentinel` to the HACS integration list.

### Repository links
- **Repository**: https://github.com/werkey/bikersentinel
- **Latest release**: https://github.com/werkey/bikersentinel/releases/tag/v2.0.0
- **CI action runs**: https://github.com/werkey/bikersentinel/actions

### Description
BikerSentinel is a data analysis engine for Home Assistant dedicated to motorcycle riding conditions. It combines rider physical parameters, machine characteristics, and meteorological data to generate safety scores and indicators.

### Features
- Biker Score (0-10) calculation
- Safety status indicators  
- Device grouping support
- Runtime ratio adjustment
- Multi-instance support
- French localization

### Requirements
- Home Assistant 2024.1.0 or later

### Checklist
- [x] I have read the [contributing guidelines](https://github.com/hacs/default/blob/master/CONTRIBUTING.md)
- [x] I have checked that the repository I am adding is not already in the list
- [x] I have checked that the repository is a Home Assistant integration
- [x] I have checked that the repository has a valid `hacs.json` file
- [x] I have checked that the repository has a valid `manifest.json` file
- [x] I have checked that the repository has been added to the [HACS store](https://hacs.xyz) or will be added before the PR is merged
- [x] I have checked that the repository follows the [HACS integration guidelines](https://hacs.xyz/docs/publish/integration)
- [x] I have confirmed that the repository has had at least one successful CI run
- [x] I have confirmed that the repository has a working CI setup