### PR TITLE
Add mjryan253/homeassistant-sonicwall

### DIFF
--- a/integration
+++ b/integration
@@ -1420,6 +1420,7 @@
   "MislavMandaric/home-assistant-vaillant-vsmart",
   "miyosmart/miyocube-homeassistant-custom-component",
   "mjcumming/wiim",
+  "mjryan253/homeassistant-sonicwall",
   "MKSG-MugunthKumar/ha-chameleon",
   "MKsys1337/MiWiFi-CB0401V2",
   "mkuthan/solis-cloud-control",


### PR DESCRIPTION
Adds [**mjryan253/homeassistant-sonicwall**](https://github.com/mjryan253/homeassistant-sonicwall) — a custom integration that polls SonicWall Gen 6 firewalls (TZ350 confirmed live; expected to work on the wider TZ / NSA / SOHO / SuperMassive lines per the SonicOS 6.5.4.4+ API surface) over their built-in REST API. **Read-only**, **local polling only**, no cloud dependency.

Background and ongoing user discussion lives on the Home Assistant community forum: **[Custom HA integration for SonicWall SonicOS API](https://community.home-assistant.io/t/custom-ha-integration-for-sonicwall-sonicos-api/1007988)** — that thread is where confirmation reports for additional Gen 6 hardware land and where install questions get answered.

Surfaces device-health (CPU%, connection-table usage, active connection count, uptime, firmware version) and per-interface RX/TX byte counters as standard sensors, plus per-interface link binary_sensors.

- Repo: https://github.com/mjryan253/homeassistant-sonicwall
- Community thread: https://community.home-assistant.io/t/custom-ha-integration-for-sonicwall-sonicos-api/1007988
- Latest release: [v0.1.1](https://github.com/mjryan253/homeassistant-sonicwall/releases/tag/v0.1.1)
- README + screenshots: https://github.com/mjryan253/homeassistant-sonicwall#readme

### Requirements checklist (per [hacs.xyz/docs/publish/include](https://hacs.xyz/docs/publish/include))

- [x] Public repository on GitHub
- [x] Repository description set
- [x] GitHub topics: `home-assistant`, `hacs`, `home-assistant-integration`, `custom-component`, `sonicwall`, `firewall`
- [x] README documenting install and use
- [x] Valid `hacs.json` at repo root
- [x] Valid integration `manifest.json` with `documentation` and `issue_tracker`
- [x] At least one published GitHub release (v0.1.0 and v0.1.1) with `sonicwall.zip` asset
- [x] Hassfest validation green on `main`
- [x] HACS Action validation green on `main` with **zero ignores** (brand assets ship locally in `custom_components/sonicwall/brand/` per the [Brands Proxy API](https://developers.home-assistant.io/blog/2026/02/24/brands-proxy-api))
- [x] Issues enabled on the repo