### PR TITLE
Adds new integration [Seidlm/Voitas-Walbox-HA-Integration]

### DIFF
--- a/integration
+++ b/integration
@@ -2240,7 +2240,8 @@
   "zubir2k/homeassistant-dailyhadith",
   "zubir2k/homeassistant-esolatgps",
   "zubir2k/homeassistant-esolattakwim",
-  "zulufoxtrot/ha-zyxel",
+  "zulufoxtrot/ha-zyxel",  "Seidlm/Voitas-Walbox-HA-Integration",
+
   "zupancicmarko/JellyHA",
   "Zwer2k/ha-pca301"
 ]


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/Seidlm/Voitas-Walbox-HA-Integration/releases/tag/v1.3.0>
Link to successful HACS action (without the `ignore` key): <https://github.com/Seidlm/Voitas-Walbox-HA-Integration/actions/runs/24241719368>
Link to successful hassfest action (if integration): <https://github.com/Seidlm/Voitas-Walbox-HA-Integration/actions/runs/24241719368>

## Description

Local Home Assistant integration for the **Voitas V11 EV Wallbox**.

Voitas Innovations has ceased operations and their cloud infrastructure is offline. This integration reverse-engineers the **local UDP broadcast** (port 43000) that the wallbox transmits every ~600ms - no cloud, no authentication required.

**IoT class:** local_push
**Entities:** status, charging power, energy (kWh, Energy Dashboard compatible), session duration, max power, diagnostic
**Config flow:** full UI + options flow to change power source without reinstalling