### PR TITLE
Include ATMOCE BATTERY (Modbus+Cloud) support

### DIFF
--- a/integration
+++ b/integration
@@ -1559,6 +1559,7 @@
   "oven-lab/tuya_cloud_map_extractor",
   "owanvik/ha-nodvarsel",
   "p0l0/hapetwalk",
+  "https://github.com/pacorola/Atmoce_battery_HA",
   "pail23/stiebel_eltron_isg_component",
   "pajeronda/xai_conversation",
   "PalmManiac/battery-smartflow-ai",


### PR DESCRIPTION
**Checklist**

 

- [x] I've read the [publishing 
- [x] documentation](https://hacs.xyz/docs/publish/start).
- [x]  I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.


- [x] The actions are passing without any disabled checks in my repository.
- [x]  I've added a link to the action run on my repository below in the links section.
- [x]  I've created a new release of the repository after the validation actions were run successfully.

**Links**
Link to current release: <https://github.com/pacorola/Atmoce_battery_HA> 
Link to successful HACS action (without the ignore key): <https://github.com/pacorola/Atmoce_battery_HA/actions/runs/24519320044/job/71672288344> 
Link to successful hassfest action (if integration): <https://github.com/pacorola/Atmoce_battery_HA/actions/runs/24519319871/job/71672288454>