### PR TITLE
Add dibi73/ha-bookstack-sync

### DIFF
--- a/integration
+++ b/integration
@@ -563,6 +563,7 @@
   "dhover/ha-cumulusmx",
   "dhover/ha-iungo",
   "dib0/ha-elro-connects-realtime",
+  "dibi73/ha-bookstack-sync",
   "diego7marques/ha-aws-cost",
   "DigitallyRefined/ha-cloudflare-speed-test",
   "DigitallyRefined/ha-hwmon_temp",


### PR DESCRIPTION
Add `dibi73/ha-bookstack-sync` — a Home Assistant custom integration that documents the entire HA setup as markdown pages inside an existing BookStack wiki and keeps it in sync.

- Repo: https://github.com/dibi73/ha-bookstack-sync
- Latest release: https://github.com/dibi73/ha-bookstack-sync/releases/latest
- Quality scale: gold (manifest)
- Hassfest + HACS validation green on `main`
- Brand image local at `custom_components/bookstack_sync/brand/icon.png` (256×256, transparent) + `icon@2x.png` (512×512)
- 100+ tests covering merge logic, renderer determinism, API client, config flow, coordinator, sync orchestrator
- v0.1 since April 2026; current v0.8.2

This fills a long-standing community need (see [community thread](https://community.home-assistant.io/t/feature-request-export-devices-and-entities/)) for a structured, persistent, manually-extendable HA documentation that survives manual user edits via marker-block protection with SHA-256 tampering detection.

The killer feature: **manually added wiki content stays preserved across syncs**. Every page is split into an auto-generated section and a manual section by markdown markers. The integration only ever rewrites the auto block — user notes, quirks, password references and "why we set option X" comments live in the manual block forever.