### PR TITLE
Add macsatcom/totalkredit-ha and macsatcom/ha-familiedosmer

### DIFF
--- a/integration
+++ b/integration
@@ -1289,6 +1289,8 @@
   "m3tac0de/home-assistant-sofabaton-x1s",
   "mac8005/xiaozhi-mcp-ha",
   "maciej-or/hikvision_next",
+  "macsatcom/ha-familiedosmer",
+  "macsatcom/totalkredit-ha",
   "macxq/foxess-ha",
   "MadOne/hass_gira_iot_api",
   "madpilot/hass-amber-electric",


### PR DESCRIPTION
## Description

Add two integrations to the default HACS repository list:

1. **macsatcom/totalkredit-ha** — Home Assistant integration that fetches Danish mortgage bond rates from Totalkredit API and exposes them as sensor entities. Config flow.

2. **macsatcom/ha-familiedosmer** — Home Assistant integration for FamilieDosmer. Syncs shopping lists, todo lists, and meal plans as native HA entities (todo, calendar, sensor). Config flow.

## Checklist

- [x] I have read the requirements for adding a new repository to HACS.
- [x] My repositories are public on GitHub.
- [x] Repository structure is correct (single integration per repo).
- [x] `manifest.json` has all required keys.
- [x] `hacs.json` has a `name` key.
- [x] Brand assets (`brand/icon.png`) exist.
- [x] HACS Action and hassfest workflows are passing.
- [x] GitHub releases exist.
- [x] Repos have descriptions and topics.
- [x] I am the owner (@macsatcom).

## Repository links

- https://github.com/macsatcom/totalkredit-ha
- https://github.com/macsatcom/ha-familiedosmer
