### PR TITLE
Add macsatcom/totalkredit-ha

### DIFF
--- a/integration
+++ b/integration
@@ -1289,6 +1289,7 @@
   "m3tac0de/home-assistant-sofabaton-x1s",
   "mac8005/xiaozhi-mcp-ha",
   "maciej-or/hikvision_next",
+  "macsatcom/totalkredit-ha",
   "macxq/foxess-ha",
   "MadOne/hass_gira_iot_api",
   "madpilot/hass-amber-electric",


### PR DESCRIPTION
Add **macsatcom/totalkredit-ha** to the default HACS integration list.

Home Assistant integration that fetches Danish mortgage bond rates from Totalkredit API and exposes them as sensor entities via config flow.

- Repository: https://github.com/macsatcom/totalkredit-ha
- HACS Action + hassfest: ✅ passing
- Brand assets: ✅ custom_components/totalkredit/brand/icon.png
- manifest.json: ✅ valid and sorted
- Releases: ✅ 6 releases
- Issues enabled: ✅
- Topics set: ✅

I am the owner of this repository (@macsatcom).