### PR TITLE
Adds new integration [BassXT/buderus]

### DIFF
--- a/integration
+++ b/integration
@@ -240,6 +240,7 @@
   "basilfx/homeassistant-biketrax",
   "basnijholt/adaptive-lighting",
   "basschipper/homeassistant-generic-hygrostat",
+  "BassXT/buderus",
   "bbckr/ha-synology-tasks",
   "bbr111/byd_hvs",
   "bcpearce/homeassistant-gtfs-realtime",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/BassXT/buderus/releases/tag/v0.1.2>
Link to successful HACS action (without the `ignore` key): <https://github.com/BassXT/buderus/actions/runs/27780165134/job/82202605009>
Link to successful hassfest action (if integration): <https://github.com/BassXT/buderus/actions/runs/27780165134/job/82202604963>