### PR TITLE
Add sdunster/ha-visual-timer-card

### DIFF
--- a/plugin
+++ b/plugin
@@ -456,6 +456,7 @@
   "Sdahl1234/sunseeker-schedule-card",
   "Sdahl1234/sunseeker-zone-card",
   "sdelliot/pie-chart-card",
+  "sdunster/ha-visual-timer-card",
   "seevee/weather_alerts_card",
   "selvalt7/badge-horizontal-container-card",
   "selvalt7/modern-circular-gauge",


### PR DESCRIPTION
## Submission

- **Repository:** https://github.com/sdunster/ha-visual-timer-card
- **Category:** plugin (Lovelace card)

## Description

A circular visual timer card for Home Assistant that tracks a `timer.*` entity. The arc sweeps down as the timer counts down. Remaining time is displayed as a smart unit (h / m / s). Supports configurable completion flash and four sizes (S, M, L, XL).

## Checklist

- [x] The repository has at least one release
- [x] The repository has a `hacs.json` file
- [x] The repository has a `README.md`
- [x] The repository follows the HACS repository requirements