### PR TITLE
Add marisma-mhe/ha-victron-ess-control

### DIFF
--- a/integration
+++ b/integration
@@ -1348,6 +1348,7 @@
   "MarcoGos/kleenex_pollenradar",
   "marcolivierarsenault/moonraker-home-assistant",
   "MarcusTaz/ha_kia_hyundai_USA",
+  "marisma-mhe/ha-victron-ess-control",
   "mariusz-ostoja-swierczynski/tech-controllers",
   "markaggar/ha-media-index",
   "markaggar/Water-Monitor",


### PR DESCRIPTION
## Add marisma-mhe/ha-victron-ess-control

Victron Energy ESS automation suite for Home Assistant.

### Features
- Daytime feed-in power control (dynamic grid export cap via `AcPowerSetPoint`)
- Smart overnight charging (weather-aware SOC target from Solcast forecast)
- Storm mode (automatic battery protection before bad weather)
- Pre-midnight charging decision
- 9 automation blueprints installed automatically on setup

### Repository
- https://github.com/marisma-mhe/ha-victron-ess-control
- Category: integration
- HACS validation: passing (v0.3.2)