### PR TITLE
Add drone mobile home assistant integration

### DIFF
--- a/integration
+++ b/integration
@@ -268,6 +268,7 @@
   "binarylogic/madvr-envy-homeassistant",
   "binarylogic/stewart-filmscreen-homeassistant",
   "binsentsu/home-assistant-solaredge-modbus",
+  "bjhiltbrand/drone_mobile_home_assistant"
   "bjorncs/ha-brewcreator",
   "BJReplay/EPA_AirQuality_HA",
   "BJReplay/ha-solcast-solar",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [X] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [X] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [X] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [X] The actions are passing without any disabled checks in my repository.
- [X] I've added a link to the action run on my repository below in the links section.
- [X] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/bjhiltbrand/drone_mobile_home_assistant/releases/tag/2026.4.10>
Link to successful HACS action (without the `ignore` key): <https://github.com/bjhiltbrand/drone_mobile_home_assistant/actions/runs/24269025156>
Link to successful hassfest action (if integration): <https://github.com/bjhiltbrand/drone_mobile_home_assistant/actions/runs/24269025163>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->