### PR TITLE
Add iret33/deepseek-ha-integration

### DIFF
--- a/integration
+++ b/integration
@@ -941,6 +941,7 @@
   "iprak/weatherapi",
   "iprak/winix",
   "iprak/yahoofinance",
+  "iret33/deepseek-ha-integration",
   "IT-my-PV/myPVHomeAssistant",
   "it00x32/lancom-lmc-ha",
   "itchannel/apex-ha",


### PR DESCRIPTION
Adds iret33/deepseek-ha-integration — DeepSeek LLM conversation agent for Home Assistant.

Repo: https://github.com/iret33/deepseek-ha-integration
HACS Validation: passing
Hassfest: passing