### PR TITLE
Add kunalkhosla/ecoplug-homeassistant

### DIFF
--- a/integration
+++ b/integration
@@ -1196,6 +1196,7 @@
   "kubawolanin/ha-reaper",
   "kuchel77/diskspace",
   "kukulich/home-assistant-jablotron100",
+  "kunalkhosla/ecoplug-homeassistant",
   "kverqus/hassam",
   "kwuest/BAPI-Wireless-HA-Integration",
   "LaggAt/ha-jokes",


### PR DESCRIPTION
Adding `kunalkhosla/ecoplug-homeassistant`, a local (no-cloud) Home Assistant integration for the DEWENWILS / ECO Plugs family of 240V Wi-Fi smart plugs (pool pumps, heaters, etc).

- Reverse-engineered UDP protocol on port 1022. No cloud, no vendor app account required.
- Tested on DEWENWILS HOWT01A (Amazon ASIN B07PP2KNNH). Should also work on other units in the ECO Plugs family (WiOn / Woods / Workchoice / KAB).
- GitHub Action runs `hacs/action` + `hassfest` + unit tests on every push.
- Release: https://github.com/kunalkhosla/ecoplug-homeassistant/releases/tag/v0.2.1