### PR TITLE
Add Icon Explorer Card

### DIFF
--- a/plugin
+++ b/plugin
@@ -479,6 +479,7 @@
   "sopelj/lovelace-kanji-clock-card",
   "starwarsfan/qclock-card",
   "stefmde/HomeAssistant-TwitchFollowedLiveStreamsCard",
+  "steuerlexi/icon-explorer-card",
   "studiobts/device-pulse-table-card",
   "studiobts/device-pulse-timeline-card",
   "superdingo101/skylight-calendar-card",


### PR DESCRIPTION
## 📋 PR Checklist

- [x] I've read the [requirements](https://hacs.xyz/docs/publish/include) for adding a repository.
- [x] My repository is a custom card for Home Assistant.
- [x] I've added the HACS action to my repository for validation.

## 🔗 Repository

**https://github.com/steuerlexi/icon-explorer-card**

## ✨ Description

Icon Explorer Card is a Lovelace custom card that lets users search and browse 18,000+ icons from all installed icon packs with live search, pagination, and one-click copy to clipboard.

### Supported Packs
- Material Design Icons (`mdi:`)
- Hass Hue Icons (`hue:`)
- Custom Brand Icons (`phu:`)
- Simple Icons (`si:`)
- Fluent UI System Icons (`fluent:`)
- IconPark (`icon-park:`)
- SVG Logos (`logos:`)
- Weather Icons (`wi:`)

### Features
- Live search across all packs
- Paginated loading (no browser freeze)
- One-click copy to clipboard
- 24h localStorage caching
- Fully configurable columns, icon size, page size, and pack selection

## 🖼️ Screenshot

<img width=\"562\" height=\"260\" alt=\"image\" src=\"https://github.com/user-attachments/assets/5b3cc111-3c07-4d21-b157-069a5ab121f1\" />

## 🏷️ Release

Latest release: **v1.0.1**