### PR TITLE
Add new integration for Thesslagreen airpack USB

### DIFF
--- a/integration
+++ b/integration
@@ -187,6 +187,7 @@
   "aropop/home-assistant-cronicle",
   "ARPOBOT-BLOOMIN8/eink_canvas_home_assistant_component",
   "ArtLogicIKE/frixos-ha-integration",
+  "arypien/ha_thesslagreen_airpack_usb",
   "asantaga/lightwaverf_HA_EnergySensor",
   "asantaga/wiserHomeAssistantPlatform",
   "asev/homeassistant-helios",


### PR DESCRIPTION
## Description

Integration for Theslagreen AirPack Home heat recovery units via Modbus RTU (RS485 → USB).

## Links

- Latest release: https://github.com/arypien/ha_thesslagreen_airpack_usb/releases/tag/1.1.2
- HACS validation: https://github.com/arypien/ha_thesslagreen_airpack_usb/actions/runs/25790748899
- Hassfest validation: https://github.com/arypien/ha_thesslagreen_airpack_usb/actions/runs/25789894935

## Checklist
- [x] The integration passes HACS validation
- [x] The integration passes hassfest validation
- [x] README is available
- [x] Brand assets (icon) are available
- [x] Topics are set on the repository