### PR TITLE
Adds new integration [notDIRK/luxtronik2-hass]

### DIFF
--- a/integration
+++ b/integration
@@ -1523,6 +1523,7 @@
   "nnnlog/homeassistant-cvnet-smarthome",
   "nordicopen/easee_hass",
   "normcyr/home-assistant-montreal-aqi",
+  "notDIRK/luxtronik2-hass",
   "NoUsername10/Solax-Cloud-API-for-Home-assistant",
   "NoUsername10/Sunlight_Visualizer",
   "nowocain/PhotoFrameCast",


### PR DESCRIPTION
## Repository

https://github.com/notDIRK/luxtronik2-hass

## Description

**Luxtronik 2.0 (Home Assistant)** — HACS integration for Luxtronik 2.0 heat pump controllers (Alpha Innotec, Novelan, Buderus, Nibe, Roth, Elco, Wolf).

Talks directly to the heat pump via the `luxtronik` library (port 8889). No Modbus layer, no extra services.

### Features
- 31+ entities: temperatures, operating modes, power, status, setpoints, SG-Ready
- **Bath Boost (Badebooster)**: on-demand hot water heating with progress tracking
- **Solar Boost**: auto-raise hot water setpoint on solar surplus
- **Night Heating Pause**: auto-disable floor heating at night
- Config flow UI, bilingual (EN+DE), write rate limiting
- Single-connection safe (connect-per-call + asyncio lock)

### Checklist
- [x] Repository is not a fork
- [x] manifest.json has all required keys (domain, name, version, documentation, issue_tracker, codeowners)
- [x] config_flow: true in manifest
- [x] GitHub release exists (v1.2.0)
- [x] English translations in translations/en.json
- [x] Brand assets in brand/ directory
- [x] MIT License