### PR TITLE
Adds new integration [volschin/eebus-ha-bridge]

### DIFF
--- a/integration
+++ b/integration
@@ -2157,6 +2157,7 @@
   "vooon/hass-myheat",
   "Vova-SH/termux-api",
   "vwylaw/nsw_fire_danger",
+  "volschin/eebus-ha-bridge",
   "wachino/orkli_wifi_thermostat",
   "wbyoung/lampie",
   "wbyoung/movement",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/volschin/eebus-ha-bridge/releases/tag/v0.1.1>
Link to successful HACS action (without the `ignore` key): <https://github.com/volschin/eebus-ha-bridge/actions/runs/24068729553>
Link to successful hassfest action (if integration): <https://github.com/volschin/eebus-ha-bridge/actions/runs/24068729539>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->