### PR TITLE
Add new integration [marccatalano/ha-powerpanel-cloud]

### DIFF
--- a/integration
+++ b/integration
@@ -1317,6 +1317,7 @@
   "Manschitz/brunner-eas-integration",
   "MarcelWepper/Inverter-Controller",
   "marcelwestrahome/home-assistant-niu-component",
+  "marccatalano/ha-powerpanel-cloud",
   "marcoboers/home-assistant-quatt",
   "MarcoGos/davis_vantage",
   "MarcoGos/kleenex_pollenradar",


### PR DESCRIPTION
## Checklist

- [x] I have read the HACS documentation about adding a repository
- [x] The repository is public and hosted on GitHub
- [x] The repository has a description
- [x] The repository has topics
- [x] The repository has a README
- [x] The repository has a hacs.json file
- [x] The repository has a valid manifest.json
- [x] The repository has at least one release
- [x] I am the owner of the repository
- [x] Brand assets are included in the integration directory (brand/icon.png)

## Repository

https://github.com/marccatalano/ha-powerpanel-cloud

## Description

Custom integration for CyberPower PowerPanel Cloud that pulls live UPS telemetry into Home Assistant via the cloud API. Supports CyberPower UPS units connected via RCCARD100 or RCCARD101 network management cards.