### PR TITLE
Add genericJE/ha-heating-schedule

### DIFF
--- a/integration
+++ b/integration
@@ -784,6 +784,7 @@
   "geertmeersman/robonect",
   "geertmeersman/yoin",
   "geertmeersman/youfone",
+  "genericJE/ha-heating-schedule",
   "gensyn/ssh_command",
   "gensyn/task_tracker",
   "gentslava/elektronny-gorod",


### PR DESCRIPTION
## Integration

Repo: https://github.com/genericJE/ha-heating-schedule
Release: https://github.com/genericJE/ha-heating-schedule/releases/tag/v0.1.0

## What it is

A per-room heating schedule for Home Assistant. Each room gets a Lovelace card with a 24h shared track holding 1–4 dual-handle heating windows; a Python schedule controller writes `set_temperature` against any climate that accepts it (Better Thermostat, generic_thermostat, MQTT HVAC, native Zigbee TRV climates).

## Pre-flight checks

- Public repo with v0.1.0 GitHub release
- `manifest.json` has domain, name, version, codeowners, documentation, issue_tracker, iot_class (`local_polling`), config_flow
- `hacs.json` valid (`name`, `homeassistant: 2024.4.0`, `render_readme: true`)
- README + CHANGELOG present
- MIT licensed
- Brand icons served from `custom_components/heating_schedule/brand/` (HA 2026.3 mechanism, since brands-repo PRs for custom integrations are now auto-closed)
- GitHub Actions: hassfest + hacs/action + pytest all passing on `main`
- 5 tests covering config-flow happy path + setup/unload lifecycle