### PR TITLE
Add mocanu-alexandru/ha-fuel-prices-ro

### DIFF
--- a/integration
+++ b/integration
@@ -1428,6 +1428,7 @@
   "mmillmor/geo_home",
   "moag1000/beurer_daylight_lamps",
   "moarph/homeassistant_berner_torantriebe",
+  "mocanu-alexandru/ha-fuel-prices-ro",
   "Moe8383/radar_map_manager",
   "moehrem/DiveraControl",
   "moerk-o/ha-solstice_season",


### PR DESCRIPTION
## Required links

- Repository: https://github.com/mocanu-alexandru/ha-fuel-prices-ro
- Latest release: https://github.com/mocanu-alexandru/ha-fuel-prices-ro/releases/tag/v0.1.1
- CI action runs: https://github.com/mocanu-alexandru/ha-fuel-prices-ro/actions

## Description

Home Assistant custom integration for Romanian fuel prices, using the public peco-online.ro API.

Provides real-time fuel price sensors (benzina, motorina, GPL, AdBlue) from petrol stations across Romania, with support for filtering by city, brand, and fuel type.