### PR TITLE
Add Nino6689/hass-anycubic_cloud

### DIFF
--- a/integration
+++ b/integration
@@ -1598,6 +1598,7 @@
   "nimroddolev/chime_tts",
   "NinDTendo/homeassistant_gradual_volume_control",
   "NinDTendo/tobi",
+  "Nino6689/hass-anycubic_cloud",
   "NirBY/ha-mashov",
   "nitaybz/optimistic_feedback",
   "njobrien1006/hass_traeger",


### PR DESCRIPTION
## What

Community fork of [WaresWichall/hass-anycubic_cloud](https://github.com/WaresWichall/hass-anycubic_cloud) v0.2.2, patched for compatibility with current Home Assistant Core (paho-mqtt 2.x / Python 3.13+).

Upstream is excellent but the maintainer moved on to another printer brand in late 2024 ([their note](https://github.com/WaresWichall/hass-anycubic_cloud/issues/33)), so stock v0.2.2 now fails with `HTTP 500 "Server got itself in trouble"` on current HA. This fork ships two minimal patches that make it work again.

## Why this isn't a PR upstream

The upstream repo hasn't merged anything since 2024-12-01 and the maintainer explicitly stepped back. I'd be very happy to retire this fork if/when upstream becomes active again.

## Validation

- HACS Validation ✅ (passing on main + tag — see [latest run](https://github.com/Nino6689/hass-anycubic_cloud/actions/workflows/hacs.yml))
- Hassfest ✅ (passing on main + tag — fixed three pre-existing strict-validation issues in services.yaml / strings.json / translations/en.json)
- LICENSE: GPL-3.0 (matches upstream)
- Tagged release: [v0.2.2-nb2](https://github.com/Nino6689/hass-anycubic_cloud/releases/tag/v0.2.2-nb2)
- Brand already exists at [home-assistant/brands](https://github.com/home-assistant/brands/tree/master/custom_integrations/anycubic_cloud)

## What's different from upstream v0.2.2

| Patch | File | Why |
|---|---|---|
| `paho-mqtt==1.6.1` → `paho-mqtt>=1.6.1` | `manifest.json` | HA Core ships paho-mqtt 2.1.0; strict pin failed to install on Python 3.13/3.14 → config flow crashed |
| `Client(client_id=…)` → `Client(CallbackAPIVersion.VERSION1, …)` | `anycubic_cloud_api/api/mqtt.py` | paho-mqtt 2.x requires `CallbackAPIVersion` as first arg; `VERSION1` keeps existing callback signatures so nothing else changes. Falls back to 1.x gracefully |
| File-selector `accept` value added | `services.yaml` | Hassfest now requires it |
| URLs removed from strings | `strings.json`, `translations/en.json` | Hassfest "string should not contain URLs" |
| Added macOS slicer-token path to README | `README.md` | Upstream only documented Windows |