### PR TITLE
Add Dreame Lawn Mower integration

### DIFF
--- a/integration
+++ b/integration
@@ -683,6 +683,7 @@
   "evercape/hass-resol-KM2",
   "evilmarty/mjpeg-timelapse",
   "evilmarty/switch_fan",
+  "EvotecIT/homeassistant-dreamelawnmower",
   "EVWorth/hass-adtpulse",
   "exavizco/ha-poe-plugin",
   "exKAjFASH/media_player.elkoep_lara",


### PR DESCRIPTION
Adds `EvotecIT/homeassistant-dreamelawnmower` to the default integration repository list.

Repository: https://github.com/EvotecIT/homeassistant-dreamelawnmower
First release: https://github.com/EvotecIT/homeassistant-dreamelawnmower/releases/tag/v0.1.0

Local checks before opening:
- `python scripts/is_sorted.py`
- `python -m json.tool integration`

The integration repository currently has passing Validate and Hassfest workflows on `main`.