### PR TITLE
Add matze-search-card to plugin list

### DIFF
--- a/plugin
+++ b/plugin
@@ -478,6 +478,7 @@
   "soestin/hass_periodic_card_reload",
   "sonite/particle-cloud-card",
   "sopelj/lovelace-kanji-clock-card",
+  "soundclub83/matze-search-card",
   "starwarsfan/qclock-card",
   "stefmde/HomeAssistant-TwitchFollowedLiveStreamsCard",
   "studiobts/device-pulse-table-card",


### PR DESCRIPTION
## Checklist

- [x] I've read the publishing documentation.
- [x] I've added the HACS action to my repository.
- [ ] (For integrations only) I've added the hassfest action to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release:
https://github.com/soundclub83/matze-search-card/releases/tag/v1.0.0

Link to successful HACS action (without the `ignore` key):
https://github.com/soundclub83/matze-search-card/actions

Link to successful hassfest action (if integration):
N/A

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->