### PR TITLE
Add evanraalte/hacs-caffeinetracker

### DIFF
--- a/integration
+++ b/integration
@@ -684,6 +684,7 @@
   "etiennec78/ha-artemis-rgb",
   "etiennec78/ha-celcat",
   "evantaur/seiverkot-consumption",
+  "evanraalte/hacs-caffeinetracker",
   "evercape/hass-resol-KM2",
   "evilmarty/mjpeg-timelapse",
   "evilmarty/switch_fan",


### PR DESCRIPTION
## Submission

- **Repository:** https://github.com/evanraalte/hacs-caffeinetracker
- **Category:** Integration

## Checklist

- [x] I am the owner of the repository
- [x] The repository is public
- [x] The repository has a description
- [x] The repository has a topic set (hacs, home-assistant, homeassistant, caffeine, custom-component)
- [x] Issues are enabled
- [x] The repository has a valid `hacs.json`
- [x] The repository has a valid `manifest.json`
- [x] The repository passes the HACS Action
- [x] The repository passes Hassfest
- [x] The repository has at least one release (latest: v0.2.1)
- [x] The repository has a README
- [x] The repository has a LICENSE (MIT)

## Description

A Home Assistant integration to track caffeine intake and model blood caffeine levels using a half-life decay formula. Supports multiple profiles, configurable half-life, absorption time, and services to log/remove consumption events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)