### PR TITLE
Adds new plugin [hudsonbrendon/nintendo-switch-card]

### DIFF
--- a/plugin
+++ b/plugin
@@ -208,6 +208,7 @@
   "homeassistant-extras/room-summary-card",
   "homeassistant-extras/toolbar-status-chips",
   "homeassistant-extras/zwave-card-set",
+  "hudsonbrendon/nintendo-switch-card",
   "Hugo0485/DoubleCurtainCard",
   "hulkhaugen/hass-bha-icons",
   "hyperb1iss/hyper-light-card",


### PR DESCRIPTION
Submitting `hudsonbrendon/nintendo-switch-card` as a plugin.

**Repository:** https://github.com/hudsonbrendon/nintendo-switch-card
**Latest release:** https://github.com/hudsonbrendon/nintendo-switch-card/releases/latest
**CI action runs:** https://github.com/hudsonbrendon/nintendo-switch-card/actions

**Description:** Lovelace card for Home Assistant that displays Nintendo Switch state in the visual style of vacuum-card. Reads MQTT entities published by the [switch-assistant](https://github.com/ErSeraph/switch-assistant) homebrew sysmodule.

**Checklist:**
- [x] Public GitHub repo with description and topics
- [x] LICENSE file (MIT)
- [x] README with image
- [x] `hacs.json` manifest
- [x] HACS Action passing on default branch
- [x] GitHub release with `nintendo-switch-card.js` asset
- [x] One-file plugin under `dist/`, name matches repo
- [x] I am the owner of the repository being submitted