### PR TITLE
Adds new plugin [skeefee/android-tv-remote-card]

### DIFF
--- a/plugin
+++ b/plugin
@@ -491,6 +491,7 @@
   "silentbil/silent-remotes-card",
   "silvanocerza/light-card-hue-feature",
   "silviokennecke/ha-public-transport-connection-card",
+  "skeefee/android-tv-remote-card",
   "skydarc/Venus-OS-Dashboard",
   "slipx06/sunsynk-power-flow-card",
   "snootched/cb-lcars",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [ ] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [ ] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [ ] The actions are passing without any disabled checks in my repository.
- [ ] I've added a link to the action run on my repository below in the links section.
- [ ] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: https://github.com/skeefee/android-tv-remote-card/releases/latest
Link to successful hassfest action (if integration): https://github.com/skeefee/android-tv-remote-card/actions

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->