### PR TITLE
Adds new integration [wizz666/homeassistant-ai-hub]

### DIFF
--- a/integration
+++ b/integration
@@ -2298,6 +2298,7 @@
   "wimpie70/ramses_extras",
   "wisedeer2022/ha_wisecloud_home",
   "wizmo2/zidoo-player",
+  "wizz666/homeassistant-ai-hub",
   "wizz666/homeassistant-smhi-brandrisk",
   "WJDDesigns/ultra-card-connect",
   "WLANThermo-nano/homeassistant",


### PR DESCRIPTION
## Checklist

- [x] I have read the [HACS publishing documentation](https://hacs.xyz/docs/publish/start)
- [x] The repository is public
- [x] The integration has a LICENSE file (MIT)
- [x] Releases are published
- [x] HACS action passes
- [x] Hassfest passes

## Links

- **Release**: https://github.com/wizz666/homeassistant-ai-hub/releases/tag/v1.0.1
- **HACS Action run**: https://github.com/wizz666/homeassistant-ai-hub/actions/runs/26007870724/job/76442635329
- **Hassfest run**: https://github.com/wizz666/homeassistant-ai-hub/actions/runs/26007870724/job/76442635333

## About

AI Hub is a centralized API key manager for Home Assistant. It stores provider keys (Groq, Anthropic, OpenAI, OpenRouter, Ollama) in the encrypted config entry and exposes them to other integrations via `hass.data["ai_hub"]` — no `input_text` entities, no frontend-visible secrets.

Previous PR #6414 was closed due to `input_text` key-syncing. Removed in v1.0.1: keys are now stored exclusively in the config entry.