### PR TITLE
Adds new plugin [hudsonbrendon/miyoo-mini-card]

### DIFF
--- a/plugin
+++ b/plugin
@@ -211,6 +211,7 @@
   "homeassistant-extras/room-summary-card",
   "homeassistant-extras/toolbar-status-chips",
   "homeassistant-extras/zwave-card-set",
+  "hudsonbrendon/miyoo-mini-card",
   "Hugo0485/DoubleCurtainCard",
   "hulkhaugen/hass-bha-icons",
   "hyperb1iss/hyper-light-card",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: https://github.com/hudsonbrendon/miyoo-mini-card/releases/tag/v0.3.1
Link to successful HACS action (without the `ignore` key): https://github.com/hudsonbrendon/miyoo-mini-card/actions/runs/25836537865
Link to successful hassfest action (if integration): N/A (this is a Lovelace plugin, not an integration)

---

Lovelace card for the **Miyoo Mini Plus** running OnionOS, paired with the companion [`miyoo-mqtt-reporter`](https://github.com/hudsonbrendon/miyoo-mqtt-reporter) daemon (73 MQTT-Discovery entities). Shows the real device photo with the currently running game overlaid on the screen, a state line, and a configurable 4-cell stat grid (battery / volume / temperature / playtime). Live WiFi / NTP / mute indicators in a bottom action bar.

Repository: https://github.com/hudsonbrendon/miyoo-mini-card