### PR TITLE
Add Virgin Router Reboot integration

### DIFF
--- a/integration
+++ b/integration
@@ -342,6 +342,7 @@
   "caplaz/home-assistant-sfpuc",
   "caplaz/micro-weather-station",
   "cardouken/homeassistant-unifi-unas",
+  "CarlBird/Virgin-Router-Reboot",
   "carohauta/oma-helen-ha-integration",
   "caronc/ha-ultrasync",
   "casungo/osservaprezzi-carburanti-ha",


### PR DESCRIPTION
## Virgin Router Reboot Integration

This integration allows users to remotely reboot Virgin Media routers from Home Assistant. It includes a configurable router IP address and password, and exposes a service to trigger a reboot.

---

### Checklist

- [x] I have tested my code locally
- [x] My code follows Home Assistant development guidelines
- [x] I have added a `manifest.json` with domain, name, version, and HACS type
- [x] I have created a release in GitHub (v1.0.0 or similar)
- [x] I have CI/Actions running for my repository

---

### Repository Links

- Repository: https://github.com/carlbird/virgin_router_reboot
- Latest Release: https://github.com/carlbird/virgin_router_reboot/releases/latest
- CI/Action Runs: https://github.com/carlbird/virgin_router_reboot/actions

---

### Description

- Provides a service `virgin_router_reboot.reboot` to reboot the router.
- Configuration allows users to set router IP and password.
- Handles self-signed SSL certificates.
- Includes logout after reboot for security.
- Designed to be HACS-installable and configurable.

---

### Troubleshooting

- Ensure your router is reachable from Home Assistant.
- Verify credentials are correct.
- Router may take a few seconds to respond after a reboot.

---

### Support

- Open issues on this repository if you encounter problems.
- Integration developed for the Home Assistant community. 