### PR TITLE
Add eccel-dev/ha-pepper-c1

### DIFF
--- a/integration
+++ b/integration
@@ -631,6 +631,7 @@
   "EarthGoodness/egi",
   "ebertek/ssm",
   "ec-blaster/magicswitchbot-homeassistant",
+  "eccel-dev/ha-pepper-c1",
   "echocat/ha-companion-media-player",
   "edekeijzer/osrm_travel_time",
   "EdLeckert/ha-tmobilehome",


### PR DESCRIPTION
## Description

Add Eccel C1 RFID Reader integration.

## Integration info

| Field | Value |
|---|---|
| Repository | eccel-dev/ha-pepper-c1 |
| Domain | pepper_c1 |
| IoT class | local_push |
| Version | 2.0.0 |

## Checklist

- [x] Repository is public
- [x] Has a valid `hacs.json`
- [x] Has a valid `manifest.json` with `config_flow: true`
- [x] Has MIT license
- [x] Has a README in English
- [x] Has at least one release (`v2.0.0`)