### PR TITLE
Add Gaming Status integration

### DIFF
--- a/integration
+++ b/integration
@@ -33,6 +33,7 @@
   "achilleasa/flamerite_ha",
   "ad-ha/mg-saic-ha",
   "adamf83/my-rail-commute",
+  "adamjthompson/Gaming-Status",
   "adammcdonagh/home-assistant-powervault",
   "adamoutler/anycubic-homeassistant",
   "adonixis/ufanet_intercom_ha",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [X] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [X] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [X] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [X] The actions are passing without any disabled checks in my repository.
- [X] I've added a link to the action run on my repository below in the links section.
- [X] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/adamjthompson/Gaming-Status/releases/tag/v1.6.1>
Link to successful HACS action (without the `ignore` key): <https://github.com/adamjthompson/Gaming-Status/actions/runs/24937357949>
Link to successful hassfest action (if integration): <https://github.com/adamjthompson/Gaming-Status/actions/runs/24937357949>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->