### PR TITLE
Add JackDempsey9/homeassistant-emergencyapi

### DIFF
--- a/integration
+++ b/integration
@@ -973,6 +973,7 @@
   "j9brown/victron-mk3-hass",
   "JAAlperin/hass-bardolph",
   "JaccoR/hass-entso-e",
+  "JackDempsey9/homeassistant-emergencyapi",
   "JackJPowell/hass-unfoldedcircle",
   "jaidenlabelle/tuya-vacuum-maps",
   "jamesshannon/thermoworks-ha",


### PR DESCRIPTION
## New integration: EmergencyAPI - Australian Emergency Data

Real-time Australian emergency incident data for Home Assistant.

- **Repository:** https://github.com/JackDempsey9/homeassistant-emergencyapi
- **Category:** Integration
- **Description:** Pulls live emergency incidents from 33 government feeds across all 8 Australian states and territories. Map pins, binary sensor alerts, incident count, polygon geometry support.
- **Home Assistant minimum version:** 2025.1.0
- **HACS manifest and hassfest validation passing.**