### PR TITLE
Adds new integration [h0jeZvgoxFepBQ2C/claude_chat_for_homeassistant]

### DIFF
--- a/integration
+++ b/integration
@@ -840,6 +840,7 @@
   "GuySie/ha-meural",
   "gvigroux/hon",
   "GyroGearl00se/ha_froeling_lambdatronic_modbus",
+  "h0jeZvgoxFepBQ2C/claude_chat_for_homeassistant",
   "h4de5/home-assistant-toshiba_ac",
   "h4de5/home-assistant-vimar",
   "ha-china/ai_hub",


### PR DESCRIPTION
Adds **claude_chat_for_homeassistant** — a sidebar chat panel powered by Anthropic's Claude. Multi-session chat where Claude can inspect HA, propose Lovelace dashboard edits, propose service calls, and create/update/delete automations — all behind a diff-and-approve UI gate so nothing applies without user confirmation.

- Repo: https://github.com/h0jeZvgoxFepBQ2C/claude_chat_for_homeassistant
- Release: https://github.com/h0jeZvgoxFepBQ2C/claude_chat_for_homeassistant/releases/tag/v0.1.0
- Domain: `claude_chat`
- Dependencies: `anthropic>=0.40.0`, `frontend`, `http`, `websocket_api`, `lovelace`
- Config flow: yes (Anthropic API key)
- 25 unit tests + Playwright-driven UI verification