### PR TITLE
Adds new integration [memphi2/ha-unifi-drive]

### DIFF
--- a/integration
+++ b/integration
@@ -1415,6 +1415,7 @@
   "mdeweerd/zha-toolkit",
   "Megarushing/ha-ld2410",
   "meltingice1337/tedee_ble",
+  "memphi2/ha-unifi-drive",
   "merlijntishauser/unifi-network-maps-ha",
   "metbril/home-assistant-brandstofprijzen",
   "mguyard/hass-diagral",


### PR DESCRIPTION
## Repository
https://github.com/memphi2/ha-unifi-drive

## Checklist
- [x] The repository is public.
- [x] The integration has a HACS-compliant repository structure.
- [x] The integration includes Home Assistant validation workflows.
- [x] The integration has a released version available.

Link to successful hassfest action (if integration): https://github.com/memphi2/ha-unifi-drive/actions/workflows/validate.yml

This recreates the previous submission from a clean, current branch.