### PR TITLE
Adds new integration [dannyrobinson/OtodataTankMonitor]

### DIFF
--- a/integration
+++ b/integration
@@ -497,6 +497,7 @@
   "danielrivard/homeassistant-innova",
   "danielsmith-eu/home-assistant-themeparks-integration",
   "danishru/silam_pollen",
+  "dannyrobinson/OtodataTankMonitor",
   "danobot/entity-controller",
   "danq8/neo_watcher",
   "Daring-Designs/meshtastic-ui-ha",


### PR DESCRIPTION
## Link to repository

https://github.com/dannyrobinson/OtodataTankMonitor

## Latest release

https://github.com/dannyrobinson/OtodataTankMonitor/releases/tag/v1.0.0

## CI Action runs

https://github.com/dannyrobinson/OtodataTankMonitor/actions

## Why do you want to add this?

This is a custom integration for monitoring propane tank levels via the Otodata Nee-Vo platform. It provides tank level percentage and last read timestamp sensors with no API key required — just a public device code.

## Checklist

- [x] The repository is publicly available on GitHub
- [x] The repository can be added as a custom repository in HACS
- [x] HACS Action and Hassfest validation workflows are configured
- [x] A GitHub release has been created (v1.0.0)
- [x] The repository has valid manifest.json and hacs.json files
- [x] I am the owner of this repository