### PR TITLE
Add dougrathbone/2n-doorman

### DIFF
--- a/integration
+++ b/integration
@@ -602,6 +602,7 @@
   "dotelpenguin/ha-integration-jirafilters",
   "doubleukay/godaikin-ha",
   "doudz/homeassistant-myjdownloader",
+  "dougrathbone/2n-doorman",
   "dphae/bsh",
   "drakhart/ha-super-soco-custom",
   "drc38/Fronius_solarweb",


### PR DESCRIPTION
**Repository:** https://github.com/dougrathbone/2n-doorman
**Category:** Integration

Doorman is a Home Assistant integration for managing users, access codes, and credentials on 2N IP intercoms — local-only, no cloud dependency.

- Config-flow setup (IP, API user/password)
- User/credential management UI in the HA sidebar (panel_custom)
- Access-log + long-poll event delivery (`doorman_access` events, ~1s latency)
- Relay switches + `grant_access` service
- Brand assets submitted in home-assistant/brands#10198

HACS validation (`hacs/action@main` with `category: integration`) is green on `main` and on the latest release (v0.2.6).