### PR TITLE
Adds new plugin [maxfok/nimbus-weather-card]

### DIFF
--- a/plugin
+++ b/plugin
@@ -354,6 +354,7 @@
   "mathoudebine/homeassistant-browser-control-card",
   "mattieha/select-list-card",
   "mawinkler/astroweather-card",
+  "maxfok/nimbus-weather-card",
   "maxwroc/battery-state-card",
   "maxwroc/github-flexi-card",
   "maybetaken/ha-makeskyblue-mppt-card",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/).
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/maxfok/nimbus-weather-card/releases/tag/v2.3.3>
Link to successful HACS action (without the `ignore` key): <https://github.com/maxfok/nimbus-weather-card/actions/runs/26046100584>
Link to successful hassfest action (if integration): <N/A - dashboard plugin>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->