### PR TITLE
Add invoker-karl/zeekr_custom

### DIFF
--- a/integration
+++ b/integration
@@ -946,6 +946,7 @@
   "Infinitte/HA-IR-Light",
   "insound/iohouse_climate",
   "InTheDaylight14/nginx-proxy-manager-switches",
+  "invoker-karl/zeekr_custom",
   "IoTFenster/MySmartWindow",
   "iPeel/HA-Eleven-Energy",
   "iprak/sensi",


### PR DESCRIPTION
Adding `invoker-karl/zeekr_custom` — Home Assistant custom integration for Zeekr vehicles, with extended support for the Zeekr 7X (panoramic glass roof + electric sunshade).

- Domain: `zeekr_custom`
- IoT class: `cloud_polling`
- Read-only telemetry (SOC, range, tire pressure/temperature, doors/windows, charging state, …) plus a 3D Lovelace card with live state animation
- Initial release: [v0.0.1](https://github.com/invoker-karl/zeekr_custom/releases/tag/v0.0.1)
- HACS validation: [passing](https://github.com/invoker-karl/zeekr_custom/actions/workflows/validate.yml) — All (8) checks green

Repo: https://github.com/invoker-karl/zeekr_custom