### PR TITLE
add m-zenker/kermi-ha-bridge to appdaemon

### DIFF
--- a/appdaemon
+++ b/appdaemon
@@ -26,6 +26,7 @@
   "madchap/energiapro_gas_consumption",
   "mguyard/appdaemon-coversmanager",
   "Mohlsson/ReplayLightsHistory",
+  "m-zenker/kermi-ha-bridge"
   "nechry/elco-remocon-net-appdaemon",
   "nickneos/Appdaemon-Ring-Doorbell-Automations",
   "nickneos/Appdaemon-ZHA-Hue-Dimmer-Switch",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository. - not applicable - appdaemon
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/m-zenker/kermi-ha-bridge/releases/tag/v0.10.2>
Link to successful HACS action (without the `ignore` key): <https://github.com/m-zenker/kermi-ha-bridge/actions/runs/25658461502>
Link to successful hassfest action (if integration): not applicable

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->