### PR TITLE
Adds new integration [htiel/LCARS-lovelace-dashboard]

### DIFF
--- a/integration
+++ b/integration
@@ -900,6 +900,7 @@
   "hsakoh/ha-switchbot-kvs-camera",
   "hsk-dk/home-assistant-thermex",
   "hstrohmaier/ha_comfoconnectpro",
+  "htiel/LCARS-lovelace-dashboard",
   "htlemos/keeplink-homeassistant",
   "hudsonbrendon/HA-drivvo",
   "hudsonbrendon/HA-solar-plus-intelbras",


### PR DESCRIPTION
## Repository
htiel/LCARS-lovelace-dashboard

A Star Trek LCARS (Library Computer Access/Retrieval System) dashboard for Home Assistant. Auto-discovers floors, areas, devices and entities with LCARS-themed panels for battery, climate, power, weather, media, cameras, and more.

- Public repo with MIT license
- Valid hacs.json and manifest.json
- Multiple GitHub releases (latest: 4.16.1)
- Full README with screenshots
- HACS installable custom integration