### PR TITLE
Add Lirum-Labs/ha-power-gauge

### DIFF
--- a/plugin
+++ b/plugin
@@ -293,6 +293,7 @@
   "levonisyas/clockpro-card",
   "levonisyas/floor3dpro-card",
   "levonisyas/overlaypro-card",
+  "Lirum-Labs/ha-power-gauge",
   "ljmerza/fitbit-card",
   "ljmerza/github-card",
   "ljmerza/harmony-remote-card",


### PR DESCRIPTION
## Repository
[Lirum-Labs/ha-power-gauge](https://github.com/Lirum-Labs/ha-power-gauge)

## Category
Plugin (Lovelace card)

## What it is
A glowing, smoothly-blending live-power gauge for Home Assistant Lovelace dashboards. Two cards in one bundle:

- **Power Gauge Card** — radial near-full-circle gauge whose colour ramps smoothly from cyan through orange to red as the load approaches its configured maximum.
- **Power Gauge Bar Card** — compact linear variant that stacks one row per device, sharing the same threshold logic and colour ramp.

Both cards register in `window.customCards` and appear separately in HA's *Add Card* picker.

## HACS validation
- `hacs.json` present and valid (`name`, `filename`, `content_in_root`, `homeassistant`).
- `dist/ha-power-gauge.js` ships in the repo and is attached to each GitHub release.
- Repository runs the official [`hacs/action`](https://github.com/hacs/action) on every push — green on the latest commit: https://github.com/Lirum-Labs/ha-power-gauge/actions/workflows/hacs.yml
- Latest release: [v0.2.2](https://github.com/Lirum-Labs/ha-power-gauge/releases/latest) (Apache-2.0 licensed).

Thanks for your work on HACS! Happy to address any feedback.