### PR TITLE
Adds new plugin [ReikanYsora/Helios]

### DIFF
--- a/plugin
+++ b/plugin
@@ -434,6 +434,7 @@
   "rccoleman/lovelace-lamarzocco-config-card",
   "redkanoon/embedded-view-card",
   "redstone99/hass-alert2-ui",
+  "ReikanYsora/Helios",
   "rejuvenate/lovelace-horizon-card",
   "reptilex/tesla-style-solar-power-card",
   "rgc99/irrigation-unlimited-card",


### PR DESCRIPTION
Hey HACS team,

I'd love to add **HELIOS** to the default catalog.

It's a Lovelace card I built to scratch a personal itch: I wanted to *see*, at a glance and in real time, how much sun was hitting my house, how the clouds were going to mess with that over the next few hours, and what my panels were doing about it. So Helios is exactly that, on a 3D map of your home, the sun's daily arc projected with depth, a live sun disc that fills with intensity proportional to the current irradiance (W/m²), an animated incidence ray flowing faster the stronger the sun, a translucent cloud disc on the ground that grows with cloud cover, and an optional PV chip pinned on the home with the instantaneous production. There's a 5-day timeline at the bottom (2 past + today + 2 forecast days) you can scrub, every layer on the map snaps to the selected instant, past or future.

<img width="451" height="515" alt="preview_01" src="https://github.com/user-attachments/assets/f7422cef-e4a6-4207-aa72-e63c87c9dacf" />
<img width="451" height="515" alt="preview_02" src="https://github.com/user-attachments/assets/16a13fba-e774-4046-9d1d-0dbc5f57b66e" />
<img width="451" height="515" alt="preview_03" src="https://github.com/user-attachments/assets/f096b5e1-27ac-4c50-90b5-6ced15b92a14" />

Under the hood it's NOAA-validated solar math (mean altitude error 0.30°, mean azimuth error 0.36° across 376 sample points), Haurwitz clear-sky GHI with Kasten-Czeplak cloud attenuation, and a multi-model weather fusion that always pairs ECMWF IFS with the best regional model for your location (AROME-France, UKMO, DWD ICON-D2, NOAA HRRR, JMA MSM, BOM ACCESS-G…). For users with cumulative-energy PV sensors (kWh), the card differentiates them on a 60s rolling window so the chip shows real instantaneous power, not a misleading lifetime total. It speaks 7 languages and follows the user's HA locale.

I've been running it on my own Home Assistant for many days now , testing, breaking, fixing, polishing and at this point I'm comfortable putting it in front of the community.

On the repo side, two GitHub Actions are wired up so the project stays compliant with HACS expectations, every push, every PR, and on a nightly cron:

- **`HACS validation`** — runs the official `hacs/action@main` with `category: plugin`, exactly as documented
- **`Tests`** — typecheck + tests + production build, with an explicit guard that fails the run if `dist/helios.js` isn't produced (so a release can never end up missing its artifact)

The v1.0.0 release has the built `helios.js` attached, the `hacs.json` manifest is in place (`render_readme: true`, minimum HA `2024.4.0`, HACS `1.32.0`), the LICENSE is MIT, the README has screenshots and a full configuration table.

- Repo: https://github.com/ReikanYsora/Helios
- Release: https://github.com/ReikanYsora/Helios/releases/tag/v1.0.0
- Latest validation run (green): https://github.com/ReikanYsora/Helios/actions/workflows/validate.yml

Thank you for everything you do for this catalog, it's genuinely an honour to be asking to join it. Happy to address anything you'd like changed.

Jérôme