### PR TITLE
Add botts7/ha-insights-card

### DIFF
--- a/plugin
+++ b/plugin
@@ -43,6 +43,7 @@
   "Bobsilvio/calcio-live-card",
   "bokub/rgb-light-card",
   "bolkedebruin/erhv-lovelace",
+  "botts7/ha-insights-card",
   "bramkragten/swipe-card",
   "bramkragten/weather-card",
   "Brianfit/calvin-card-ha",


### PR DESCRIPTION
Adds [botts7/ha-insights-card](https://github.com/botts7/ha-insights-card) — the companion Lovelace card for the HA Insights integration.

Companion PR for the integration (botts7/ha-insights) is in [#7682](https://github.com/hacs/default/pull/7682).

- HACS validation: passing on the source repo
- `hacs.json` shipped
- Released versions on the repo's [Releases page](https://github.com/botts7/ha-insights-card/releases)