### PR TITLE
Add ljmerza/orbit-bhyve-ble

### DIFF
--- a/integration
+++ b/integration
@@ -1261,6 +1261,7 @@
   "lizardsystems/hass-taipit",
   "lizardsystems/hass-tnse",
   "ljbotero/hvac-vent-optimizer",
+  "ljmerza/orbit-bhyve-ble",
   "lloydw/hass-spanet",
   "lnagel/hass-eaton-ups-mqtt",
   "lnagel/hass-komfovent",


### PR DESCRIPTION
## Repository

- **Repo**: https://github.com/ljmerza/orbit-bhyve-ble
- **Domain**: `orbit_bhyve`
- **Category**: integration
- **Latest release**: [v2.0.1](https://github.com/ljmerza/orbit-bhyve-ble/releases/tag/v2.0.1)

## What it does

Local BLE control of Orbit B-Hyve hose-tap (HT25) and 4-port XD (HT34A) irrigation timers from Home Assistant. Cloud is contacted only at setup to discover devices and fetch each device's BLE network key; every command and state poll afterward is BLE-only.

## Validation status

- HACS Action: **all 8 checks pass** on `main` ([latest run](https://github.com/ljmerza/orbit-bhyve-ble/actions/workflows/validate.yaml))
- Hassfest: passes
- Brand icons bundled at `custom_components/orbit_bhyve/brand/` per the [HA 2026.3 brands proxy API](https://developers.home-assistant.io/blog/2026/02/24/brands-proxy-api).
- GitHub release published with `orbit_bhyve.zip` artifact.
- Repo description and topics set.