### PR TITLE
Add Marker284/zond2gis

### DIFF
--- a/integration
+++ b/integration
@@ -1346,6 +1346,7 @@
   "mariusz-ostoja-swierczynski/tech-controllers",
   "markaggar/ha-media-index",
   "markaggar/Water-Monitor",
+  "Marker284/zond2gis",
   "markfrancisonly/ha-cameralux",
   "markgdev/home-assistant_OctopusAgile",
   "markuzzi/somfy_cul_integration",


### PR DESCRIPTION
## Description

Add [Marker284/zond2gis](https://github.com/Marker284/zond2gis) — a Home Assistant integration for **2GIS Friends on Map**.

## Integration overview

Tracks friends' real-time locations from the 2GIS "Friends on Map" feature.

- **IoT class:** `cloud_push` — persistent WebSocket to `zond.api.2gis.ru`, no polling
- **Entities per friend:** Device Tracker, Battery, Charging, Movement, Place, Speed, Distance from Home
- **Config flow:** 2-step — credentials → friend selection. Options flow to change tracked friends after setup.
- **Languages:** Russian, English
- **HA version:** 2024.1+

## Checklist

- [x] The repository is public on GitHub
- [x] Repository has a description
- [x] Repository has topics: `home-assistant`, `hacs`, `hacs-integration`
- [x] Repository has a README
- [x] `hacs.json` is present in the root
- [x] `manifest.json` with `domain`, `version`, `codeowners`, `documentation`, `config_flow`, `iot_class`
- [x] `brand/` directory with `icon.png`, `icon@2x.png`, `logo.png`
- [x] GitHub Release v1.0.0 exists (not just a tag)
- [x] Only one integration in the repository