### PR TITLE
Add Bosso-Family/hass-bosso

### DIFF
--- a/integration
+++ b/integration
@@ -298,6 +298,7 @@
   "boralyl/steam-wishlist",
   "borski/ha-lucidmotors",
   "bosch-thermostat/home-assistant-bosch-custom-component",
+  "Bosso-Family/hass-bosso",
   "BottlecapDave/HomeAssistant-FirstBus",
   "BottlecapDave/HomeAssistant-HarvestTimeTracker",
   "BottlecapDave/HomeAssistant-OctopusEnergy",


### PR DESCRIPTION
Adding the Bosso Lights integration to HACS default.

   - Repository: https://github.com/Bosso-Family/hass-bosso
   - Domain: `bosso`
   - Description: Home Assistant integration for Bosso smart lights

   This integration provides:
   - Full light control (on/off, brightness, RGB color, color temperature)
   - Lighting effects from the Bosso effects catalog
   - Predefined and user-defined preset selection
   - Multi-device support

   The integration has been tested against the production Bosso API and passes both HACS Validation and Hassfest checks. Brand icons and logos are included in the integration's `brand/` directory per the new HA 2026.3+ local brands system.