### PR TITLE
Add k-flow-card to plugin list

### DIFF
--- a/plugin
+++ b/plugin
@@ -272,6 +272,7 @@
   "karlis-vagalis/circular-timer-card",
   "KartoffelToby/better-thermostat-ui-card",
   "kattcrazy/Stacked-Bar-Card",
+  "thekhan1122/k-flow-card",
   "kerstenremco/busvertrektijden-ha-card",
   "kevin-briand/massa-node-card",
   "kibibit/kb-better-graph-colors",


### PR DESCRIPTION
Add K-Flow Card to the default HACS repository.

## Checklist
- [x] My repository has a `hacs.json` file.
- [x] My repository has at least one tagged release.
- [x] My repository has a README with installation and configuration instructions.
- [x] My card works with the latest Home Assistant version.
- [x] My card uses no long-lived tokens.
- [x] My card has no external dependencies that must be installed separately.
- [x] I have read the contribution guidelines.

## Required links
- Latest release: https://github.com/thekhan1122/k-flow-card/releases/latest
- CI / action runs: https://github.com/thekhan1122/k-flow-card/actions