### PR TITLE
Add Mofei HACS repositories

### DIFF
--- a/integration
+++ b/integration
@@ -2261,5 +2261,6 @@
   "zubir2k/homeassistant-esolattakwim",
   "zulufoxtrot/ha-zyxel",
   "zupancicmarko/JellyHA",
-  "Zwer2k/ha-pca301"
+  "Zwer2k/ha-pca301",
+  "zyjsmile857/mofei_mqtt_bridge"
 ]

--- a/plugin
+++ b/plugin
@@ -576,5 +576,6 @@
   "yuri-val/th-sensor-card",
   "zanac/temperature-heatmap-card",
   "zanna-37/hass-swipe-navigation",
-  "zeronounours/lovelace-energy-entity-row"
+  "zeronounours/lovelace-energy-entity-row",
+  "zyjsmile857/mofei-remote-card"
 ]


### PR DESCRIPTION
Adds the following repositories to the HACS default list:

- Integration: zyjsmile857/mofei_mqtt_bridge
- Plugin: zyjsmile857/mofei-remote-card

Both repositories have HACS metadata, repository topics, descriptions, and v0.1.1 releases.