### PR TITLE
Add pjordanandrsn/ha-generac

### DIFF
--- a/integration
+++ b/integration
@@ -1643,6 +1643,7 @@
   "pippyn/Home-Assistant-Sensor-Afvalbeheer",
   "Pirate-Weather/pirate-weather-ha",
   "Pjarbit/home-assistant-combined-notification-integration",
+  "pjordanandrsn/ha-generac",
   "pkarimov/jukeaudio_ha",
   "plamish/xcomfort",
   "PlanetCitizen1829381/ha-nsw-beachwatch",


### PR DESCRIPTION
## Repository
https://github.com/pjordanandrsn/ha-generac

## Category
Integration

## Description
Auth0 universal-login fork of [`binarydev/ha-generac`](https://github.com/binarydev/ha-generac) that handles MobileLink's post-2024 auth migration.

Generac switched MobileLink from cookie-scrape login to Auth0 universal-login + DPoP-bound refresh tokens on 2026-04-21 ([support article](https://support.generac.com/s/article/Mobile-Link-Migration)). The original integration broke; this fork ports `@sslivins`'s in-flight rewrite ([PR #267](https://github.com/binarydev/ha-generac/pull/267)) and adds a `_handle_custom_prompt` handler for Auth0 Forms consent / T&C prompts that some accounts get on first OAuth login.

## Why a fork instead of upstream PR
PR #267 has been open since 2026-04 without a merge. This fork lets users with broken MobileLink integrations install a working version through HACS today; the prompt-handler patch is a candidate to push back to PR #267 once that's accepted.

## Checklist
- [x] Latest release tagged on default branch (v0.5.3)
- [x] `hacs.json` present
- [x] `manifest.json` complete
- [x] HACS validate + hassfest CI green on main
- [x] License preserved from upstream (MIT)
- [x] README documents install + reauth flow