### PR TITLE
Add raman325/ha-integration-tester

### DIFF
--- a/integration
+++ b/integration
@@ -1681,6 +1681,7 @@
   "radical-squared/aquatemp",
   "raelix/HA-Radoff-integration",
   "Rafciq/BM6",
+  "raman325/ha-integration-tester",
   "raman325/ha-zoom-automation",
   "raman325/lock_code_manager",
   "ramirezhr/ha-winkhaus-doorclient",


### PR DESCRIPTION
## New integration

**Repository:** https://github.com/raman325/ha-integration-tester

**Description:** Integration Tester is a Home Assistant custom integration that downloads and installs custom integrations from GitHub URLs for testing. Supports external HACS-compatible repos (branches, PRs, commits) and Home Assistant core repo (extracts single integrations from PRs/branches/commits).

**Features:**
- Install integrations from GitHub PRs, branches, or commits
- Track updates with polling and update entities
- Services for programmatic add/list/remove
- Repair issues for PR closed/merged, restart required, etc.
- Supports both custom integrations and HA core integrations