### PR TITLE
Add mrebbert/1komma5-ha

### DIFF
--- a/integration
+++ b/integration
@@ -1442,6 +1442,7 @@
   "Mr-Groch/ambihue",
   "Mr-Groch/HA-ESA-NASK-Air-Quality",
   "MrBearPresident/JBL_Soundbar",
+  "mrebbert/1komma5-ha",
   "mrhedstrom/ha-tibber-pulse-mqtt",
   "mrk-its/homeassistant-blitzortung",
   "MrSjodin/HomeAssistant_Trafiklab_Integration",


### PR DESCRIPTION
## Type

Adding a new integration to the default repositories.

## Repository

- Owner: `mrebbert`
- Name: `1komma5-ha`
- Domain: `onekommafive`
- Description: Unofficial Home Assistant integration for the 1KOMMA5° Heartbeat home energy platform — PV, battery, heat pump, EV charger and dynamic electricity prices.
- Repository URL: https://github.com/mrebbert/1komma5-ha

## Checklist

- [x] Repository is public, not archived, has issues enabled and a description.
- [x] Repository topics include `hacs` and `hacs-integration`.
- [x] `manifest.json` contains all required fields (`domain`, `name`, `documentation`, `issue_tracker`, `codeowners`, `version`).
- [x] `hacs.json` contains `name` and the minimum HA version (`2024.10`).
- [x] Repository has releases (latest: v0.1.32).
- [x] HACS Action and hassfest both pass on every push (workflow `validate.yml`, latest run green).
- [x] Brand directory with a 256×256 RGBA PNG icon at `custom_components/onekommafive/brand/icon.png`.
- [x] README documents installation (HACS + manual), configuration, services, and a comprehensive feature list.
- [x] CHANGELOG follows Keep-a-Changelog.
- [x] Issue templates for bug reports and feature requests.
- [x] Unit tests run on every push via GitHub Actions (`test.yml`).
- [x] I am the owner of the repository.

## Notes

The integration is built around the [`onekommafive`](https://github.com/mrebbert/1komma5-api) Python library (also maintained by me). Both libraries reverse-engineer the undocumented 1KOMMA5° Heartbeat API.