### PR TITLE
Add DECTYR/ha-integration

### DIFF
--- a/integration
+++ b/integration
@@ -533,7 +533,7 @@
   "deblockt/hass-aria2",
   "deblockt/hass-proscenic-790T-vacuum",
   "DeclanSC/hass-esi-thermostat",
-  "dectyr/ha-integration",
+  "DECTYR/ha-integration",
   "DeerMaximum/QR-Code-Generator",
   "DeerMaximum/Technische-Alternative-CMI",
   "DeerMaximum/Technische-Alternative-CoE",

--- a/integration
+++ b/integration
@@ -533,6 +533,7 @@
   "deblockt/hass-aria2",
   "deblockt/hass-proscenic-790T-vacuum",
   "DeclanSC/hass-esi-thermostat",
+  "dectyr/ha-integration",
   "DeerMaximum/QR-Code-Generator",
   "DeerMaximum/Technische-Alternative-CMI",
   "DeerMaximum/Technische-Alternative-CoE",


### PR DESCRIPTION
## Repository details

**Repository:** https://github.com/DECTYR/ha-integration

**Latest release:** https://github.com/DECTYR/ha-integration/releases/tag/v1.1.2

**CI action runs:** https://github.com/DECTYR/ha-integration/actions

## Description

Home Assistant integration for **Dectyr drone detectors** with full Remote ID surveillance support, developed and maintained by the official Dectyr engineering team.

### Features

- Auto-discovery of all Dectyr scanners via MQTT (no per-device configuration needed)
- Each detected drone appears as a Home Assistant device with rich telemetry: position, altitude, speed, heading, RSSI, manufacturer, model, operator info, EU classification (50+ entities per drone)
- Scanner health monitoring: temperatures, UPS battery, GNSS, 4G connectivity, MQTT health (50+ entities per scanner)
- Scanner remote control via Home Assistant: reboot, firmware updates, log retrieval
- Two custom Lovelace cards:
  - **dectyr-surveillance-card**: rich list of detected drones with stats
  - **dectyr-map-card**: live Leaflet map with drone markers oriented by heading, scanner radar icons, operator silhouettes, and 30-min trail polylines
- 3 ready-to-use Home Assistant blueprints
- Multi-scanner fusion when multiple units detect the same drone
- Validated against real DJI Matrice 4T, Matrice 400, and Parrot ANAFI UKR Remote ID broadcasts

### Validation status

| Check | Status |
| --- | --- |
| HACS Validate workflow | ✅ passing |
| Hassfest workflow | ✅ passing |
| Tests workflow (82 tests) | ✅ passing |
| Latest release with zip artifact | ✅ v1.1.2 |

## HACS submission checklist

- [x] My repository follows the [HACS publish documentation](https://hacs.xyz/docs/publish/start)
- [x] My repository has a `hacs.json` file with the required fields (`name`, `render_readme`, `homeassistant`)
- [x] My repository has a valid `manifest.json` with all required fields (`domain`, `name`, `version`, `documentation`, `issue_tracker`, `requirements`, `dependencies`, `codeowners`, `iot_class`)
- [x] My repository has at least one [release](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases) with a downloadable `.zip` artifact
- [x] My repository has a public license file (MIT)
- [x] My repository description and topics are filled in on GitHub
- [x] HACS Validate workflow is passing on the latest commit
- [x] Hassfest workflow is passing on the latest commit
- [x] Repository name uses the exact case as registered on GitHub (`DECTYR/ha-integration`)