### PR TITLE
Add new integration 'gaboriaudn/suivi-alimentation-ha'

### DIFF
--- a/integration
+++ b/integration
@@ -759,6 +759,7 @@
   "g470258/hass-esplus",
   "g4bri3lDev/munich_public_transport",
   "gabest11/homeassistant-brother_scanner",
+  "gaboriaudn/suivi-alimentation-ha",
   "gadgetchnnel/entities_calendar",
   "ganhammar/hass-mcp-server",
   "ganhammar/hass-oidc-server",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: https://github.com/gaboriaudn/suivi-alimentation-ha/releases/tag/v0.0.22
Link to successful HACS action (without the `ignore` key): https://github.com/gaboriaudn/suivi-alimentation-ha/actions
Link to successful hassfest action (if integration): <>