### PR TITLE
Add vdgced/ha-card-playground

### DIFF
--- a/plugin
+++ b/plugin
@@ -538,6 +538,7 @@
   "usernein/tailwindcss-template-card",
   "usernein/tv-card",
   "vasqued2/ha-teamtracker-card",
+  "vdgced/ha-card-playground",
   "VeniVidiVici/givtcp-power-flow-card",
   "victorigualada/lovelace-solar-card",
   "Villhellm/lovelace-clock-card",


### PR DESCRIPTION
## Checklist

- [x] I have read and understand the [requirements](https://hacs.xyz/docs/publish/include/)
- [x] The repository is public
- [x] The repository has a description
- [x] The repository has GitHub Issues enabled
- [x] The repository has at least one GitHub topic
- [x] The repository has a README
- [x] A `hacs.json` file exists in the root of the repository
- [x] The HACS validation action runs and passes without any `ignore` keys
- [x] A release exists

## Links

- Repository: https://github.com/vdgced/ha-card-playground
- HACS Action run (passing): https://github.com/vdgced/ha-card-playground/actions
- Latest release: https://github.com/vdgced/ha-card-playground/releases/tag/v0.7.91

## Description

**HA Card Playground** is a Home Assistant sidebar panel providing a full-featured YAML editor with live card preview, smart autocomplete (7447 MDI icons with SVG preview, entity IDs, services, Jinja2 templates, CSS), a YAML checker, drag & drop file support, and a detachable preview window for dual-screen setups.