### PR TITLE
Add karl-petter/protimeter-ble-humidity-sensor-for-ha

### DIFF
--- a/integration
+++ b/integration
@@ -1121,6 +1121,7 @@
   "Kannix2005/ha_siedle_python",
   "Kannix2005/homeassistant-selve",
   "Kaptensanders/skolmat",
+  "karl-petter/protimeter-ble-humidity-sensor-for-ha",
   "Kartax/home-assistant-binance",
   "KartoffelToby/better_thermostat",
   "kattcrazy/tuya_unsupported_sensors",


### PR DESCRIPTION
## Description

Adds the [Protimeter BLE](https://github.com/karl-petter/protimeter-ble-humidity-sensor-for-ha) custom integration.

A Home Assistant integration for the [Protimeter BLE humidity sensor](https://www.protimeter.com/products/protimeter-bluetooth-le-hygrometer/). Connects via Bluetooth and imports humidity, temperature, Wood Moisture Equivalent (WME), and battery level as HA long-term statistics.

## Checklist

- [x] Repository is public
- [x] Has a tagged release (v1.0.0)
- [x] Has a valid `manifest.json` with `domain`, `name`, `version`, `documentation`, `issue_tracker`, `codeowners`
- [x] Has `hacs.json`
- [x] Has brand assets in `brand/` directory
- [x] Has a README