### PR TITLE
Add botts7/ha-insights

### DIFF
--- a/integration
+++ b/integration
@@ -308,6 +308,7 @@
   "BottlecapDave/HomeAssistant-OctopusEnergy",
   "BottlecapDave/HomeAssistant-Smol",
   "BottlecapDave/HomeAssistant-TargetTimeframes",
+  "botts7/ha-insights",
   "Bouni/drkblutspende",
   "Bouni/luxtronik",
   "bramd/qstream-ha",


### PR DESCRIPTION
Adds [botts7/ha-insights](https://github.com/botts7/ha-insights) — a privacy-first home automation insights integration for Home Assistant.

Companion PR for the Lovelace card (botts7/ha-insights-card) is a separate single-file PR per the workflow.

- HACS validation: passing on the source repo
- `hacs.json` + `manifest.json` shipped
- Released versions on the repo's [Releases page](https://github.com/botts7/ha-insights/releases)
- Brand icons ship in `custom_components/ha_insights/brand/` per the new local-icon mechanism (the `home-assistant/brands` upstream PR was closed since the policy changed in HA 2026.3.0)