### PR TITLE
Add SkyTechNerds/ha-soft-presence

### DIFF
--- a/integration
+++ b/integration
@@ -1897,6 +1897,7 @@
   "skircr115/ha-verizonFiOS",
   "skodaconnect/homeassistant-myskoda",
   "skyer/home-assistant-tylo-sauna",
+  "SkyTechNerds/ha-soft-presence",
   "Slalamander/Home-Assistant-Eetlijst",
   "slashback100/presence_simulation",
   "slesinger/HomeAssistant-BMR",


### PR DESCRIPTION
## Add SkyTechNerds/ha-soft-presence

**HA Soft Presence** — Virtual presence sensors for Home Assistant.

Combines multiple signals (mmWave, PIR, BLE/ESPresense, media players, workstations, lights, door contacts, locks) using a weighted score engine and a 6-state machine to produce a stable, automation-ready occupancy decision per room.

- Repository: https://github.com/SkyTechNerds/ha-soft-presence
- Version: 2026.4.28
- License: MIT
- HA min version: 2024.1.0