### PR TITLE
Add redchupa/kakao-noti

### DIFF
--- a/integration
+++ b/integration
@@ -1737,6 +1737,7 @@
   "rccoleman/channels_dvr_recently_recorded",
   "rdehuyss/homeassistant-custom_components-denkovi",
   "recalbox/RecalboxHomeAssistant",
+  "redchupa/kakao-noti",
   "RedFirebreak/ha-osrs-data",
   "redlukas/emu_mbus_center",
   "redpomodoro/fronius_modbus",


### PR DESCRIPTION
Add `redchupa/kakao-noti` to the integration list.

**Send to myself on KakaoTalk Notify** — Home Assistant integration that sends notifications to the user's own KakaoTalk via the official Kakao "Memo" API. Uses Home Assistant's standard OAuth2 (`application_credentials`); no bridge or add-on required. Supports multiple accounts and the modern `notify` entity platform.

- Repository: https://github.com/redchupa/kakao-noti
- Domain: `kakao_noti`
- Latest release: v0.7.0
- Country: KR
- Brand: already registered in `home-assistant/brands` (`https://brands.home-assistant.io/_/kakao_noti/icon.png`)