### PR TITLE
Adds new integration [Herbertmt978/Norman_Gen1_HA_Integration]

### DIFF
--- a/integration
+++ b/integration
@@ -873,6 +873,7 @@
   "helv-io/ha-gif",
   "HenkieThee/clash_royale",
   "henricm/ha-ferroamp",
+  "Herbertmt978/Norman_Gen1_HA_Integration",
   "herikw/home-assistant-custom-components",
   "Hermesiss/itchio_homeassistant",
   "herruzo99/ista-calista",

--- a/integration
+++ b/integration
@@ -942,6 +942,7 @@
   "helv-io/ha-gif",
   "HenkieThee/clash_royale",
   "henricm/ha-ferroamp",
+  "Herbertmt978/Norman_Gen1_HA_Integration",
   "herikw/home-assistant-custom-components",
   "Hermesiss/itchio_homeassistant",
   "herruzo99/ista-calista",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/Herbertmt978/Norman_Gen1_HA_Integration/releases/tag/v0.1.6>
Link to successful HACS action (without the `ignore` key): <https://github.com/Herbertmt978/Norman_Gen1_HA_Integration/actions/runs/24914317726>
Link to successful hassfest action (if integration): <https://github.com/Herbertmt978/Norman_Gen1_HA_Integration/actions/runs/24914317720>

This adds a Home Assistant custom integration for Norman Gen 1 shutter hubs. It uses the hub's local Gen 1 HTTP endpoints and has been written for HACS installation as an integration.