### PR TITLE
Adds new integration [Hybirdss/smartest-tv]

### DIFF
--- a/integration
+++ b/integration
@@ -909,6 +909,7 @@
   "hultenvp/solis-sensor",
   "hwmland/homeassistant-xmrig",
   "hwmland/homeassistant-xmrpool_stat",
+  "Hybirdss/smartest-tv",
   "hydroqc/hydroqc-ha",
   "hyperb1iss/signalrgb-homeassistant",
   "Hyrla/integration_bwt_cosmy_ha",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/Hybirdss/smartest-tv/releases/tag/v1.0.1>
Link to successful HACS action (without the `ignore` key): <https://github.com/Hybirdss/smartest-tv/actions/runs/24265730427>
Link to successful hassfest action (if integration): <https://github.com/Hybirdss/smartest-tv/actions/runs/24265730415>