### PR TITLE
Add cnc-lasercraft/device-saver

### DIFF
--- a/integration
+++ b/integration
@@ -394,6 +394,7 @@
   "Cmajda/ha_golemio",
   "CMGeorge/homeassistant_sabiana_smart_energy",
   "cmgrayb/hass-dyson",
+  "cnc-lasercraft/device-saver",
   "cnecrea/cursbnr",
   "cnecrea/eonromania",
   "cnecrea/erovinieta",


### PR DESCRIPTION
## Checklist

- [x] I have read the [publishing docs](https://hacs.xyz/docs/publish/start)
- [x] I have added a [HACS Action](https://hacs.xyz/docs/publish/action) to the repository
- [x] I have added a [Hassfest Action](https://developers.home-assistant.io/docs/creating_integration_manifest) to the repository

## What does the integration do?

Device Saver monitors all Home Assistant devices and alerts when they stop responding. It auto-discovers devices, classifies them by connection type (Zigbee, Thread, WLAN, etc.), and creates persistent notifications when devices go offline.

- Auto-discovery of all devices with exclusion list
- Two timeout tiers: Critical (default 15min) and Slow (default 90min)
- Persistent notifications with auto-dismiss on recovery
- Optional mobile push notifications
- Dashboard card included

## Repository

https://github.com/cnc-lasercraft/device-saver