### PR TITLE
Add portbusy/smart-presence-notify

### DIFF
--- a/integration
+++ b/integration
@@ -1662,6 +1662,7 @@
   "popeen/Home-Assistant-Custom-Component-TCL-Remote",
   "popeen/Home-Assistant-Custom-Component-Temperatur-Nu",
   "PorlyBe/glance_clock_ha",
+  "portbusy/smart-presence-notify",
   "Poshy163/HomeAssistant-Sharesight",
   "postlund/dlink_hnap",
   "Pouzor/freebox_player",


### PR DESCRIPTION
## smart-presence-notify

**Repository:** https://github.com/portbusy/smart-presence-notify  
**Category:** integration

### What it does

Smart Presence Notify routes Home Assistant notifications based on who is currently home:

- Sends to all present household members, a designated admin, or a caller-defined target
- Queues notifications when nobody is home and delivers them on arrival (FIFO, last-only, or summary mode)
- High-priority notifications bypass the queue
- Per-message timeout with optional fallback to another notify service (e.g. Telegram)
- Multi-device support per person
- 100% UI configuration via config flow — no YAML required

### Checklist

- [x] `hacs.json` present
- [x] `manifest.json` valid (hassfest passes)
- [x] GitHub release published (v0.3.1)
- [x] README with installation instructions
- [x] HACS Validation workflow passes
- [x] Translations: en, es, fr, de
- [x] Brand assets in `custom_components/smart_presence_notify/brand/`