### PR TITLE
Add Veloretti integration

### DIFF
--- a/integration
+++ b/integration
@@ -1541,6 +1541,7 @@
   "NoUsername10/Sunlight_Visualizer",
   "nowocain/PhotoFrameCast",
   "nstrelow/ha_philips_android_tv",
+  "NSURLSession0/homeassistant-veloretti",
   "nussfuellung/paradigma-homeassistant",
   "nyffchanium/argoclima-integration",
   "NylonDiamond/homeassistant-wrist-assistant",


### PR DESCRIPTION
## Repository

https://github.com/NSURLSession0/homeassistant-veloretti

## Category

Integration

## Checklist

- I am the repository owner.
- The repository can be added to HACS as a custom repository.
- HACS Action passes without ignored checks.
- Hassfest passes.
- A GitHub Release exists for v0.1.0.
- The integration includes local brand assets under custom_components/veloretti/brand/.
