### PR TITLE
Add andrejs2/ha_clss_shade

### DIFF
--- a/integration
+++ b/integration
@@ -133,6 +133,7 @@
   "andreas-glaser/ha-dessmonitor",
   "AndreaTomatis/loex-xsmart-integration",
   "andrejs2/arso_potresi",
+  "andrejs2/ha_clss_shade",
   "andrejs2/slovenian_weather_integration",
   "andrew-codechimp/HA-Andrews-Arnold-Quota",
   "andrew-codechimp/HA-Battery-Notes",


### PR DESCRIPTION
## Add new integration repository

**Repository:** https://github.com/andrejs2/ha_clss_shade

**Description:** LiDAR-based solar/shade analysis for Home Assistant using Slovenia's CLSS (Cyclical Laser Scanning) data. Provides real-time shade computation, PV production forecast, and per-zone smart irrigation with FAO-56 crop coefficients.

**Country:** Slovenia (SI) — uses GURS/ARSO public LiDAR and agrometeo data

**Checklist:**
- [x] Repository is public
- [x] Has a valid `hacs.json` with `country: ["SI"]`
- [x] Has a valid `manifest.json` with version `0.0.1`
- [x] Has at least one release (`v0.0.1`)
- [x] Has `README.md` with documentation
- [x] Has `LICENSE` (MIT)
- [x] Hassfest validation passes
- [x] HACS validation passes
- [x] Repository description set
- [x] Issues enabled
- [x] Topics configured
- [x] Brand assets included (`icon.png`, `icon@2x.png`)

**Owner confirmation:** I am the repository owner (@andrejs2)