### PR TITLE
Add cdelaet/sensor-bar-card-plus

### DIFF
--- a/plugin
+++ b/plugin
@@ -63,6 +63,7 @@
   "ciotlosm/lovelace-thermostat-dark-card",
   "Clooos/Bubble-Card",
   "Codegnosis/givtcp-battery-card",
+  "cdelaet/sensor-bar-card-plus",
   "custom-cards/beer-card",
   "custom-cards/bignumber-card",
   "custom-cards/button-card",


### PR DESCRIPTION
## Summary\n- add `cdelaet/sensor-bar-card-plus` to the HACS plugin registry\n\n## Validation\n- HACS validation workflow passes on the repository\n- Latest release published: `v1.1.0`\n\nRepository: https://github.com/cdelaet/sensor-bar-card-plus\nRelease: https://github.com/cdelaet/sensor-bar-card-plus/releases/tag/v1.1.0\nValidation run: https://github.com/cdelaet/sensor-bar-card-plus/actions/runs/24236652051\n