### PR TITLE
Add dn5qMDW3/briiv

### DIFF
--- a/integration
+++ b/integration
@@ -589,6 +589,7 @@
   "dmoo500/ekz-ha",
   "dmoralesdev/zha_lock_manager",
   "dmoranf/home-assistant-wattio",
+  "dn5qMDW3/briiv",
   "dolezsa/thermal_comfort",
   "dominikamann/oekofen-pellematic-compact",
   "DominikStarke/becker_centralcontrol_has",


### PR DESCRIPTION
Adds `dn5qMDW3/briiv` — a Home Assistant custom integration for [Briiv](https://briiv.com/) air purifiers.

Communicates locally over UDP (no cloud). Supports Briiv and Briiv Pro with fan control (power, speed 25/50/75/100%, boost) and PM1/PM2.5/PM4/PM10, VOC, CO, NOx, temperature, and humidity sensors.

- Repo: https://github.com/dn5qMDW3/briiv
- Latest release: v1.0.3
- HACS + Hassfest validation: passing on master