### PR TITLE
Add vmvelev/home-assistant-toshiba_ac (replaces unmaintained h4de5 fork)

### DIFF
--- a/integration
+++ b/integration
@@ -15,7 +15,7 @@
   "5high/phicomm-dc1-homeassistant",
   "62fixolab/HA-Panda-PWR",
   "8none1/lednetwf_ble",
-  "9a4gl/hass-centrometal-boiler",
+  "9a4gl/hass-centrometal-boiler",h
   "AaronDavidSchneider/SonosAlarm",
   "Aasikki/daily-fingerpori",
   "abhichandra21/ha-flavoroftheday",
@@ -840,7 +840,7 @@
   "GuySie/ha-meural",
   "gvigroux/hon",
   "GyroGearl00se/ha_froeling_lambdatronic_modbus",
-  "h4de5/home-assistant-toshiba_ac",
+  "vmvelev/home-assistant-toshiba_ac",
   "h4de5/home-assistant-vimar",
   "ha-china/ai_hub",
   "ha-china/virtual_devices",

--- a/integration
+++ b/integration
@@ -15,7 +15,7 @@
   "5high/phicomm-dc1-homeassistant",
   "62fixolab/HA-Panda-PWR",
   "8none1/lednetwf_ble",
-  "9a4gl/hass-centrometal-boiler",h
+  "9a4gl/hass-centrometal-boiler",
   "AaronDavidSchneider/SonosAlarm",
   "Aasikki/daily-fingerpori",
   "abhichandra21/ha-flavoroftheday",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [ ] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [ ] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [ ] The actions are passing without any disabled checks in my repository.
- [ ] I've added a link to the action run on my repository below in the links section.
- [ ] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <>
Link to successful HACS action (without the `ignore` key): <>
Link to successful hassfest action (if integration): <>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->