### PR TITLE
Adds new integration [pjordanandrsn/ha-ecobee]

### DIFF
--- a/integration
+++ b/integration
@@ -1643,6 +1643,7 @@
   "pippyn/Home-Assistant-Sensor-Afvalbeheer",
   "Pirate-Weather/pirate-weather-ha",
   "Pjarbit/home-assistant-combined-notification-integration",
+  "pjordanandrsn/ha-ecobee",
   "pkarimov/jukeaudio_ha",
   "plamish/xcomfort",
   "PlanetCitizen1829381/ha-nsw-beachwatch",


### PR DESCRIPTION
## Repository
https://github.com/pjordanandrsn/ha-ecobee

## Latest release
https://github.com/pjordanandrsn/ha-ecobee/releases/tag/v0.3.1

## CI runs
https://github.com/pjordanandrsn/ha-ecobee/actions/runs/25286948067

## Category
Integration

## Description
Auth0 universal-login fork of the built-in `ecobee` integration. Restores ecobee functionality after ecobee shut down their developer-portal API in 2026.

ecobee disabled new developer-portal accounts in late 2025 and shut down the existing portal in early 2026, breaking the built-in HA integration's PIN-based authentication path. This fork bypasses the dead portal by signing in through ecobee.com's web login (Auth0 universal-login + PKCE), the same way ecobee.com itself does, and includes inline support for Auth0's MFA OTP-challenge flow for 2FA-enabled accounts.

## Why a fork instead of upstream PR
The built-in integration's auth path is tightly coupled to the developer-portal PIN flow; replacing it requires a complete config-flow rewrite. This fork uses domain `ecobee` (collides with the built-in — Hassfest emits a warning, expected) so existing entity_ids and automations keep working when users swap the integration. A clean upstream PR would require coordinating a breaking config-flow migration with HA core maintainers; the fork lets users with broken integrations recover today.

## Related upstream tracking
- HA community thread: https://community.home-assistant.io/t/ecobee-dumped-developer-accounts/711817
- HA core issues: home-assistant/core#131789, home-assistant/core#169328, home-assistant/core#146560

## Checklist
- [x] v0.3.1 release tagged on `main`
- [x] `hacs.json` present
- [x] `manifest.json` complete (all required keys)
- [x] HACS validate + hassfest CI green on `main` (run linked above)
- [x] Apache 2.0 license preserved from the built-in integration
- [x] README documents install + reauth + MFA flows