### PR TITLE
Add 777Timo/inkbird-ble-ha

### DIFF
--- a/integration
+++ b/integration
@@ -15,6 +15,7 @@
   "5high/konke",
   "5high/phicomm-dc1-homeassistant",
   "62fixolab/HA-Panda-PWR",
+  "777Timo/inkbird-ble-ha",
   "8none1/lednetwf_ble",
   "9a4gl/hass-centrometal-boiler",
   "aaamoeder/ha-goboony",


### PR DESCRIPTION
## Integration info

| | |
|---|---|
| **Repository** | [777Timo/inkbird-ble-ha](https://github.com/777Timo/inkbird-ble-ha) |
| **Integration domain** | `inkbird_ble` |
| **Device** | Inkbird ISC-027BW (Bluetooth grill thermometer with fan controller) |
| **IoT class** | `local_push` |
| **Min. HA version** | 2026.1.0 |

## Description

Custom integration for the **Inkbird ISC-027BW** Bluetooth grill thermometer. The BLE protocol was fully reverse-engineered (Tuya Cloud was rejected). The integration connects locally via BLE and provides:

- 4 temperature probe sensors
- Fan speed sensor
- Grill target temperature (read/write)
- Probe alarm temperatures (read/write)
- Fan on/off switch

## Checklist

- [x] `hacs.json` present and valid
- [x] `manifest.json` with `codeowners`, `documentation`, `issue_tracker`, `version`
- [x] English and German translations (`en.json`, `de.json`)
- [x] Brand assets (`brand/icon.png`, `brand/logo.png`)
- [x] HACS validation workflow passing (8/8 checks)
- [x] GitHub release with matching tag (`v1.2.0`)
- [x] MIT License
- [x] README in English