### PR TITLE
Add BlackCube4/TabCard to plugin list

### DIFF
--- a/plugin
+++ b/plugin
@@ -39,6 +39,7 @@
   "bernikr/lovelace-webos-keyboard-card",
   "BigPiloto/ha-drugstore-stock-card",
   "bkbilly/lnxlink-touchpad-card",
+  "BlackCube4/TabCard",
   "blaineventurine/simple-inventory-card",
   "Bobsilvio/calcio-live-card",
   "bokub/rgb-light-card",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/BlackCube4/TabCard/releases/latest>
Link to successful HACS action (without the `ignore` key): <https://github.com/BlackCube4/TabCard/actions/runs/24748557859/job/72406946346>
Link to successful hassfest action (if integration): <>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->