### PR TITLE
Adds new integration [iret33/deepseek-ha-integration]

### DIFF
--- a/integration
+++ b/integration
@@ -951,6 +951,7 @@
   "iprak/weatherapi",
   "iprak/winix",
   "iprak/yahoofinance",
+  "iret33/deepseek-ha-integration",
   "IT-my-PV/myPVHomeAssistant",
   "it00x32/lancom-lmc-ha",
   "itchannel/apex-ha",


### PR DESCRIPTION
Repository: https://github.com/iret33/deepseek-ha-integration

A Home Assistant **conversation agent** for the DeepSeek LLM API.

- Pure custom integration, conversation entity built against HA's modern `chat_log` API (chat-completions endpoint).
- Domain: `deepseek`. Brand assets are bundled in-repo at `custom_components/deepseek/brand/icon.png` and `icon@2x.png` per the post-2026.3.0 HACS / HA brands policy.
- Manifest declares `config_flow`, `integration_type: service`, `iot_class: cloud_polling`, requirement `openai>=2.0.0`.
- Supports DeepSeek's current model catalogue (`deepseek-v4-flash`, `deepseek-v4-pro`) plus the deprecated `deepseek-chat` / `deepseek-reasoner` for backward compatibility.
- Latest release: `v3.0.5` (workflows green: Hassfest, HACS Validation, Validate, Tests).

Earlier PRs (#6833, #6834, #6845) were closed before brand assets were added in-repo and before the conversation entity was ported to `_async_handle_message` / `chat_log`. Both have now been resolved.