### PR TITLE
Add rgg-spagano/ha-zentraly

### DIFF
--- a/integration
+++ b/integration
@@ -1710,6 +1710,7 @@
   "rexave/hass-orange-internet-on-the-move",
   "rgc99/irrigation_unlimited",
   "rgerbranda/rbfa",
+  "rgg-spagano/ha-zentraly",
   "rhanekom/hass-qwikswitch-api",
   "rhizomatics/autoarm",
   "rhizomatics/remote_logger",


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://hacs.xyz/docs/publish/include)
- [x] I am the owner of the repository being added
- [x] The repository has a description
- [x] The repository has topics
- [x] The repository has a README
- [x] The repository has a `hacs.json` file
- [x] The repository has a `manifest.json` file with all required keys
- [x] The repository has brand assets (`brand/icon.png`)
- [x] HACS Action passes ✅
- [x] Hassfest passes ✅
- [x] At least one GitHub release is published

## Repository

https://github.com/rgg-spagano/ha-zentraly

## Description

Home Assistant integration for **Zentraly WiFi thermostats** (boiler controllers). Allows controlling target temperature and on/off mode, and reading current temperature, humidity, and boiler output state via the Zentraly cloud API.

Supports:
- Climate entity with `heat` / `off` modes
- Target temperature control (5–35 °C)
- Auto-discovery of all thermostats linked to the account
- Multilanguage: EN, ES, PT
