### PR TITLE
Add Barma-lej/landroid-card

### DIFF
--- a/plugin
+++ b/plugin
@@ -26,6 +26,7 @@
   "aukedejong/lovelace-windrose-card",
   "azuwis/zigbee2mqtt-networkmap",
   "badguy99/PlantPictureCard",
+  "Barma-lej/landroid-card",
   "bbbenji/synthwave-hass-extras",
   "ben8p/lovelace-auto-reload-card",
   "ben8p/lovelace-tab-redirect-card",


### PR DESCRIPTION
## Description

Adds [Barma-lej/landroid-card](https://github.com/Barma-lej/landroid-card) to the HACS default plugin list.

## Information

| | |
|---|---|
| **Category** | Plugin |
| **Repository** | https://github.com/Barma-lej/landroid-card |

## Checklist

- [x] I have read and followed the [HACS contribution guidelines](https://hacs.xyz/docs/publish/start)
- [x] The repository has a `hacs.json` file
- [x] The repository has a valid `README.md`
- [x] The repository has a release with a compiled file
- [x] The repository is not a fork
- [x] The repository has been around for at least 30 days
