### PR TITLE
Add Virgin Router Reboot integration

### DIFF
--- a/integration
+++ b/integration
@@ -342,6 +342,7 @@
   "caplaz/home-assistant-sfpuc",
   "caplaz/micro-weather-station",
   "cardouken/homeassistant-unifi-unas",
+  "CarlBird/Virgin-Router-Reboot",
   "carohauta/oma-helen-ha-integration",
   "caronc/ha-ultrasync",
   "casungo/osservaprezzi-carburanti-ha",


### PR DESCRIPTION
This PR adds a new Home Assistant integration called **Virgin Router Reboot**, which allows users to remotely reboot their Virgin Media routers directly from Home Assistant.

---

### Features:

- Logs into the router using a user-specified password.
- Sends a reboot command to the router.
- Logs out automatically after the reboot command is sent.
- Supports self-signed SSL certificates.
- Service is accessible via `virgin_router_reboot.reboot` in Home Assistant.
- Configurable via `configuration.yaml` or UI (router IP and password).

---

### Repository Links

- **Repository:** https://github.com/YOUR_USERNAME/virgin_router_reboot
- **Latest Release:** https://github.com/YOUR_USERNAME/virgin_router_reboot/releases/latest
- **CI/Action Runs:** https://github.com/YOUR_USERNAME/virgin_router_reboot/actions

---

### HACS Compliance:

- Public GitHub repository.
- `manifest.json` includes `domain`, `name`, `version`, and `"hacs": { "type": "integration" }`.
- Compatible with Home Assistant 2026.3.
- Tested locally and verified that the service executes correctly without blocking the event loop.

---

### Installation Notes:

After merging, users will be able to:

1. Go to HACS → Integrations.
2. Search for **Virgin Router Reboot**.
3. Install it without adding a custom repository.
4. Configure router IP and password, then call the `reboot` service.

---

### Additional Information:

This integration is intended for the Home Assistant community and makes it easier to manage Virgin Media routers without accessing the web interface. 