### PR TITLE
Add Muxee4ka/ucams_home_assistant

### DIFF
--- a/integration
+++ b/integration
@@ -1468,6 +1468,7 @@
   "mutilator/homeassistant-iqua-softener",
   "mutilator/homeassistant-zone-label-trigger",
   "muxa/home-assistant-niwa-tides",
+  "Muxee4ka/ucams_home_assistant",
   "MvdDonk/brewfather",
   "mvdwetering/huesyncbox",
   "mvdwetering/yamaha_ynca",


### PR DESCRIPTION
Adds `Muxee4ka/ucams_home_assistant` — Home Assistant integration for Ufanet (Уфанет) video surveillance and intercoms.

- Latest release: [v0.5.0](https://github.com/Muxee4ka/ucams_home_assistant/releases/tag/v0.5.0)
- License: MIT
- HACS validator: passing on `master` (CI: https://github.com/Muxee4ka/ucams_home_assistant/actions/workflows/validate.yml)
- Hassfest: passing
