### PR TITLE
Add czechbol/hass-mcp

### DIFF
--- a/integration
+++ b/integration
@@ -484,6 +484,7 @@
   "Cyr-ius/hass-heatzy",
   "Cyr-ius/hass-livebox-component",
   "cyr-ius/hass-reolink-thumbs",
+  "czechbol/hass-mcp",
   "D-N91/home-assistant-global-health-score",
   "d03n3rfr1tz3/hass-divoom",
   "DaanVervacke/hass-engie-be",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/czechbol/hass-mcp/releases/tag/v1.0.0>
Link to successful HACS action (without the `ignore` key): <https://github.com/czechbol/hass-mcp/actions/runs/25975359975/job/76354446973>
Link to successful hassfest action (if integration): <https://github.com/czechbol/hass-mcp/actions/runs/25975359975/job/76354446955>

Fully Featured Home Assistant MCP Server — HACS-installable HA custom integration mounting an MCP server inside HA with 39 generic meta-tools (states, services, registries, automations/scripts/scenes CRUD, blueprints, helpers, history, statistics, diagnostics, traces, lovelace, backups, HACS itself, auth tokens, webhooks, config flow, more).

- Repo: https://github.com/czechbol/hass-mcp
