### PR TITLE
Add ha-dhe-connect-card

### DIFF
--- a/plugin
+++ b/plugin
@@ -358,6 +358,7 @@
   "maxwroc/github-flexi-card",
   "maybetaken/ha-makeskyblue-mppt-card",
   "MelleD/lovelace-expander-card",
+  "memphi2/ha-dhe-connect-card",
   "mentalilll/ha-vpd-chart",
   "micash545/hass-selfhst-icons",
   "michalowskil/flex-cells-card",


### PR DESCRIPTION
## Adds

- Add memphi2/ha-dhe-connect-card to HACS plugin repository listings.

## Validation

- Repository release is available as v0.3.1 with changelog and validation already in place.
- HACS compatibility checks and browser render smoke tests are passing in CI for the card repository.
