### PR TITLE
Add ha-dyson-card

### DIFF
--- a/plugin
+++ b/plugin
@@ -497,6 +497,7 @@
   "tcarlsen/lovelace-light-with-profiles",
   "tdvtdv/ha-tdv-bar",
   "teuchezh/dynamic-weather-card",
+  "thanhn062/ha-dyson-card",
   "TheLuXoR/calendar-week-card",
   "TheRealEiskaffee/brightness-overlay",
   "TheScubadiver/camera-gallery-card",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository. Not applicable, this is a plugin/dashboard card.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/thanhn062/ha-dyson-card/releases/tag/v0.1.1>
Link to successful HACS action (without the `ignore` key): <https://github.com/thanhn062/ha-dyson-card/actions/runs/25486323383>
Link to successful hassfest action (if integration): <N/A - plugin/dashboard card>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->
