### PR TITLE
Add kildahldev/unofficial-polestar-api

### DIFF
--- a/integration
+++ b/integration
@@ -1132,6 +1132,7 @@
   "kgn3400/trafikmeldinger",
   "kgn3400/wage_calculator",
   "kgstorm/home-assistant-calorie-tracker",
+  "kildahldev/unofficial-polestar-api",
   "killer0071234/ha-hiq",
   "kimjohnsson/wiheat",
   "KipK/marees_france",


### PR DESCRIPTION
Adds [unofficial-polestar-api](https://github.com/kildahldev/unofficial-polestar-api) to the HACS default integration list.

Unofficial Home Assistant integration for Polestar vehicles with real-time streaming via gRPC. Supports battery, location, climate, locks, charging, OTA updates, and more.

- HACS and Hassfest validations passing
- Has `hacs.json`, brand assets, and release workflow with zip artifacts