### PR TITLE
Add sbr-labs/tuya-radiators

### DIFF
--- a/integration
+++ b/integration
@@ -1897,6 +1897,7 @@
   "sayurin/hems_echonet_lite",
   "sbabcock23/hass-tryfi",
   "sbenodiz/ai_agent_ha",
+  "sbr-labs/tuya-radiators",
   "scaarup/aula",
   "schmidtfx/ekz-tariffs",
   "schmidtfx/koch-ag-hass",


### PR DESCRIPTION
## Add

`sbr-labs/tuya-radiators` — Home Assistant integration for Tuya / Smart Life WiFi panel-heater radiators (Ecostrad iQ Ceramic and FLS-118C OEM rebrands).

## Why

The official `tuya` integration and `xtend_tuya` both expose these radiators with generic `wk`-category entities, missing presets, and "unknown unit" warnings. This integration is a thin, focused adapter — it borrows the already-loaded `tuya_sharing.Manager` from either `tuya` or `xtend_tuya` at runtime (so it adds no second terminal to the user's Tuya account) and surfaces clean `climate` / `switch.power` / `switch.child_lock` / `number.calibration` / `select.window_detection` / `binary_sensor.online` entities per radiator.

## Checklist

- [x] Public GitHub repository: https://github.com/sbr-labs/tuya-radiators
- [x] `hacs.json` present
- [x] `manifest.json` valid (`domain`, `name`, `version`, `documentation`, `issue_tracker`, `codeowners`, `iot_class`, `integration_type`, `requirements`)
- [x] Brand assets included in `custom_components/tuya_radiators/brand/` (HA 2026.3+ Brands Proxy API)
- [x] `hacs/action` validation workflow in `.github/workflows/validate.yml`
- [x] Released as `v0.3.0-alpha`
- [x] README explains the prerequisite (`tuya` or `xtend_tuya` signed in)