### PR TITLE
Add Lirum-Labs/ha-power-gauge

### DIFF
--- a/plugin
+++ b/plugin
@@ -293,6 +293,7 @@
   "levonisyas/clockpro-card",
   "levonisyas/floor3dpro-card",
   "levonisyas/overlaypro-card",
+  "Lirum-Labs/ha-power-gauge",
   "ljmerza/fitbit-card",
   "ljmerza/github-card",
   "ljmerza/harmony-remote-card",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: https://github.com/Lirum-Labs/ha-power-gauge/releases/tag/v0.2.3
Link to successful HACS action (without the `ignore` key): https://github.com/Lirum-Labs/ha-power-gauge/actions/runs/25619393843
Link to successful hassfest action (if integration): N/A — this is a Lovelace plugin, not an integration.