### PR TITLE
Add john1506/ring-stash

### DIFF
--- a/integration
+++ b/integration
@@ -1037,6 +1037,7 @@
   "joggs/home_assistant_ebeco",
   "johannesWen/KEBA-Heat-Pump-Modbus-Integration",
   "john-lazarus/HomeAssistant-SolisCloudMonitoring",
+  "john1506/ring-stash",
   "JohNan/homeassistant-homevolt-local",
   "JohNan/homeassistant-wellbeing",
   "johnf/actron-air-esphome",


### PR DESCRIPTION
## Add john1506/ring-stash

**Ring Stash** — automatically downloads and stores Ring doorbell clips to your Home Assistant server.

### What it does
- Polls Ring's API and downloads new motion, doorbell and live clips to `/media/ring_stash/`
- Exposes sensors for clip counts (today/week/month/total), event categories (motion/doorbell/live), storage usage, free space, pending downloads, locked clips and oldest clip date
- Retention-based automatic cleanup with per-clip lock support
- Background history backfill on first run; subsequent polls are lightweight (one page)
- Built-in panel with clip grid, AI descriptions, search and playback

### Checklist
- [x] `hacs.json` present
- [x] Valid `manifest.json` with `domain`, `name`, `version`, `codeowners`
- [x] Public repo with MIT license
- [x] Repository topics: `hacs`, `homeassistant`, `home-assistant`, `ring`, `ring-doorbell`
- [x] Releases published (latest: v1.0.4)
- [x] README present
- [x] Depends on the built-in `ring` integration for authentication