### PR TITLE
Add redchupa/kr_finance_kit

### DIFF
--- a/integration
+++ b/integration
@@ -1712,6 +1712,7 @@
   "rccoleman/channels_dvr_recently_recorded",
   "rdehuyss/homeassistant-custom_components-denkovi",
   "recalbox/RecalboxHomeAssistant",
+  "redchupa/kr_finance_kit",
   "RedFirebreak/ha-osrs-data",
   "redlukas/emu_mbus_center",
   "redpomodoro/fronius_modbus",


### PR DESCRIPTION
- Repository: https://github.com/redchupa/kr_finance_kit
- Category: integration

KR Finance Kit — a Home Assistant integration exposing Korean financial data (KOSPI/KOSDAQ indices, USD/KRW FX, KR/US ticker quotes, holdings P/L converted to KRW, OpenDart disclosures) as native sensors, with a `finance_query` LLM tool for voice queries.

Built on free data sources only (yfinance + OpenDart's free key). No brokerage credentials anywhere in the codebase.

- Tagged release: `v0.1.0`
- Hassfest: passes
- HACS Action: 7/8 passes — the remaining brands check will clear once the home-assistant/brands PR for `custom_integrations/kr_finance_kit/` is merged (in flight separately).