### PR TITLE
Add AldenDana/ha-zte-fibra

### DIFF
--- a/integration
+++ b/integration
@@ -64,6 +64,7 @@
   "AlbinLind/dawarich-home-assistant",
   "AlbrechtL/hass-padersprinter",
   "alceasan/ha-deepgram-tts",
+  "AldenDana/ha-zte-fibra",
   "aldweb/ha-lg-hombot",
   "aldweb/ha-openwrt-mqtt",
   "aldweb/ha-tasmota-mielhvac",


### PR DESCRIPTION
## Description

Adds [AldenDana/ha-zte-fibra](https://github.com/AldenDana/ha-zte-fibra) to the HACS default integration list.

## Integration details

- **Domain**: `zte_fibra_tracker`
- **Category**: Integration
- **IoT Class**: Local polling
- **Version**: v1.0.0

## What it does

Tracks devices connected to ZTE FIBRA6S routers (deployed by Orange/Jazztel in Spain and other ISPs) via the router's internal `hiddenData` API. Uses a 3-step SHA256 challenge-response authentication protocol.

Fills a gap in Home Assistant — no existing integration supports this specific router model. Inspired by and credits [juacas/zte_tracker](https://github.com/juacas/zte_tracker).

## Checklist

- [x] Brand assets included at \`custom_components/zte_fibra_tracker/brand/icon.png\`
- [x] Manifest key order: \`domain\`, \`name\`, then alphabetical
- [x] Config flow UI — no YAML required
- [x] \`v1.0.0\` release published