### PR TITLE
Adds new plugin [steuerlexi/shopping-list-card]

### DIFF
--- a/plugin
+++ b/plugin
@@ -479,6 +479,7 @@
   "sopelj/lovelace-kanji-clock-card",
   "starwarsfan/qclock-card",
   "stefmde/HomeAssistant-TwitchFollowedLiveStreamsCard",
+  "steuerlexi/shopping-list-card",
   "studiobts/device-pulse-table-card",
   "studiobts/device-pulse-timeline-card",
   "superdingo101/skylight-calendar-card",


### PR DESCRIPTION
## Description

Adds the Shopping List Card to the HACS default repository.

### Repository
- **URL:** https://github.com/steuerlexi/shopping-list-card
- **Category:** Lovelace (Plugin)

### Features
- Tile grid view with auto-mapped MDI icons
- Auto-categorization (Obst & Gemüse, Milch & Eier, etc.)
- 30+ intelligent icon mappings
- Search bar with live filter
- Long-press edit for descriptions
- Collapsible done section
- Fully themed with Home Assistant CSS variables
- Mobile-optimized

### Requirements
- Home Assistant 2024.1.0+
- Native  platform integration

### Checklist
- [x] The repository has a  file
- [x] The repository has a  file
- [x] The repository has a  file
- [x] The repository has a  file
- [x] The card is a single JS file ()
- [x] The card uses  in 