### PR TITLE
Add ferroamp-modbus to integration list

### DIFF
--- a/integration
+++ b/integration
@@ -491,6 +491,7 @@
   "Danieldiazi/homeassistant-meteogalicia_tides",
   "danieldotnl/ha-measureit",
   "danieldotnl/ha-multiscrape",
+  "danielolsson100/ferroamp-modbus",
   "Danielhiversen/home_assistant_adax",
   "Danielhiversen/home_assistant_tractive",
   "danielpetrovic/ha-ducobox",


### PR DESCRIPTION
Adds the ferroamp-modbus custom integration to HACS.

Repository: https://github.com/danielolsson100/ferroamp-modbus

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: [https://github.com/danielolsson100/ferroamp-modbus/releases/tag/v0.1.0](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/e7fb5e96c0/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Link to successful HACS action (without the ignore key): [https://github.com/danielolsson100/ferroamp-modbus/actions/runs/23993278960](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/e7fb5e96c0/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Link to successful hassfest action (if integration): [https://github.com/danielolsson100/ferroamp-modbus/actions/runs/23980342593](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/e7fb5e96c0/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->