### PR TITLE
Add ha-dhe-connect-card

### DIFF
--- a/plugin
+++ b/plugin
@@ -358,6 +358,7 @@
   "maxwroc/github-flexi-card",
   "maybetaken/ha-makeskyblue-mppt-card",
   "MelleD/lovelace-expander-card",
+  "memphi2/ha-dhe-connect-card",
   "mentalilll/ha-vpd-chart",
   "micash545/hass-selfhst-icons",
   "michalowskil/flex-cells-card",


### PR DESCRIPTION
## Adds\n\n- Add memphi2/ha-dhe-connect-card to HACS plugin repository listings.\n\n## Required links\n\n- Repository latest release: https://github.com/memphi2/ha-dhe-connect-card/releases/tag/v0.3.1\n- CI action runs: https://github.com/memphi2/ha-dhe-connect-card/actions/runs/26063339804\n\n## Validation\n\n- HACS compatibility checks and browser render smoke tests are passing in CI for the repository.