### PR TITLE
Add GroupAlarm integration

### DIFF
--- a/integration
+++ b/integration
@@ -790,6 +790,7 @@
   "g4bri3lDev/munich_public_transport",
   "gabest11/homeassistant-brother_scanner",
   "gadgetchnnel/entities_calendar",
+  "GamingonTour1/ha-groupalarm-api",
   "ganhammar/hass-mcp-server",
   "ganhammar/hass-oidc-server",
   "garbled1/homeassistant_ecowitt",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [ X ] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [ X ] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ X  ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [ X ] The actions are passing without any disabled checks in my repository.
- [ X ] I've added a link to the action run on my repository below in the links section.
- [ X ] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: < https://github.com/GamingonTour1/ha-groupalarm-api/releases/tag/v1.0.0 >
Link to successful HACS action (without the `ignore` key): < https://github.com/GamingonTour1/ha-groupalarm-api/actions/runs/25991719494 >
Link to successful hassfest action (if integration): < https://github.com/GamingonTour1/ha-groupalarm-api/actions/runs/25991719504/job/76398972884 >

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->