### PR TITLE
Add Seidlm/Voitas-Walbox-HA-Integration

### DIFF
--- a/integration
+++ b/integration
@@ -2240,7 +2240,8 @@
   "zubir2k/homeassistant-dailyhadith",
   "zubir2k/homeassistant-esolatgps",
   "zubir2k/homeassistant-esolattakwim",
-  "zulufoxtrot/ha-zyxel",
+  "zulufoxtrot/ha-zyxel",  "Seidlm/Voitas-Walbox-HA-Integration",
+
   "zupancicmarko/JellyHA",
   "Zwer2k/ha-pca301"
 ]


### PR DESCRIPTION
## Voitas Wallbox Integration

Local Home Assistant integration for the **Voitas V11 EV Wallbox**.

### Why this integration?
Voitas Innovations has ceased operations. Their cloud backend is offline. This integration reverse-engineered the local UDP broadcast protocol (port 43000) to provide full local access - no cloud required.

### Details
- **IoT class:** local_push (UDP broadcast ~600ms)
- **Entities:** status, charging power, energy (kWh), session duration, diagnostic
- **Energy Dashboard:** compatible (TOTAL_INCREASING, kWh)
- **Config flow:** full UI setup with options flow
- **Tested on:** HA 2026.3.x