### PR TITLE
Add moshiko2312/BYD-CARD to plugin

### DIFF
--- a/plugin
+++ b/plugin
@@ -361,6 +361,7 @@
   "mrded/ha-air-comfort-card",
   "MrSjodin/HomeAssistant_Trafiklab_TravelSearch_Card",
   "mutilator/homeassistant-solar-panel-preview",
+  "moshiko2312/BYD-CARD",
   "nathan-gs/ha-map-card",
   "nathanmarlor/foxess_modbus_charge_period_card",
   "nathkrill/lovelace-google-fonts-header-card",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/moshiko2312/BYD-CARD/releases/tag/v1.0.5>
Link to successful HACS action (without the  key): <https://github.com/moshiko2312/BYD-CARD/actions/runs/25375705551>
Link to successful hassfest action (if integration): <N/A - plugin repository>