### PR TITLE
Add macsatcom/ha-familiedosmer

### DIFF
--- a/integration
+++ b/integration
@@ -1289,6 +1289,7 @@
   "m3tac0de/home-assistant-sofabaton-x1s",
   "mac8005/xiaozhi-mcp-ha",
   "maciej-or/hikvision_next",
+  "macsatcom/ha-familiedosmer",
   "macxq/foxess-ha",
   "MadOne/hass_gira_iot_api",
   "madpilot/hass-amber-electric",


### PR DESCRIPTION
Add **macsatcom/ha-familiedosmer** to the default HACS integration list.

Home Assistant integration for FamilieDosmer — syncs shopping lists, todo lists, and meal plans as native HA entities (todo, calendar, sensor) via config flow.

- Repository: https://github.com/macsatcom/ha-familiedosmer
- HACS Action + hassfest: ✅ passing
- Brand assets: ✅ custom_components/familiedosmer/brand/icon.png
- manifest.json: ✅ valid and sorted, issue_tracker and codeowners set
- Releases: ✅ 6 releases
- Issues enabled: ✅
- Topics set: ✅
- Description set: ✅

I am the owner of this repository (@macsatcom).