### PR TITLE
Adds new integration [actabi/delonghi_coffeelink]

### DIFF
--- a/integration
+++ b/integration
@@ -31,6 +31,7 @@
   "aceindy/Duepi_EVO",
   "acesyde/hassio_mylight_integration",
   "achilleasa/flamerite_ha",
+  "actabi/delonghi_coffeelink",
   "ad-ha/mg-saic-ha",
   "adamf83/my-rail-commute",
   "adammcdonagh/home-assistant-powervault",


### PR DESCRIPTION
## Repository

https://github.com/actabi/delonghi_coffeelink

## Integration description

Home Assistant integration for De'Longhi PrimaDonna Soul and other Coffee Link machines, using the Ayla Networks cloud protocol (same protocol used by the official De'Longhi Coffee Link mobile app).

Provides cloud-polling entities for machine status, beverage selection, and remote brewing control, with config flow (UI-based setup).

## Checklist

- [x] The repository has a valid `hacs.json`
- [x] The repository has GitHub topics
- [x] The repository has a published release (v0.2.0)
- [x] The `Validate` workflow passes on the latest commit
- [x] Integration lives under `custom_components/delonghi_coffeelink/`