### PR TITLE
Add kayloehmann/ha-gardena-smart-system

### DIFF
--- a/integration
+++ b/integration
@@ -1156,6 +1156,7 @@
   "Kartax/home-assistant-binance",
   "KartoffelToby/better_thermostat",
   "kattcrazy/tuya_unsupported_sensors",
+  "kayloehmann/ha-gardena-smart-system",
   "kclif9/hassactronneo",
   "kcoffau/AUS_BOM_Space_Weather_Alert_System",
   "kcofoni/ha-netro-watering",


### PR DESCRIPTION
Adds the custom integration **kayloehmann/ha-gardena-smart-system**.

Required repository links:

- Repository: https://github.com/kayloehmann/ha-gardena-smart-system
- Latest release: https://github.com/kayloehmann/ha-gardena-smart-system/releases/latest
- CI action runs: https://github.com/kayloehmann/ha-gardena-smart-system/actions

---

Fresh PR replacing #6379 and #7676. #6379 was closed-as-changes-requested by @frenck ([review](https://github.com/hacs/default/pull/6379#pullrequestreview-4300954973)) because the integration used the `gardena_smart_system` domain, already taken in the default catalog by `py-smart-gardena/hass-gardena-smart-system`. #7676 was a re-submission that the validation bot auto-closed for PR-hygiene reasons (now fixed: single-file change, correctly sorted, 3 required links present).

Resolution (all completed, per Frenck's instructions):

- Integration domain renamed `gardena_smart_system` → `gardena_smart_system_ng` (unique in both the HACS default catalog and HA core).
- Brand assets bundled locally at `custom_components/gardena_smart_system_ng/brand/` (HA 2026.3.0+ local brand mechanism; `home-assistant/brands` no longer accepts custom-integration icons).
- New release: [v2.0.2](https://github.com/kayloehmann/ha-gardena-smart-system/releases/tag/v2.0.2).

This PR is a single-file, correctly sorted, one-line addition to `integration`. The repository's own HACS Action validation passes on its default branch.