### PR TITLE
Add Rad Pro USB integration

### DIFF
--- a/integration
+++ b/integration
@@ -1965,6 +1965,7 @@
   "sugoi-wada/acer-air-monitor-2018",
   "SukramJ/homematicip_local",
   "sumgup0/FanimationHA-AC-BT",
+  "SunboX/radpro-home-assistant-plugin",
   "sunology-tech/sunology-ha",
   "superbox-dev/keba_keenergy",
   "Superkikim/mh-maxsmart-hass",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/SunboX/radpro-home-assistant-plugin/releases/tag/v0.1.0>
Link to successful HACS action (without the `ignore` key): <https://github.com/SunboX/radpro-home-assistant-plugin/actions/runs/24609601091>
Link to successful hassfest action (if integration): <https://github.com/SunboX/radpro-home-assistant-plugin/actions/runs/24609601080>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->
