### PR TITLE
Adds new plugin [Padraiggg/Padraigggs-ha-interactive-floorplan]

### DIFF
--- a/plugin
+++ b/plugin
@@ -398,6 +398,7 @@
   "pacemaker82/Compact-Power-Card",
   "pacemaker82/Home-Climate-Card",
   "pacemaker82/Sections-Gauge-Card",
+  "Padraiggg/Padraigggs-ha-interactive-floorplan",
   "partach/switch_port_card",
   "pennisiandrea/media-explorer-card",
   "petergridge/Irrigation-Card",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/Padraiggg/Padraigggs-ha-interactive-floorplan/releases/tag/v1.1.8>
Link to successful HACS action (without the `ignore` key): <https://github.com/Padraiggg/Padraigggs-ha-interactive-floorplan/actions/runs/24178035339>
Link to successful hassfest action (if integration): <>