### PR TITLE
Add jayzuccarelli/ha-memory

### DIFF
--- a/integration
+++ b/integration
@@ -1003,6 +1003,7 @@
   "jaycollett/OpenIRBlaster",
   "jaydeethree/Home-Assistant-weatherdotcom",
   "jayjojayson/hass-victron-vrm-api",
+  "jayzuccarelli/ha-memory",
   "jazzz/ha-evocarshare",
   "jbergler/hass-ttlock",
   "jbouwh/ha-elro-connects",


### PR DESCRIPTION
Adds [jayzuccarelli/ha-memory](https://github.com/jayzuccarelli/ha-memory) as a HACS-listed integration.

**Memory** — persistent file-backed memory for Home Assistant Assist and any LLM conversation agent (Anthropic Claude, OpenAI Conversation, Google Gemini, AI Tasks). No vector DB, no embeddings — markdown files you can read, edit, version-control. Inspired by Claude Code's MEMORY.md pattern.

- Released: [v0.2.0](https://github.com/jayzuccarelli/ha-memory/releases/tag/v0.2.0)
- Validation: hassfest ✅, HACS 8/8 ✅, 27 tests ✅
- Brand assets included locally per [Brands Proxy API announcement](https://developers.home-assistant.io/blog/2026/02/24/brands-proxy-api)
- Native LLM API via `homeassistant.helpers.llm.AssistAPI` — no per-provider script wrappers needed
- License: MIT