### PR TITLE
Adds new integration [ogerardin/ha-cfl-commute]

### DIFF
--- a/integration
+++ b/integration
@@ -1578,6 +1578,7 @@
   "nzrutman/hello_fairy_ble",
   "odya/hass-ina219-ups-hat",
   "ofalvai/home-assistant-candy",
+  "ogerardin/ha-cfl-commute",
   "ohheyrj/home-assistant-aws-codepipeline",
   "okkine/HA-Luna",
   "okkine/HA-Sol",


### PR DESCRIPTION
Adds CFL Commute - a Home Assistant integration for tracking Luxembourg CFL train commutes.

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
And consider adding a GitHub Action workflow to your repository: https://hacs.xyz/docs/publish/action
-->