### PR TITLE
Add kdeyev/eyeonwater integration

### DIFF
--- a/integration
+++ b/integration
@@ -1116,6 +1116,7 @@
   "kcoffau/AUS_BOM_Space_Weather_Alert_System",
   "kcofoni/ha-netro-watering",
   "kcsoft/virtual-keys",
+  "kdeyev/eyeonwater",
   "kennethroe/vehiclevue",
   "kenyonj/kohler-konnect-ha",
   "kerstenremco/busvertrektijden-ha",


### PR DESCRIPTION
## Repository

https://github.com/kdeyev/eyeonwater

## Description

Home Assistant integration for [EyeOnWater](https://eyeonwater.com) — track water usage directly in HA's Energy Dashboard with accurate hourly meter readings, historical data backfill, and optional cost tracking. Supports US and Canada.

## Checklist

- [x] The repository has a description
- [x] The repository has topics set
- [x] The repository has issues enabled
- [x] The repository is not archived
- [x] The repository is not a fork
- [x] The integration has a valid \\hacs.json\\ file with \\
ame\\ set
- [x] The integration has a valid \\manifest.json\\ file
- [x] The repository has at least one published release
- [x] Brand icons exist in [home-assistant/brands](https://github.com/home-assistant/brands/tree/master/custom_integrations/eyeonwater)
- [x] The [HACS Action](https://github.com/hacs/action) workflow is set up
- [x] The [Hassfest](https://github.com/home-assistant/actions) workflow is set up
- [x] I am the owner of the repository