### PR TITLE
Add BassXT/buderus

### DIFF
--- a/integration
+++ b/integration
@@ -239,6 +239,7 @@
   "basilfx/homeassistant-biketrax",
   "basnijholt/adaptive-lighting",
   "basschipper/homeassistant-generic-hygrostat",
+  "BassXT/buderus",
   "bbckr/ha-synology-tasks",
   "bbr111/byd_hvs",
   "bcpearce/homeassistant-gtfs-realtime",


### PR DESCRIPTION
Adds the BassXT/buderus Home Assistant custom integration to the HACS default integration list.

Repository checklist:
- Public GitHub repository
- HACS custom repository validation passes
- Hassfest validation passes
- GitHub release v0.1.0 published
- Repository description, topics, issues, README, hacs.json, manifest metadata and brand icon are present