### PR TITLE
Add Beennnn/hass-scs-sentinel

### DIFF
--- a/integration
+++ b/integration
@@ -238,6 +238,7 @@
   "Beat2er/homeassistant-trmnl-battery",
   "Bebbssos/ha-defa-power",
   "beecho01/material-symbols",
+  "Beennnn/hass-scs-sentinel",
   "bemfa/behome",
   "beMoD/homeassistant-hyperliquid",
   "ben8p/home-assistant-bunq-balance-sensors",


### PR DESCRIPTION
Adding [Beennnn/hass-scs-sentinel](https://github.com/Beennnn/hass-scs-sentinel) — open-source Home Assistant integration for **SCS Sentinel** automated gate kits (residential gate + video doorbell, French OEM on Tuya hardware).

LAN-only architecture (no Tuya cloud account required) — speaks Tuya local protocol port 6668 / AES-128 directly. Reverse engineered from the official iSCS Sentinel mobile app per EU Directive 2009/24/EC art. 6 (interoperability carve-out).

Entities :
- `cover.<name>_portail` — vehicle gate, device_class gate
- `lock.<name>_portillon` — pedestrian gate (momentary unlock)

Supported SKUs : PVF0053, PVF0054, PVF0055, PVF0056, PVF0058, PVS0014.

Compliance :
- ✅ manifest.json sorted, hassfest passes
- ✅ hacs.json + info.md present
- ✅ Released v0.1.0 (https://github.com/Beennnn/hass-scs-sentinel/releases/tag/v0.1.0)
- ✅ GitHub topics : home-assistant, hacs, hacs-default, mcp, gate, scs-sentinel
- ✅ License : GPL-3.0-or-later
- ✅ CI workflows : hassfest + HACS validators green
- ⏭ Brand assets : follow-up PR to home-assistant/brands (using HACS `ignore: brands` flag in the meantime)

Thanks for reviewing !