### PR TITLE
Adds new plugin [WeAreSmart-home/wesmart-garbage-card]

### DIFF
--- a/integration
+++ b/integration
@@ -2290,6 +2290,7 @@
   "wbyoung/movement",
   "wbyoung/smartcar",
   "wbyoung/watersmart",
+  "WeAreSmart-home/wesmart-garbage",
   "WeaveHubHQ/ha-tovala",
   "WeaveHubHQ/ha-u-by-moen",
   "WeaveHubHQ/robinhood_crypto",

--- a/plugin
+++ b/plugin
@@ -577,6 +577,7 @@
   "wassy92x/lovelace-digital-clock",
   "wassy92x/lovelace-entities-btn-group",
   "wassy92x/lovelace-ha-dashboard",
+  "WeAreSmart-home/wesmart-garbage-card",
   "weedpump/timeline-card",
   "weirdtangent/pulse-photo-card",
   "WickedGhost/avinor-flight-card",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: https://github.com/WeAreSmart-home/wesmart-garbage-card/releases/tag/1.2.1
Link to successful HACS action (without the `ignore` key): https://github.com/WeAreSmart-home/wesmart-garbage-card/actions/runs/26030171898
Link to successful hassfest action (if integration): N/A - plugin
