### PR TITLE
Add redchupa/kr_component_kit

### DIFF
--- a/integration
+++ b/integration
@@ -1712,6 +1712,7 @@
   "rccoleman/channels_dvr_recently_recorded",
   "rdehuyss/homeassistant-custom_components-denkovi",
   "recalbox/RecalboxHomeAssistant",
+  "redchupa/kr_component_kit",
   "RedFirebreak/ha-osrs-data",
   "redlukas/emu_mbus_center",
   "redpomodoro/fronius_modbus",


### PR DESCRIPTION
<!--
  This PR adds the integration `redchupa/kr_component_kit` (Korea-only HA services
  bundle: KEPCO, 아리수, 안전알림, 가스앱, 카카오맵, 굿스플로우 etc.) to the HACS Default repository.
-->

## Checklist

- [x] I have read the [publishing documentation](https://hacs.xyz/docs/publish/start)
- [x] I have added the [HACS action](https://github.com/hacs/action) to the repository
- [x] I have added the [hassfest action](https://developers.home-assistant.io/docs/creating_integration_manifest#hassfest) to the repository (integration only)
- [x] The actions pass without disabled checks
- [x] I have a successful action run for the HACS action
- [x] I have a successful action run for the hassfest action (integration only)
- [x] I have a release of the integration

## Links

**Link to current release:**
https://github.com/redchupa/kr_component_kit/releases/tag/v4.2.9

**Link to successful HACS action run (without `ignore` key):**
https://github.com/redchupa/kr_component_kit/actions/runs/25603399289/job/75161042727

**Link to successful hassfest action run:**
https://github.com/redchupa/kr_component_kit/actions/runs/25603399289/job/75161042732