### PR TITLE
Adds new plugin [hudsonbrendon/miyoo-mini-card]

### DIFF
--- a/plugin
+++ b/plugin
@@ -211,6 +211,7 @@
   "homeassistant-extras/room-summary-card",
   "homeassistant-extras/toolbar-status-chips",
   "homeassistant-extras/zwave-card-set",
+  "hudsonbrendon/miyoo-mini-card",
   "Hugo0485/DoubleCurtainCard",
   "hulkhaugen/hass-bha-icons",
   "hyperb1iss/hyper-light-card",


### PR DESCRIPTION
Adds [hudsonbrendon/miyoo-mini-card](https://github.com/hudsonbrendon/miyoo-mini-card) to the plugin catalog.

Lovelace card for the **Miyoo Mini Plus** running OnionOS, paired with the companion [`miyoo-mqtt-reporter`](https://github.com/hudsonbrendon/miyoo-mqtt-reporter) daemon (73 MQTT-Discovery entities). Shows the real device photo with the currently running game overlaid on the screen, a state line, and a configurable 4-cell stat grid (battery / volume / temperature / playtime). Live WiFi / NTP / mute indicators in a bottom action bar.

- Repository: https://github.com/hudsonbrendon/miyoo-mini-card
- Released asset: `miyoo-mini-card.js` attached to GitHub Releases
- `hacs.json` present; `homeassistant: "2024.1.0"`
- MIT licensed