### PR TITLE
Add obeauche/owlwatt-home-assistant

### DIFF
--- a/integration
+++ b/integration
@@ -1569,6 +1569,7 @@
   "nyffchanium/argoclima-integration",
   "NylonDiamond/homeassistant-wrist-assistant",
   "nzrutman/hello_fairy_ble",
+  "obeauche/owlwatt-home-assistant",
   "odya/hass-ina219-ups-hat",
   "ofalvai/home-assistant-candy",
   "ohheyrj/home-assistant-aws-codepipeline",


### PR DESCRIPTION
Adding [OwlWatt for Home Assistant](https://github.com/obeauche/owlwatt-home-assistant) — an integration that surfaces independent solar production measurement, expected production, shortfall detection, anomaly flags, and roof imagery as Home Assistant sensors / binary sensors / camera / image / button entities. Works with Enphase + SolarEdge systems via OwlWatt's cloud API.

Free integration, open source. Subscription (for the value-in-dollars / claim-letter features) is optional and managed at owlwatt.com.

## Repository compliance

- [x] HACS validation passing — https://github.com/obeauche/owlwatt-home-assistant/actions/workflows/hacs.yml
- [x] hassfest validation passing — https://github.com/obeauche/owlwatt-home-assistant/actions/workflows/hassfest.yml
- [x] Brand assets present at `custom_components/owlwatt/brand/` (icon, icon@2x, logo, logo@2x)
- [x] Repository topics set (`home-assistant`, `hacs`, `hacs-integration`, `solar`, `energy`, `enphase`, `solaredge`)
- [x] LICENSE (MIT), README.md, info.md, hacs.json all present
- [x] config_flow + cloud_polling iot_class
- [x] codeowners declared (@obeauche)

Happy to address any review feedback.