### PR TITLE
Add Trodah/ha-entur-skyss to integration list

### DIFF
--- a/integration
+++ b/integration
@@ -2110,6 +2110,7 @@
   "trcyberoptic/hoval-connect-api",
   "trevorwarwick/minidspshd",
   "trickv/hass-claude-usage",
+  "Trodah/ha-entur-skyss",
   "tronikos/google_assistant_sdk_custom",
   "tronikos/nest_legacy",
   "troykelly/homeassistant-au-nsw-covid",


### PR DESCRIPTION
Home Assistant integration that fetches real-time bus departures from the Entur Journey Planner API, focused on Skyss in the Bergen region (Vestland, Norway). Supports both full stops (NSR:StopPlace:) and individual platforms (NSR:Quay:, SKY:Quay:).

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <>
Link to successful HACS action (without the `ignore` key): <>
Link to successful hassfest action (if integration): <>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->