### PR TITLE
Add JayDeeCo-Limited/homekit-climate-plus

### DIFF
--- a/integration
+++ b/integration
@@ -995,6 +995,7 @@
   "jasperslits/haithowifi",
   "JayBlackedOut/hass-nhlapi",
   "jaycollett/OpenIRBlaster",
+  "JayDeeCo-Limited/homekit-climate-plus",
   "jaydeethree/Home-Assistant-weatherdotcom",
   "jayjojayson/hass-victron-vrm-api",
   "jazzz/ha-evocarshare",


### PR DESCRIPTION
## Add JayDeeCo-Limited/homekit-climate-plus

Adds the HomeKit Climate Plus custom integration to the HACS default store.

### About
https://github.com/JayDeeCo-Limited/homekit-climate-plus

A Home Assistant custom integration that exposes `climate.*` entities to Apple HomeKit as single rich accessories (one tile per climate with linked fan-speed, swing, preset-mode switches, and linked humidity/battery sensors). Runs its own pyhap bridge alongside the stock HomeKit Bridge. Auto-maps arbitrary fan / swing / preset mode names onto HomeKit's predefined-set filter, so entities like a Daikin reporting `fan_modes=[Auto, Silence, 1..5]` and `swing_modes=[Off, Vertical, Horizontal, 3D]` get full control in Apple Home (instead of no fan/swing exposure at all from the stock bridge).

### HACS validation
- Repository: MIT license, descriptive README, hacs.json, manifest.json with HA minimum 2025.1.0
- Topics set: `home-assistant`, `hacs`, `hacs-integration`, `homekit`, `homekit-bridge`, `climate`
- Brand assets submitted to home-assistant/brands: home-assistant/brands#10190
- Latest release: [v0.5.0](https://github.com/JayDeeCo-Limited/homekit-climate-plus/releases/tag/v0.5.0)
- CI (hassfest + HACS validation + pytest) green on every commit to `main`