### PR TITLE
Adds new integration [redchupa/kr_baby_kit]

### DIFF
--- a/integration
+++ b/integration
@@ -1737,6 +1737,7 @@
   "rccoleman/channels_dvr_recently_recorded",
   "rdehuyss/homeassistant-custom_components-denkovi",
   "recalbox/RecalboxHomeAssistant",
+  "redchupa/kr_baby_kit",
   "RedFirebreak/ha-osrs-data",
   "redlukas/emu_mbus_center",
   "redpomodoro/fronius_modbus",


### PR DESCRIPTION
Korean baby/toddler kit for Home Assistant — exposes growth-chart percentiles, NIP immunization, MOHW well-child checkups, and Korean public-childcare tuition as HA sensors and calendars.

- Repository: https://github.com/redchupa/kr_baby_kit
- Latest release: v0.8.8
- Data sources: KDCA (성장도표), NIP (예방접종), MOHW (영유아 검진), MOE (보육사업안내) — all public, no PII collected.
- Country tag: KR (set in `hacs.json`).