### PR TITLE
Add botts7/ha-insights + botts7/ha-insights-card

### DIFF
--- a/integration
+++ b/integration
@@ -308,6 +308,7 @@
   "BottlecapDave/HomeAssistant-OctopusEnergy",
   "BottlecapDave/HomeAssistant-Smol",
   "BottlecapDave/HomeAssistant-TargetTimeframes",
+  "botts7/ha-insights",
   "Bouni/drkblutspende",
   "Bouni/luxtronik",
   "bramd/qstream-ha",

--- a/plugin
+++ b/plugin
@@ -43,6 +43,7 @@
   "Bobsilvio/calcio-live-card",
   "bokub/rgb-light-card",
   "bolkedebruin/erhv-lovelace",
+  "botts7/ha-insights-card",
   "bramkragten/swipe-card",
   "bramkragten/weather-card",
   "Brianfit/calvin-card-ha",


### PR DESCRIPTION
Adds two new community repos to the default catalog.

## Integration: `botts7/ha-insights`

[HA Insights](https://github.com/botts7/ha-insights) is a Home Assistant custom integration that audits existing automations + spots new patterns to automate.

- v1.5.43 tagged release
- `hacs.json` present + valid; `manifest.json` properly declares `version`, `iot_class`, `config_flow: true`
- Branding submitted in [home-assistant/brands#10317](https://github.com/home-assistant/brands/pull/10317)
- Privacy-first: zero outbound network by default; opt-in LLM (Anthropic / OpenAI / Google / Ollama) with audit log and pseudonymization

## Plugin: `botts7/ha-insights-card`

[HA Insights Card](https://github.com/botts7/ha-insights-card) is the companion Lovelace card + sidebar panel for the integration.

- v1.2.24 tagged release
- `hacs.json` present + valid
- Filter chips, group-by, side-by-side diff modal, audit findings UI

## Validation

- Both repos are public
- Both have a tagged release with version matching `manifest.json` / `package.json`
- Sorted alphabetically into the existing JSON arrays (integration: position 309 of 2338; plugin: position 44 of 597)