### PR TITLE
Add ralmoe/otto-wilde-g32-cloudless-hass

### DIFF
--- a/integration
+++ b/integration
@@ -1684,6 +1684,7 @@
   "radical-squared/aquatemp",
   "raelix/HA-Radoff-integration",
   "Rafciq/BM6",
+  "ralmoe/otto-wilde-g32-cloudless-hass",
   "raman325/ha-zoom-automation",
   "raman325/lock_code_manager",
   "ramirezhr/ha-winkhaus-doorclient",


### PR DESCRIPTION
## Checklist

- [x] I have read the [HACS documentation](https://hacs.xyz/docs/publish/start)
- [x] The repository is public
- [x] The repository has a description
- [x] The repository has a README
- [x] The repository has a license (GPL-3.0)
- [x] The repository has a release/tag
- [x] The repository has a valid `hacs.json`
- [x] The repository has a valid `manifest.json`
- [x] The GitHub Actions (Validate + Hassfest) are passing on `main`
- [x] Brand assets are available in [home-assistant/brands](https://github.com/home-assistant/brands/tree/master/custom_integrations/otto_wilde_g32)

## Repository

https://github.com/ralmoe/otto-wilde-g32-cloudless-hass

## Description

Home Assistant integration for the Otto Wilde G32 grill. Receives temperature data directly via local WiFi without cloud dependency.

## Category

Integration

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: https://github.com/ralmoe/otto-wilde-g32-cloudless-hass/releases/tag/v1.0.1
Link to successful HACS action (without the `ignore` key): https://github.com/ralmoe/otto-wilde-g32-cloudless-hass/actions/runs/24639641781
Link to successful hassfest action (if integration): https://github.com/ralmoe/otto-wilde-g32-cloudless-hass/actions/runs/24639641777

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->