### PR TITLE
Add nitaybz/geely-global-ha

### DIFF
--- a/integration
+++ b/integration
@@ -1081,6 +1081,7 @@
   "nimroddolev/chime_tts",
   "NinDTendo/homeassistant_gradual_volume_control",
   "NinDTendo/tobi",
+  "nitaybz/geely-global-ha",
   "nkvoll/home-assistant-qsys-qrc",
   "nnnlog/homeassistant-cvnet-smarthome",
   "nordicopen/easee_hass",


### PR DESCRIPTION
Adds the Geely Global integration for Home Assistant.

Repository: https://github.com/nitaybz/geely-global-ha
Domain: `geely_intl`
Category: integration

Capability-driven integration for vehicles using the Geely Global / Geely International mobile app. Tested on Geely EX5 and intended to work on most Geely-family EVs that use the same backend.

Validation: https://github.com/nitaybz/geely-global-ha/actions

Topics: home-assistant, hacs, geely, ev, homeassistant-integration, hacs-integration, home-automation
