### PR TITLE
Add hilman2/ha-sunspec2

### DIFF
--- a/integration
+++ b/integration
@@ -874,6 +874,7 @@
   "hfehrmann/hass-dash-bouncer",
   "hg1337/homeassistant-dwd",
   "hif2k1/battery_sim",
+  "hilman2/ha-sunspec2",
   "hitchin999/protector_net",
   "hitchin999/YidCal",
   "hiteule/rte-jours-signales",


### PR DESCRIPTION
- Repository: https://github.com/hilman2/ha-sunspec2
- Category: integration

## About

**SunSpec 2** is a Home Assistant integration for SunSpec Modbus devices (solar inverters, energy meters, batteries) — actively maintained, built on current `pysunspec2` (1.3.3+ with the `[serial]` extra), and debugging-first: structured logging with device context, one-click diagnostics dump, opt-in raw register capture, and Repairs panel integration with English / German translations.

## Verification of HACS submission requirements

- [x] Repository is publicly accessible
- [x] Repository is not a fork
- [x] Repository has a `description` set
- [x] Repository has the `integration` topic (plus `home-assistant`, `homeassistant`, `hacs`, `sunspec`, `modbus`, `solar`, `inverter`, `kaco`, `pysunspec2`)
- [x] Repository has at least one published release (currently `v0.7.0`, with prior tags `v0.1.0` through `v0.6.0`)
- [x] `manifest.json` declares `documentation`, `issue_tracker`, `codeowners`, `iot_class`, `version`, and pinned `requirements`
- [x] Brand assets are bundled in `custom_components/sunspec2/brand/` (HA 2026.3+ Brands Proxy API). A fallback PR with the same icons is open at home-assistant/brands#10091 for older HA versions.
- [x] CI on push and PR runs `ruff check`, `ruff format --check`, `hassfest`, and `pytest` (91 tests, currently green on `main`)
- [x] Smoke-tested in production against a real KACO Powador 7.8 TL3 (firmware V2.30)
- [x] As maintainer, I confirm that I will actively maintain this integration

## Notes

The integration includes a one-step migration helper for users coming from other SunSpec integrations: when added to a Home Assistant instance that already has `sensor.*` entities under the `sunspec` platform, those entities are atomically retargeted to `sunspec2` so the user keeps their entity IDs, Recorder history, dashboard references, and automations. Verified end-to-end on a real install with 21 sensors. A conflict guard refuses setup with a clear Repairs panel issue when the previous integration is still actively running, so the two never compete for the inverter's single Modbus TCP slot.