### PR TITLE
Add elax46/card-bolletta to plugin list

### DIFF
--- a/plugin
+++ b/plugin
@@ -129,6 +129,7 @@
   "Edward13ruf/nationalrail-status-card",
   "Edward13ruf/tfl-status-card",
   "elax46/custom-brand-icons",
+  "elax46/card-bolletta",
   "elchininet/custom-sidebar",
   "elchininet/home-assistant-secret-taps",
   "elchininet/keep-texts-in-tabs",


### PR DESCRIPTION
Insert elax46/card-bolletta into the plugin registry list in the plugin file. This adds the new card to the set of recognized plugins.

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [X] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [X] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [X] The actions are passing without any disabled checks in my repository.
- [X] I've added a link to the action run on my repository below in the links section.
- [X] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/elax46/card-bolletta/releases/tag/2026.4.0>
Link to successful HACS action (without the `ignore` key): <https://github.com/elax46/card-bolletta/actions/runs/24240611106>
Link to successful hassfest action (if integration): <>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->