### PR TITLE
Add k-flow-card to plugin list

### DIFF
--- a/plugin
+++ b/plugin
@@ -272,6 +272,7 @@
   "karlis-vagalis/circular-timer-card",
   "KartoffelToby/better-thermostat-ui-card",
   "kattcrazy/Stacked-Bar-Card",
+  "thekhan1122/k-flow-card",
   "kerstenremco/busvertrektijden-ha-card",
   "kevin-briand/massa-node-card",
   "kibibit/kb-better-graph-colors",


### PR DESCRIPTION
## Checklist
- [x] I read the [contribution guidelines](https://github.com/hacs/default/blob/master/.github/CONTRIBUTING.md).
- [x] The repository has a `hacs.json` file.
- [x] The repository has at least one tagged release.
- [x] The repository has a README with installation and configuration instructions.
- [x] The card works with the latest Home Assistant version.
- [x] The card uses no long‑lived tokens.
- [x] The card has no external JavaScript dependencies that must be installed separately.

## Required links
- Latest release: https://github.com/thekhan1122/k-flow-card/releases/latest
- CI / action runs: https://github.com/thekhan1122/k-flow-card/actions