### PR TITLE
Add GardenTrib/ha-ecowitt-cloud

### DIFF
--- a/integration
+++ b/integration
@@ -765,6 +765,7 @@
   "ganhammar/hass-mcp-server",
   "ganhammar/hass-oidc-server",
   "garbled1/homeassistant_ecowitt",
+  "GardenTrib/ha-ecowitt-cloud",
   "GarthDB/ha-wattbox",
   "gazoodle/gecko-home-assistant",
   "gbroeckling/padspanHA",


### PR DESCRIPTION
## Checklist

- [x] I have read and followed the [HACS contribution guidelines](https://hacs.xyz/docs/publish/start)
- [x] The repository has a valid `hacs.json` file
- [x] The repository has a valid `manifest.json` with a version field
- [x] The repository has at least one release (v1.0.0)
- [x] The integration uses `cloud_polling` IoT class
- [x] Compatible with Home Assistant 2024.1+

## Repository

**GardenTrib/ha-ecowitt-cloud**

Home Assistant custom integration for the Ecowitt Cloud API v3. Connects Ecowitt weather stations, soil sensors (WH51/WH51L, up to 16 channels) and irrigation valves (WFC01 WittFlow, up to 8 channels) via cloud polling.