### PR TITLE
Add homeassistant-homgar integration

### DIFF
--- a/integration
+++ b/integration
@@ -313,6 +313,7 @@
   "bremor/bureau_of_meteorology",
   "bremor/public_transport_victoria",
   "brewmarsh/meraki-homeassistant",
+  "brettmeyerowitz/homeassistant-homgar",
   "brezlord/hass-waterco-electrochlor",
   "brianegge/home-assistant-sdnotify",
   "brianegge/homeassistant-magewell",


### PR DESCRIPTION
## Summary
Add `brettmeyerowitz/homeassistant-homgar` to the default integration list.

## Repository
- https://github.com/brettmeyerowitz/homeassistant-homgar

## Validation
- HACS validation workflow passes
- Hassfest workflow passes
- GitHub release published: `v3.0.28`
