### PR TITLE
Add vmvelev/home-assistant-toshiba_ac (replaces unmaintained h4de5 fork)

### DIFF
--- a/integration
+++ b/integration
@@ -15,7 +15,7 @@
   "5high/phicomm-dc1-homeassistant",
   "62fixolab/HA-Panda-PWR",
   "8none1/lednetwf_ble",
-  "9a4gl/hass-centrometal-boiler",
+  "9a4gl/hass-centrometal-boiler",h
   "AaronDavidSchneider/SonosAlarm",
   "Aasikki/daily-fingerpori",
   "abhichandra21/ha-flavoroftheday",
@@ -840,7 +840,7 @@
   "GuySie/ha-meural",
   "gvigroux/hon",
   "GyroGearl00se/ha_froeling_lambdatronic_modbus",
-  "h4de5/home-assistant-toshiba_ac",
+  "vmvelev/home-assistant-toshiba_ac",
   "h4de5/home-assistant-vimar",
   "ha-china/ai_hub",
   "ha-china/virtual_devices",

--- a/integration
+++ b/integration
@@ -15,7 +15,7 @@
   "5high/phicomm-dc1-homeassistant",
   "62fixolab/HA-Panda-PWR",
   "8none1/lednetwf_ble",
-  "9a4gl/hass-centrometal-boiler",h
+  "9a4gl/hass-centrometal-boiler",
   "AaronDavidSchneider/SonosAlarm",
   "Aasikki/daily-fingerpori",
   "abhichandra21/ha-flavoroftheday",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: https://github.com/vmvelev/home-assistant-toshiba_ac/releases/tag/v2026.4.1
Link to successful HACS action (without the 'ignore' key): https://github.com/vmvelev/home-assistant-toshiba_ac/actions/runs/25137569613
Link to successful hassfest action (if integration): https://github.com/vmvelev/home-assistant-toshiba_ac/actions/runs/25137569613

## Context

This PR replaces the existing unmaintained entry `h4de5/home-assistant-toshiba_ac` with the actively maintained fork `vmvelev/home-assistant-toshiba_ac`.

The original repository (`h4de5/home-assistant-toshiba_ac`) has been inactive - no responses to issues or PRs since 2024, with 23 open issues and 6 open PRs. The integration was causing reliable startup failures for all users on every HA restart due to expired SAS token handling.

The fork (`vmvelev/home-assistant-toshiba_ac`) fixes the critical startup failures and has been tested successfully. An issue has been opened on the original repository to notify the community: https://github.com/h4de5/home-assistant-toshiba_ac/issues/285