### PR TITLE
Add Chrisalvir1/Argus

### DIFF
--- a/integration
+++ b/integration
@@ -372,6 +372,7 @@
   "Chouffy/home_assistant_tgtg",
   "chris-mc1/homeconnect_local_hass",
   "chris-mc1/unraid_api",
+  "Chrisalvir1/Argus",
   "chriscamicas/gazdebordeaux-ha",
   "chrisdoherty4/maint",
   "christiaangoossens/hass-oidc-auth",


### PR DESCRIPTION
Adds Argus Home Hub to default integrations.