### PR TITLE
Add Seidlm/Voitas-Walbox-HA-Integration

### DIFF
--- a/integration
+++ b/integration
@@ -2240,7 +2240,8 @@
   "zubir2k/homeassistant-dailyhadith",
   "zubir2k/homeassistant-esolatgps",
   "zubir2k/homeassistant-esolattakwim",
-  "zulufoxtrot/ha-zyxel",
+  "zulufoxtrot/ha-zyxel",  "Seidlm/Voitas-Walbox-HA-Integration",
+
   "zupancicmarko/JellyHA",
   "Zwer2k/ha-pca301"
 ]


### PR DESCRIPTION
## Voitas Wallbox Integration for Home Assistant

Local Home Assistant integration for the **Voitas V11 EV Wallbox** - reverse-engineered local UDP protocol since the cloud backend (Voitas Innovations) is offline.

### Repository
https://github.com/Seidlm/Voitas-Walbox-HA-Integration

### Latest Release
https://github.com/Seidlm/Voitas-Walbox-HA-Integration/releases/latest

### CI Action Runs
https://github.com/Seidlm/Voitas-Walbox-HA-Integration/actions

### Details
- **IoT class:** local_push (UDP broadcast ~600ms, no cloud)
- **Entities:** status, charging power, energy (kWh), session duration, max power, diagnostic
- **Energy Dashboard:** compatible (TOTAL_INCREASING, kWh, RestoreEntity)
- **Config flow:** full UI setup + options flow
- **Tested on:** HA 2026.3.x