### PR TITLE
Add 'memphi2/ha-dhe-connect' to integration list

### DIFF
--- a/integration
+++ b/integration
@@ -1388,6 +1388,7 @@
   "mdeweerd/zha-toolkit",
   "Megarushing/ha-ld2410",
   "meltingice1337/tedee_ble",
+  "memphi2/ha-dhe-connect",
   "merlijntishauser/unifi-network-maps-ha",
   "metbril/home-assistant-brandstofprijzen",
   "mguyard/hass-diagral",


### PR DESCRIPTION
Adds Stiebel DHE Connect, a local Home Assistant custom integration for STIEBEL ELTRON DHE Connect water heaters.

Repository: https://github.com/memphi2/ha-dhe-connect
Release: https://github.com/memphi2/ha-dhe-connect/releases/tag/v1.0.0

HACS and Hassfest validation are passing.