### PR TITLE
Add ha-unifi-drive-card

### DIFF
--- a/plugin
+++ b/plugin
@@ -357,6 +357,7 @@
   "maxwroc/battery-state-card",
   "maxwroc/github-flexi-card",
   "maybetaken/ha-makeskyblue-mppt-card",
+  "memphi2/ha-unifi-drive-card",
   "MelleD/lovelace-expander-card",
   "mentalilll/ha-vpd-chart",
   "micash545/hass-selfhst-icons",


### PR DESCRIPTION
Adds memphi2/ha-unifi-drive-card as a Lovelace custom card repository.