### PR TITLE
Add Padraiggg/Padraigggs-ha-interactive-floorplan

### DIFF
--- a/plugin
+++ b/plugin
@@ -398,6 +398,7 @@
   "pacemaker82/Compact-Power-Card",
   "pacemaker82/Home-Climate-Card",
   "pacemaker82/Sections-Gauge-Card",
+  "Padraiggg/Padraigggs-ha-interactive-floorplan",
   "partach/switch_port_card",
   "pennisiandrea/media-explorer-card",
   "petergridge/Irrigation-Card",


### PR DESCRIPTION
## New repository to add to HACS default

**Repository:** [Padraiggg/Padraigggs-ha-interactive-floorplan](https://github.com/Padraiggg/Padraigggs-ha-interactive-floorplan)

**Category:** Plugin (Dashboard/Lovelace card)

### What does it do?

Interactive floorplan card for Home Assistant with a built-in visual editor. Features include:
- **Drag & drop** entity placement on uploaded floorplan images
- **Real-time RGB colors** — lights render actual brightness/color from HA state
- **Polygon light zones** — draw realistic light spread shapes
- **Camera integration** — idle/streaming/recording states with blinking animation
- **WebSocket push** — editor saves directly to HA dashboards
- **Single JS bundle** — viewer + editor combined in one file

Built with Vue 3 + TypeScript, bundled with Vite. No external dependencies.

### Checklist

- [x] `hacs.json` present with `filename` and `render_readme`
- [x] GitHub releases with JS asset (10 releases, latest v1.1.8)
- [x] HACS validation GitHub Action passes on every push
- [x] Comprehensive README with installation + usage docs
- [x] MIT license
- [x] Repository topics set (home-assistant, lovelace, hacs, custom-card)
- [x] Repository description set
- [x] Repository is public
