### PR TITLE
Add nitaybz/ha-switchbee

### DIFF
--- a/integration
+++ b/integration
@@ -1555,6 +1555,7 @@
   "NinDTendo/homeassistant_gradual_volume_control",
   "NinDTendo/tobi",
   "NirBY/ha-mashov",
+  "nitaybz/ha-switchbee",
   "nitaybz/optimistic_feedback",
   "njobrien1006/hass_traeger",
   "nkvoll/home-assistant-qsys-qrc",


### PR DESCRIPTION
- Repository: https://github.com/nitaybz/ha-switchbee
- Category: integration
- HA integration domain: \`ha_switchbee\`
- Display name: SwitchBee Local
- Minimum HA core: \`2024.1.0\`
- Latest release: \`v0.1.0\`

### What it does

Direct, local WebSocket integration for the SwitchBee Central Unit (port 7891). Push-based state updates via \`CONFIGURATION_CHANGE\` notifications. Replaces the legacy \`homebridge-switchbee\` plugin path for users who want native HA control without a HomeKit bridge in the middle.

Platforms covered in v1: \`switch\`, \`light\` (dimmers), \`cover\` (shutters + Somfy), \`scene\`.

### Validation

- \`hassfest\` passing (custom integration manifest, sorted keys, valid integration_type=hub).
- \`hacs/action@main\` passing (hacs.json, brand assets, repository topics).
- 234 unit tests passing on CI (Python 3.12).

### Notes

- Brand assets are bundled in-repo under \`custom_components/ha_switchbee/brand/\` (icon + logo @1x and @2x).
- A migration tool is shipped at \`tools/migrate.py\` for users migrating from \`homebridge-switchbee\` with entity_id preservation, backup-first invariant, and a documented rollback procedure.