### PR TITLE
add a-better-history-card

### DIFF
--- a/plugin
+++ b/plugin
@@ -283,6 +283,7 @@
   "kibibit/kb-frosted-cards",
   "kibibit/kb-steam-card",
   "kinghat/tabbed-card",
+  "KipK/a-better-history-card",
   "KipK/openevse-card",
   "kirbo/ha-lovelace-elapsed-time-card",
   "kizza/magic-home-party-card",


### PR DESCRIPTION
The native Home Assistant history panel only graphs entity states. Many of the most useful values in HA live in entity attributes — the current temperature of a climate thermostat, the battery level of a sensor, the power draw of a smart plug, the position of a cover, etc. These are invisible to the built-in history.

ha-better-history graphs attributes as first-class series. You can mix state series and attribute series on the same graph, with independent colors, labels, and Y-axis scale groups:

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/KipK/a-better-history-card/releases/tag/0.1.1>
Link to successful HACS action (without the `ignore` key): <https://github.com/KipK/a-better-history-card/actions/runs/25731574299>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->