### PR TITLE
Adds new integration [rsp2k/omni-pca]

### DIFF
--- a/integration
+++ b/integration
@@ -1826,6 +1826,7 @@
   "rsnodgrass/hass-lunos",
   "rsnodgrass/hass-poolmath",
   "rsnodgrass/hass-xantech",
+  "rsp2k/omni-pca",
   "rstrouse/ESPSomfy-RTS-HA",
   "rt400/Jewish-Sabbaths-Holidays",
   "ruaan-deysel/ha-unifi-insights",


### PR DESCRIPTION
# Adds new integration [rsp2k/omni-pca]

Adding `rsp2k/omni-pca` — a HACS-installable integration + async Python client for HAI/Leviton **Omni-Link II** home automation panels (Omni Pro II, Omni IIe, Omni LTe, Lumina).

## Repository

- **GitHub:** <https://github.com/rsp2k/omni-pca>
- **Latest release:** `v2026.5.11`
- **Library on PyPI:** [`omni-pca`](https://pypi.org/project/omni-pca/) (referenced via `manifest.json`'s `requirements`)
- **Documentation:** <https://hai-omni-pro-ii.warehack.ing/>

## What it does

Talks Omni-Link II directly to the panel over TCP — no middleware. HA opens an encrypted session straight to the controller and listens for unsolicited push messages. Creates one device per panel plus typed entities for every named object: `alarm_control_panel` for areas, `light` for units, `binary_sensor` + `switch` for zones (state + bypass), `climate` for thermostats, `sensor` for analog zones and panel telemetry, `button` for panel macros, `event` for the typed push-notification stream.

Built from a clean-room reverse engineering of HAI's PC Access 3.17. The protocol layer captures two non-public quirks that public Omni-Link clients miss — full byte-level protocol spec at <https://hai-omni-pro-ii.warehack.ing/reference/protocol/>.

## Validation

Both required checks pass on `main`:

- [HACS validation](https://github.com/rsp2k/omni-pca/actions/workflows/validate.yml) — 8/8
- [Hassfest](https://github.com/rsp2k/omni-pca/actions/workflows/validate.yml) — clean

Brand icons (`icon.png` 256×256, `icon@2x.png` 512×512) are shipped inline at `custom_components/omni_pca/brand/` per the HA 2026.3 brands-proxy API.

## Checklist

- [x] Hosted on GitHub, public, non-archived
- [x] Description and topics set
- [x] `hacs.json` at repo root
- [x] `custom_components/omni_pca/manifest.json` with `version`, `documentation`, `issue_tracker`, `codeowners`, `iot_class`, `integration_type`, sorted keys
- [x] Git tag `v2026.5.11` matches `manifest.json` version
- [x] README rendered (`render_readme: true`)
- [x] HACS validation passes
- [x] Hassfest passes
- [x] Brand icons present inline
