### PR TITLE
Add octopus_agile_window_finder to integration list

### DIFF
--- a/integration
+++ b/integration
@@ -1425,6 +1425,7 @@
   "mkuthan/solis-cloud-control",
   "mletenay/home-assistant-goodwe-inverter",
   "mmillmor/geo_home",
+  "mmillmor/octopus_agile_window_finder",
   "moag1000/beurer_daylight_lamps",
   "moarph/homeassistant_berner_torantriebe",
   "Moe8383/radar_map_manager",


### PR DESCRIPTION
Added octopus_agile_window_finder integration to the list of integrations

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [X ] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [X ] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ X] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [ X] The actions are passing without any disabled checks in my repository.
- [ X] I've added a link to the action run on my repository below in the links section.
- [ X] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/mmillmor/octopus_agile_window_finder/releases/tag/1.0.2>
Link to successful HACS action (without the `ignore` key): <https://github.com/mmillmor/octopus_agile_window_finder/actions/runs/24990144836>
Link to successful hassfest action (if integration): <https://github.com/mmillmor/octopus_agile_window_finder/actions/runs/24990144840>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->