### PR TITLE
Add castellotti/frigate-ai-event-card

### DIFF
--- a/plugin
+++ b/plugin
@@ -48,6 +48,7 @@
   "Brianfit/calvin-card-ha",
   "Brianfit/xkcd-card-ha",
   "brunosabot/streamline-card",
+  "castellotti/frigate-ai-event-card",
   "cataseven/Alarm-and-Security-Card",
   "cataseven/google-map-card",
   "cataseven/Navigate-Anywhere",


### PR DESCRIPTION
## frigate-ai-event-card

**Repository:** https://github.com/castellotti/frigate-ai-event-card
**Category:** plugin

### Description

A Lovelace custom card that displays a filmstrip of Frigate security camera events with AI-generated descriptions. Designed to work alongside a Home Assistant REST/command-line sensor that polls the Frigate events API.

### Features

- Filmstrip of event thumbnails with configurable height and limit
- `limit: auto` - ResizeObserver-driven slot calculation that fills available width
- `scrollable: true` - horizontal scroll filmstrip showing all events
- `time_window` filter (`24h`, `7d`, `30d`, `all`, or custom `<N>m`/`<N>h`/`<N>d`)
- Click thumbnail to open snapshot + AI description dialog
- `<ha-markdown>` rendering for AI descriptions with plain-text fallback
- HLS video clip playback via hls.js with HA VOD proxy authentication
- `show_metadata`, `filter_no_description` display toggles
- `provider_label` badge for vision model attribution

### Checklist

- [x] Repository is public
- [x] Repository has a description
- [x] Repository has required topics: `lovelace`, `home-assistant`, `hacs`, `frigate`, `lovelace-card`
- [x] `hacs.json` present with correct `name`, `render_readme: true`
- [x] `info.md` present
- [x] GitHub release published with JS file as asset (`frigate-ai-event-card.js`)
- [x] HACS validation workflow passes (`.github/workflows/hacs.yml`)