### PR TITLE
Add HYMER Connect Metadata

### DIFF
--- a/integration
+++ b/integration
@@ -491,6 +491,7 @@
   "damanic/ha-integration-mempool",
   "Dams51/Pleinchamp",
   "dan-r/HomeAssistant-NissanConnect",
+  "dan-simms1/hymer-connect-ha",
   "danielcherubini/elegoo-homeassistant",
   "danieldiazi/homeassistant-meteogalicia",
   "Danieldiazi/homeassistant-meteogalicia_tides",


### PR DESCRIPTION
Adds dan-simms1/hymer-connect-ha to the HACS default integration repository list.\n\nRepository checks:\n\n- Public repository with Issues enabled\n- HACS validation workflow passing\n- Hassfest validation workflow passing\n- Latest GitHub release: v1.0.20\n- Custom integration domain: hymer_connect_metadata