### PR TITLE
Add marcovolt/homeassistant-binance

### DIFF
--- a/integration
+++ b/integration
@@ -1314,6 +1314,7 @@
   "MarcoGos/davis_vantage",
   "MarcoGos/kleenex_pollenradar",
   "marcolivierarsenault/moonraker-home-assistant",
+  "marcovolt/homeassistant-binance",
   "MarcusTaz/ha_kia_hyundai_USA",
   "mariusz-ostoja-swierczynski/tech-controllers",
   "markaggar/ha-media-index",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start)
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository
- [x] For integrations only, I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository

Adds `marcovolt/homeassistant-binance` as a default HACS integration repository.

## Required links
- Latest release: https://github.com/marcovolt/homeassistant-binance/releases/tag/v1.0.9
- HACS validation run: https://github.com/marcovolt/homeassistant-binance/actions/runs/24681310493
- Hassfest run: https://github.com/marcovolt/homeassistant-binance/actions/runs/24681310457

This repository is public and includes:
- valid `manifest.json`
- valid `hacs.json`
- branding assets
- issues enabled
- GitHub release
- passing HACS validation
- passing Hassfest

This fork adds functionality not available in the upstream repository, including automatic EUR portfolio support and removal of manual coin symbol entry requirements. It is maintained independently as a separate HACS-installable integration.