### PR TITLE
Add JohannBlais/lovelace-electrical-panel-card

### DIFF
--- a/plugin
+++ b/plugin
@@ -249,6 +249,7 @@
   "jianyu-li/yet-another-media-player",
   "JMatuszczakk/Locked-Button",
   "jo-ket/compact-cover-control-card",
+  "JohannBlais/lovelace-electrical-panel-card",
   "john-lazarus/HomeAssistantLGThinkQCards",
   "jonahkr/power-distribution-card",
   "JonasDoebertin/ha-today-card",


### PR DESCRIPTION
Adds [`JohannBlais/lovelace-electrical-panel-card`](https://github.com/JohannBlais/lovelace-electrical-panel-card) to the plugin list.

A Lovelace custom card rendering an electrical panel as an interactive one-line diagram — phase trunks, RCDs, breakers, zones — with live power readings at every level and inline smart-plug toggles. Configured entirely from YAML.

- Latest release: [`v0.17.1`](https://github.com/JohannBlais/lovelace-electrical-panel-card/releases/tag/v0.17.1)
- HACS validation workflow: green ([`hacs.yml`](https://github.com/JohannBlais/lovelace-electrical-panel-card/blob/main/.github/workflows/hacs.yml))
- CI: green (lint, typecheck, build, preview snapshot drift check)
- Bundle: single ESM `electrical-panel-card.js` attached to each release
- License: MIT