### PR TITLE
Add kayloehmann/ha-gardena-smart-system

### DIFF
--- a/integration
+++ b/integration
@@ -1155,6 +1155,7 @@
   "Kaptensanders/skolmat",
   "Kartax/home-assistant-binance",
   "KartoffelToby/better_thermostat",
+  "kayloehmann/ha-gardena-smart-system",
   "kattcrazy/tuya_unsupported_sensors",
   "kclif9/hassactronneo",
   "kcoffau/AUS_BOM_Space_Weather_Alert_System",


### PR DESCRIPTION
Adds the custom integration **kayloehmann/ha-gardena-smart-system**.

Required repository links:

- Repository: https://github.com/kayloehmann/ha-gardena-smart-system
- Latest release: https://github.com/kayloehmann/ha-gardena-smart-system/releases/latest
- CI action runs: https://github.com/kayloehmann/ha-gardena-smart-system/actions

---

This is a fresh PR replacing #6379, which @frenck closed-as-changes-requested ([review](https://github.com/hacs/default/pull/6379#pullrequestreview-4300954973)) because the integration used the `gardena_smart_system` domain — already taken in the default catalog by `py-smart-gardena/hass-gardena-smart-system`.

Resolution (all completed before this PR, per Frenck's instructions):

- Integration domain renamed `gardena_smart_system` → `gardena_smart_system_ng` (unique in both the HACS default catalog and HA core).
- Brand assets bundled locally at `custom_components/gardena_smart_system_ng/brand/` (HA 2026.3.0+ local brand mechanism; `home-assistant/brands` no longer accepts custom-integration icons).
- New release cut: [v2.0.2](https://github.com/kayloehmann/ha-gardena-smart-system/releases/tag/v2.0.2).

The repository's own HACS Action validation passes on the current default branch.