### PR TITLE
Add marisma-mhe/ha-victron-ess-control

### DIFF
--- a/integration
+++ b/integration
@@ -1358,6 +1358,7 @@
   "markvader/sonic",
   "marnixt/PowerClimate",
   "marotoweb/home-assistant-vacuum-viomise",
+  "marisma-mhe/ha-victron-ess-control",
   "marq24/ha-bosch-ebike-flow",
   "marq24/ha-evcc",
   "marq24/ha-fordconnect-query",


### PR DESCRIPTION
## Add marisma-mhe/ha-victron-ess-control

Victron Energy ESS automation suite for Home Assistant.

### Features
- Daytime feed-in power control (dynamic grid export cap via `AcPowerSetPoint`)
- Smart overnight charging (weather-aware SOC target from Solcast forecast)
- Storm mode (automatic battery protection before bad weather)
- Pre-midnight charging decision
- 9 automation blueprints installed automatically on setup

### Repository
- https://github.com/marisma-mhe/ha-victron-ess-control
- Category: integration
- HACS validation: passing (v0.3.0)