### PR TITLE
Add il90il90/hass-requester

### DIFF
--- a/integration
+++ b/integration
@@ -934,6 +934,7 @@
   "iKaew/hass-lifesmart-addon",
   "ikb42/homeassistant-lightwave2",
   "ikifar2012/neosmartblue-ha",
+  "il90il90/hass-requester",
   "ilpianista/meteoeuregio",
   "iluvdata/august_access_codes",
   "iluvdata/liebherr",


### PR DESCRIPTION
## Checklist

- [x] I am the owner of the repository being submitted.
- [x] I have read and followed the [submission guidelines](https://hacs.xyz/docs/publish/include).
- [x] The repository has a description.
- [x] The repository has topics defined.
- [x] The repository has a README.
- [x] The repository has a hacs.json file.
- [x] The GitHub Actions HACS Action passes.
- [x] The GitHub Actions Hassfest passes.
- [x] A GitHub release has been published.

## Information

**Repository:** https://github.com/il90il90/hass-requester
**Category:** Integration

## Description

HASS Requester is a Home Assistant custom integration that provides a beautiful panel UI for managing and sending HTTP requests from automations. It supports dynamic slot parameters, multiple HTTP methods, JSON/form/text body types, cURL import, and export/import backup.