### PR TITLE
Adds new integration [ljmerza/utilities_email_tracker]

### DIFF
--- a/integration
+++ b/integration
@@ -1257,6 +1257,7 @@
   "lizardsystems/hass-taipit",
   "lizardsystems/hass-tnse",
   "ljbotero/hvac-vent-optimizer",
+  "ljmerza/utilities_email_tracker",
   "lloydw/hass-spanet",
   "lnagel/hass-eaton-ups-mqtt",
   "lnagel/hass-komfovent",


### PR DESCRIPTION
Add `ljmerza/utilities_email_tracker` to the integration list.

- Repository: https://github.com/ljmerza/utilities_email_tracker
- Integration domain: `utilities_email_tracker`
- Latest release: [1.1.2](https://github.com/ljmerza/utilities_email_tracker/releases/tag/1.1.2)
- HACS Action and Hassfest pass on `main` and on the release tag.
- Brand assets PR: home-assistant/brands#10255

Description: Home Assistant custom integration that polls an IMAP mailbox and parses utility-bill emails (Duke Energy, PSNC Energy, Raleigh Water, Truist Mortgage) into a sensor with detailed bill attributes.