### PR TITLE
Add mosandlt/Bosch-Smart-Home-Camera-Tool-HomeAssistant

### DIFF
--- a/integration
+++ b/integration
@@ -1437,6 +1437,7 @@
   "moox-it/hass-moox-track",
   "moralmunky/Home-Assistant-Mail-And-Packages",
   "morosanmihail/HA-LondonTfL",
+  "mosandlt/Bosch-Smart-Home-Camera-Tool-HomeAssistant",
   "mossipcams/autosnooze",
   "mr-deamon/publibike_stations",
   "Mr-Groch/ambihue",


### PR DESCRIPTION
Home Assistant integration for Bosch Smart Home cameras (Eyes Outdoor, Eyes Outdoor II, 360 Indoor) with live streaming via TLS proxy, snapshots, privacy mode, motion alerts, and a Lovelace card. Supports both LOCAL (direct HTTPS/RTSP) and REMOTE (Bosch cloud) connection modes with automatic fallback.