### PR TITLE
Add mocanu-alexandru/ha-fuel-prices-ro

### DIFF
--- a/integration
+++ b/integration
@@ -1427,6 +1427,7 @@
   "mmillmor/geo_home",
   "moag1000/beurer_daylight_lamps",
   "moarph/homeassistant_berner_torantriebe",
+  "mocanu-alexandru/ha-fuel-prices-ro",
   "Moe8383/radar_map_manager",
   "moehrem/DiveraControl",
   "moerk-o/ha-solstice_season",


### PR DESCRIPTION
## Description

Adds **Fuel Prices Romania** (`fuel_prices_ro`) to the HACS default integrations list.

## Required links

- Repository: https://github.com/mocanu-alexandru/ha-fuel-prices-ro
- Latest release: https://github.com/mocanu-alexandru/ha-fuel-prices-ro/releases/tag/v0.1.1
- CI (Validate — hassfest + HACS Action): https://github.com/mocanu-alexandru/ha-fuel-prices-ro/actions/runs/25436533077

## Integration details

| Field | Value |
|-------|-------|
| Domain | `fuel_prices_ro` |
| Category | Integration |

## What it does

Pulls daily fuel prices for Romanian gas stations (per city × per brand × per fuel type) from [monitorulpreturilor.info](https://monitorulpreturilor.info/Home/Gas) — the official Consiliul Concurenței price monitor — and exposes them as Home Assistant sensors with native long-term statistics.

- 7 major brands: OMV, Petrom, Rompetrol, MOL, Lukoil, Socar, Gazprom
- 5 fuel categories: Benzină standard/premium, Motorină standard/premium, GPL
- Config flow, `state_class: measurement`, bilingual (RO + EN)

## Checklist

- [x] The integration has a `v0.1.1` GitHub Release
- [x] Validate workflow (hassfest + HACS Action) passes on `main`
- [x] Brand assets served locally from `custom_components/fuel_prices_ro/brand/` (HA 2026.3+ format — no brands repo PR needed)
- [x] Repository is public with description and topics set