### PR TITLE
Add bluenazgul/unifi-device-card to default plugins

### DIFF
--- a/plugin
+++ b/plugin
@@ -40,6 +40,7 @@
   "BigPiloto/ha-drugstore-stock-card",
   "bkbilly/lnxlink-touchpad-card",
   "blaineventurine/simple-inventory-card",
+  "bluenazgul/unifi-device-card",
   "Bobsilvio/calcio-live-card",
   "bokub/rgb-light-card",
   "bolkedebruin/erhv-lovelace",


### PR DESCRIPTION
Link to successful HACS action:
https://github.com/bluenazgul/unifi-device-card/actions/runs/24565599775

Link to latest release:
https://github.com/bluenazgul/unifi-device-card/releases/latest

## Checklist

- [x] I am the owner or a major contributor of this repository.
- [x] The repository is public and hosted on GitHub.
- [x] The repository can be added to HACS as a custom repository.
- [x] The HACS validation action passes without errors or ignores.
- [x] A full GitHub release has been created after the validation passed.
- [x] The repository has been added to the correct file (`plugin`) in alphabetical order.

## Repository

- **Name:** UniFi Device Card
- **Repository:** `bluenazgul/unifi-device-card`
- **Type:** Plugin

## Description

This pull request adds `bluenazgul/unifi-device-card` to the default HACS plugin list.

The repository provides a custom Lovelace card for Home Assistant focused on displaying UniFi device information and controls in a single card.