### PR TITLE
Adds new integration [vincentto13/hass-energa-outages]

### DIFF
--- a/integration
+++ b/integration
@@ -2141,6 +2141,7 @@
   "vgcouso/ha-tracker",
   "vigonotion/hass-simpleicons",
   "VilniusTechnology/ha-unavailable-devices-report",
+  "vincentto13/hass-energa-outages",
   "vincentwolsink/home_assistant_micronova_agua_iot",
   "vingerha/gtfs2",
   "vinnybad/choremander",


### PR DESCRIPTION
* Add vincentto13/hass-energa-outages to integration list

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [ ] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

Had to disable brand checking, as there is no "Energa Operator" brand in home assistant, and I guess I'm not able to add one due to legal constraints

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: https://github.com/vincentto13/hass-energa-outages/releases/tag/v0.1.0
Link to successful HACS action (without the `ignore` key): https://github.com/vincentto13/hass-energa-outages/actions/runs/24432484085
Link to successful hassfest action (if integration): https://github.com/vincentto13/hass-energa-outages/actions/runs/24432484082

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->