### PR TITLE
Add memphi2/ha-unifi-drive

### DIFF
--- a/integration
+++ b/integration
@@ -1389,6 +1389,7 @@
   "Megarushing/ha-ld2410",
   "meltingice1337/tedee_ble",
   "memphi2/ha-dhe-connect",
+  "memphi2/ha-unifi-drive",
   "merlijntishauser/unifi-network-maps-ha",
   "metbril/home-assistant-brandstofprijzen",
   "mguyard/hass-diagral",

--- a/integration
+++ b/integration
@@ -1388,6 +1388,7 @@
   "mdeweerd/zha-toolkit",
   "Megarushing/ha-ld2410",
   "meltingice1337/tedee_ble",
+  "memphi2/ha-dhe-connect",
   "merlijntishauser/unifi-network-maps-ha",
   "metbril/home-assistant-brandstofprijzen",
   "mguyard/hass-diagral",


### PR DESCRIPTION
Adds the UniFi Drive Home Assistant custom integration to the default HACS integration repositories.\n\nRepository: https://github.com/memphi2/ha-unifi-drive\nRelease: https://github.com/memphi2/ha-unifi-drive/releases/tag/v0.1.0\nValidation: HACS, Hassfest and repository checks are passing on main.