### PR TITLE
Add Niek/ha-velux-active

### DIFF
--- a/integration
+++ b/integration
@@ -1516,6 +1516,7 @@
   "Nicxe/home-assistant-smhialerts",
   "Nicxe/homeassistant-trafikinfo-se",
   "Nicxe/krisinformation",
+  "Niek/ha-velux-active",
   "nielsfaber/alarmo",
   "nielsfaber/scheduler-component",
   "nielstron/inteno_hass",


### PR DESCRIPTION
## Summary

Add Niek/ha-velux-active to the default HACS integration repositories.

## Validation

- Verified the repository has passing HACS and Hassfest workflows.
- Verified published release v0.1.1 exists.
- Ran local JSON, sorting, changed repository/category, existing, removed, release, and owner checks.