### PR TITLE
Add delgusto/ha-bulk-entity-editor

### DIFF
--- a/integration
+++ b/integration
@@ -540,6 +540,7 @@
   "Dekadinious/trsdm_custom_device_tracker_for_home_assistant",
   "DeKaN/ha-boneco",
   "deler-aziz/fuel_prices_sweden",
+  "delgusto/ha-bulk-entity-editor",
   "delize/home-assistant-loggamera-integration",
   "delphiki/hass-pronote",
   "delphiki/hass-tarif-edf",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: https://github.com/delgusto/ha-bulk-entity-editor/releases/tag/v0.1.1
Link to successful HACS action (without the \`ignore\` key): https://github.com/delgusto/ha-bulk-entity-editor/actions/runs/24604044921
Link to successful hassfest action (if integration): https://github.com/delgusto/ha-bulk-entity-editor/actions/runs/24604044921

---

**Repository:** https://github.com/delgusto/ha-bulk-entity-editor
**Category:** Integration

### Description

Bulk Entity Editor adds a sidebar panel to Home Assistant that lets administrators multi-select entities and apply changes in one action — change area, enable/disable, show/hide, and rename (friendly name or entity_id, with prefix/suffix/find-replace, live preview, and collision detection). Useful for cleaning up dead entities and reorganising large registries after onboarding new integrations.

Brand assets are shipped in-repo at \`custom_components/bulk_entity_editor/brand/\` per the [HA 2026.3 brands proxy API](https://developers.home-assistant.io/blog/2026/02/24/brands-proxy-api).