### PR TITLE
Adds new integration [Koky05/comair-modbus-homeassistant]

### DIFF
--- a/integration
+++ b/integration
@@ -1155,6 +1155,7 @@
   "kodi1/songpal_m",
   "kodi1/tvh_rec",
   "koenhendriks/ha-eplucon",
+  "Koky05/comair-modbus-homeassistant",
   "Koky05/ha-budgetbakers-wallet",
   "KoljaWindeler/ics",
   "KoljaWindeler/kaco",


### PR DESCRIPTION
## Adds new integration [Koky05/comair-modbus-homeassistant]

### Repository
https://github.com/Koky05/comair-modbus-homeassistant

### Description
Home Assistant HACS integration for **ComAir HRUC-Plus 3 VL** (Vent-Axia) ventilation units via Modbus RTU over TCP.

### Checklist
- [x] Repository is public
- [x] Repository has a description
- [x] Repository has topic `hacs-integration`
- [x] Repository has `hacs.json` at root
- [x] Integration has `manifest.json` with `version` field
- [x] Integration uses config flow (UI setup)
- [x] Repository has at least one release (v1.0.0)
- [x] Repository has `README.md`
- [x] Integration has English translations
- [x] Domain does not conflict with built-in HA integrations