### PR TITLE
Add Victron ESS Control integration

### DIFF
--- a/integration
+++ b/integration
@@ -1348,6 +1348,7 @@
   "MarcoGos/kleenex_pollenradar",
   "marcolivierarsenault/moonraker-home-assistant",
   "MarcusTaz/ha_kia_hyundai_USA",
+  "marisma-mhe/ha-victron-ess-control",
   "mariusz-ostoja-swierczynski/tech-controllers",
   "markaggar/ha-media-index",
   "markaggar/Water-Monitor",


### PR DESCRIPTION
## Description

Adds `marisma-mhe/ha-victron-ess-control` to the integration category.

This integration provides:
- Guided setup wizard (config flow) for Victron Energy ESS systems
- Deploys `packages/victron_ess.yaml` with user serials filled in
- All helpers, canonical template sensors, and utility meters for ESS control

**Repository:** https://github.com/marisma-mhe/ha-victron-ess-control
**Release:** v0.1.0
**IoT class:** local_push
**Dependencies:** mqtt (core), ha-victron-mqtt (HACS custom)