### PR TITLE
Adds new integration [o-mettam/HomeAssistant-WebexStatus]

### DIFF
--- a/integration
+++ b/integration
@@ -1531,6 +1531,7 @@
   "nyffchanium/argoclima-integration",
   "NylonDiamond/homeassistant-wrist-assistant",
   "nzrutman/hello_fairy_ble",
+  "o-mettam/HomeAssistant-WebexStatus",
   "odya/hass-ina219-ups-hat",
   "ofalvai/home-assistant-candy",
   "ohheyrj/home-assistant-aws-codepipeline",


### PR DESCRIPTION
Adding UI/UX for Home Assistant Webex Status integration so users don't have to edit the configuration.yaml file directly.

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/o-mettam/HomeAssistant-WebexStatus/releases/tag/v1.0.1>
Link to successful HACS action (without the `ignore` key): <https://github.com/o-mettam/HomeAssistant-WebexStatus/actions/runs/24348813660>
Link to successful hassfest action (if integration): <https://github.com/o-mettam/HomeAssistant-WebexStatus/actions/runs/24348813686>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->