### PR TITLE
add ogerardin/lovelace-cfl-commute-card

### DIFF
--- a/plugin
+++ b/plugin
@@ -404,6 +404,7 @@
   "nutteloost/todo-swipe-card",
   "Nyaran/myjdownloader-card",
   "ofekashery/vertical-stack-in-card",
+  "ogerardin/lovelace-cfl-commute-card",
   "omachala/ha-treemap-card",
   "othorg/rv-level-ha-lovelace-card",
   "OtisPresley/snmp-switch-manager-card",


### PR DESCRIPTION
## Description

Add ogerardin/lovelace-cfl-commute-card to the default HACS plugin list.

## Checklist

- [x] I have read the [contribution guidelines](https://hacs.xyz/docs/publish/include)
- [x] The repository has been added to the plugin file at the correct alphabetical position