### PR TITLE
Add bluenazgul/unifi-device-card to plugin

### DIFF
--- a/plugin
+++ b/plugin
@@ -40,6 +40,7 @@
   "BigPiloto/ha-drugstore-stock-card",
   "bkbilly/lnxlink-touchpad-card",
   "blaineventurine/simple-inventory-card",
+  "bluenazgul/unifi-device-card",
   "Bobsilvio/calcio-live-card",
   "bokub/rgb-light-card",
   "bolkedebruin/erhv-lovelace",


### PR DESCRIPTION
## Checklist

- [x] I am the owner or a major contributor of this repository.
- [x] The repository is public and hosted on GitHub.
- [x] The repository can be added to HACS as a custom repository.
- [x] The HACS validation action passes without errors or ignores.
- [x] A full GitHub release has been created after the validation passed.
- [x] The repository has been added to the correct file (`plugin`) in alphabetical order.

## Repository

- **Name:** UniFi Device Card
- **Repository:** `bluenazgul/unifi-device-card`
- **Type:** Plugin

## Description

This pull request adds `bluenazgul/unifi-device-card` to the default HACS plugin list.

The repository provides a custom Lovelace card for Home Assistant focused on displaying UniFi device information and controls in a single card.

## Notes

- The repository includes a `hacs.json` file.
- The repository is maintained and not archived.
- A GitHub release is available.