### PR TITLE
Add hilman2/ha-xtool-s1

### DIFF
--- a/integration
+++ b/integration
@@ -874,6 +874,7 @@
   "hfehrmann/hass-dash-bouncer",
   "hg1337/homeassistant-dwd",
   "hif2k1/battery_sim",
+  "hilman2/ha-xtool-s1",
   "hitchin999/protector_net",
   "hitchin999/YidCal",
   "hiteule/rte-jours-signales",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/hilman2/ha-xtool-s1/releases/tag/v1.9.0>
Link to successful HACS action (without the `ignore` key): <https://github.com/hilman2/ha-xtool-s1/actions/runs/24192505878>
Link to successful hassfest action (if integration): <https://github.com/hilman2/ha-xtool-s1/actions/runs/24192505878>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->