### PR TITLE
Add bigmoby/home-assistant-candy

### DIFF
--- a/integration
+++ b/integration
@@ -261,6 +261,7 @@
   "biclighter81/wattwallet-ha",
   "bieniu/ha-meteo-imgw-pib",
   "bieniu/ha-perplexity",
+  "bigmoby/home-assistant-candy",
   "BigNocciolino/CryptoTracker",
   "BigPiloto/ha-drugstore-stock",
   "binarydev/ha-generac",


### PR DESCRIPTION
Add custom integration for Candy Washing Machines & Dishwashers to the default store. All HACS quality checks are passing.

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [X] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [X] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [X] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [X] The actions are passing without any disabled checks in my repository.
- [X] I've added a link to the action run on my repository below in the links section.
- [X] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/bigmoby/home-assistant-candy/releases/tag/v1.2.0>
Link to successful HACS action (without the `ignore` key): <https://github.com/bigmoby/home-assistant-candy/actions/runs/24409755966/job/71302955304>
Link to successful hassfest action (if integration): <https://github.com/bigmoby/home-assistant-candy/actions/runs/24409755966/job/71302955324>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->