### PR TITLE
Add energiedaten-at/ha-energiedaten

### DIFF
--- a/integration
+++ b/integration
@@ -659,6 +659,7 @@
   "emanuelegreco29/Ksenia_Lares_4.0-HASS_Addon",
   "emes30/facebook_messenger",
   "emics/ham_radio_propagation",
+  "energiedaten-at/ha-energiedaten",
   "energy-tracker/home-assistant-energy-tracker",
   "enes-oerdek/Home-Assistant-Helium-Integration",
   "enoch85/ge-spot",


### PR DESCRIPTION
## Repository

https://github.com/energiedaten-at/ha-energiedaten

## Description

Home Assistant integration for [energiedaten.at](https://energiedaten.at) — imports Austrian smart meter energy data into the HA Energy Dashboard.

- Quarter-hourly consumption and feed-in data via Austria's EDA network
- Automatic 6-hour polling with incremental sync
- Correction detection for re-sent grid operator readings
- Multi-meter support

## Checklist

- [x] Public repository
- [x] `hacs.json` in root
- [x] `manifest.json` in `custom_components/energiedaten/`
- [x] README
- [x] MIT License
- [x] GitHub topics set (`hacs`, `home-assistant`, `homeassistant-integration`)
- [x] Tagged release (`v0.3.0`)