### PR TITLE
Rename hass-chargeamps repository reference

### DIFF
--- a/integration
+++ b/integration
@@ -1148,7 +1148,7 @@
   "kimjohnsson/wiheat",
   "KipK/marees_france",
   "KiraPC/ha-switchbot-remote",
-  "kirei/hass-chargeamps",
+  "hass-chargeamps/hass-chargeamps",
   "kirill-k2/hass-guk-krasnodar",
   "klacol/homeassistant-clage_homeserver",
   "klaptafel/ha-previous-state-tracker",


### PR DESCRIPTION
The repo for hass-chargeamps has moved to a proper org.

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [X] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [X] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [X] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [X] The actions are passing without any disabled checks in my repository.
- [X] I've added a link to the action run on my repository below in the links section.
- [X] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/hass-chargeamps/hass-chargeamps/releases/tag/v2.0.0>
Link to successful HACS action (without the `ignore` key): <https://github.com/hass-chargeamps/hass-chargeamps/actions/runs/24964722545/job/73097423393>
Link to successful hassfest action (if integration): <https://github.com/hass-chargeamps/hass-chargeamps/actions/runs/24964722530/job/73097423383>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->