### PR TITLE
Add SolaxCloud API integration

### DIFF
--- a/integration
+++ b/integration
@@ -1971,6 +1971,7 @@
   "stuartp44/hambrewclient",
   "studiobts/home-assistant-card-builder",
   "studiobts/home-assistant-device-pulse",
+  "Sturmi77/solax-cloud-api-ha",
   "StyraHem/ShellyForHASS",
   "sugoi-wada/acer-air-monitor-2018",
   "SukramJ/homematicip_local",


### PR DESCRIPTION
## Description

Adding the SolaxCloud API integration for Home Assistant.

**Repository:** https://github.com/Sturmi77/solax-cloud-api-ha

**What it does:**
- Integrates with the SolaxCloud Open API to monitor and control SolaxCloud devices from Home Assistant
- Currently supports EV Charger (X3-EVC-22K): 9 sensors, 3 selects, 1 number entity
- Self-healing token invalidation with UI re-authentication
- Energy Dashboard compatible sensor

**Checklist:**
- [x] Public GitHub repository
- [x] `hacs.json` present
- [x] `manifest.json` with all required fields (domain, documentation, issue_tracker, codeowners, name, version)
- [x] Single integration per repository
- [x] GitHub Release v1.0.0 created
- [x] `quality_scale.yaml` present