### PR TITLE
Add nitaybz/ha-pima

### DIFF
--- a/integration
+++ b/integration
@@ -1081,6 +1081,7 @@
   "nimroddolev/chime_tts",
   "NinDTendo/homeassistant_gradual_volume_control",
   "NinDTendo/tobi",
+  "nitaybz/ha-pima",
   "nkvoll/home-assistant-qsys-qrc",
   "nnnlog/homeassistant-cvnet-smarthome",
   "nordicopen/easee_hass",


### PR DESCRIPTION
Native Home Assistant integration for PIMA alarm panels (both legacy Hunter Pro and modern Force/Vision).

## Repository
- https://github.com/nitaybz/ha-pima
- v0.3.0 release tagged

## Hardware supported
- **Hunter Pro 32 / 96 / 144** via the legacy net4pro protocol or any serial-to-Ethernet bridge (Lantronix XPort, Moxa NPort, Elfin EW11). Vendors the deiger/Alarm protocol implementation under GPL-3.0 with a frame-sync read loop added for serial bridges.
- **Force / Vision** via the official JSON-over-TCP protocol (Force Interface JSON Format Specification ver. 2.1). HA acts as TCP server; the panel dials in.

## What you get
- Full UI config flow with LAN auto-discovery for legacy panels (ARP-first + module-id validation) and listen-port setup for modern panels with on-connect auto-learning of account id, zone count, partitions, zone names, user names, and fault state.
- alarm_control_panel per partition with ARMING / DISARMING progress state.
- binary_sensor per zone (named with panel's own labels on Force).
- switch entities for sirens and 8 controlled outputs on Force.
- pima_alarm_triggered / pima_zone_triggered HA events for automation triggers.
- pima.bypass_zone service (works on both adapters).
- Options flow, diagnostics (redacted), stale-entity pruning, optional require-code toggle.

## Validation
- hacs.json present
- manifest.json valid, codeowners set to @nitaybz
- README explains install + configure for both panel families
- v0.3.0 release tag in place