### PR TITLE
Add smart fountain card to plugin list

### DIFF
--- a/plugin
+++ b/plugin
@@ -386,6 +386,7 @@
   "Nisbo/ha-shopping-list-improved",
   "nitaybz/apple-home-dashboard",
   "noambergauz/dreame-vacuum-map-card",
+  "Noco242/smart-fountain-card",
   "nutteloost/actions-card",
   "nutteloost/simple-swipe-card",
   "nutteloost/todo-swipe-card",


### PR DESCRIPTION
Added 'Noco242/smart-fountain-card' to the plugin list.

## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: https://github.com/Noco242/smart-fountain-card/releases/latest
Link to successful HACS action: https://github.com/Noco242/smart-fountain-card/actions/runs/24768930966
Link to successful hassfest action (if integration): https://github.com/Noco242/smart-fountain-card/actions/runs/24768930966