### PR TITLE
Add "1e1/hass-deauth-guard" integration

### DIFF
--- a/integration
+++ b/integration
@@ -5,6 +5,7 @@
   "0xAHA/Midea-Heat-Pump-HA",
   "0xAlon/dolphin",
   "0xQuantumHome/bayrol-home-hassistant",
+  "1e1/hass-deauth-guard",
   "3dg1luk43/ha_creality_ws",
   "3dg1luk43/ha_washdata",
   "3ll3d00d/jriver_homeassistant",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: https://github.com/1e1/hass-deauth-guard/releases/tag/v0.3.1
Link to successful HACS action (without the `ignore` key): https://github.com/1e1/hass-deauth-guard/actions/runs/25143514604
Link to successful hassfest action (if integration): https://github.com/1e1/hass-deauth-guard/actions/runs/25143514604

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->