### PR TITLE
Add maximusIIxII/hass-desk2ha

### DIFF
--- a/integration
+++ b/integration
@@ -1356,6 +1356,7 @@
   "MattXcz/CEZ",
   "mawinkler/astroweather",
   "MaxensF/personal_weather_station",
+  "maximusIIxII/hass-desk2ha",
   "Maxou44/ha-tiko-component",
   "maybetaken/Solar_Manager",
   "mb-software/homeassistant-powerbrain",


### PR DESCRIPTION
## New Integration: Desk2HA

**Repository:** https://github.com/maximusIIxII/hass-desk2ha
**Latest Release:** https://github.com/maximusIIxII/hass-desk2ha/releases/tag/v0.1.1
**CI Runs:** https://github.com/maximusIIxII/hass-desk2ha/actions/runs/24141725093

Multi-vendor desktop monitoring integration for Home Assistant. Brings your entire desk — PC, monitors, peripherals — into Home Assistant via the [Desk2HA Agent](https://github.com/maximusIIxII/desk2ha-agent).

### Features
- 9 entity platforms (sensor, binary_sensor, number, select, switch, light, media_player, button, update)
- 50+ dynamic sensors (CPU, RAM, disk, battery, GPU, thermals, fans, network, display)
- DDC/CI monitor control (brightness, contrast, volume, input source, KVM switch)
- Display as dimmable light + speaker as media player
- Multi-vendor: Dell, HP, Lenovo support
- Cross-platform agent: Windows, Linux, macOS
- Auto-discovery via Zeroconf
- MQTT and HTTP transport

### Checklist
- [x] Public repository
- [x] `hacs.json` present with `name` and `homeassistant` minimum version
- [x] `manifest.json` valid (hassfest CI passes)
- [x] At least one release (v0.1.1)
- [x] README with installation instructions
- [x] Brand icons in `brand/` directory
- [x] CI workflow with ruff lint + hassfest