### PR TITLE
Add ifMike/homeyHASS to default integration list

### DIFF
--- a/integration
+++ b/integration
@@ -920,6 +920,7 @@
   "IATkachenko/HA-SleepAsAndroid",
   "IATkachenko/HA-YandexWeather",
   "Ibepower/Ibepower-Homeassistant-Integration",
+  "ifMike/homeyHASS",
   "IgnacioHR/de-dietrich-c230-ha",
   "iioel/magiline-imagix-homeassistant",
   "iKaew/hass-lifesmart-addon",


### PR DESCRIPTION
## Summary
- Add `ifMike/homeyHASS` to the `integration` default repository list.

## Notes
- Repository already follows stable release tagging (`vX.Y.Z`) and has current stable release `v1.2.3`.