### PR TITLE
Adds new integration [Shaffer-Softworks/Openobserve]

### DIFF
--- a/integration
+++ b/integration
@@ -1987,6 +1987,7 @@
   "Sha-Darim/brandriskute",
   "shadow578/homeassistant_sma-ennexos",
   "Shaffer-Softworks/Android-Management",
+  "Shaffer-Softworks/Openobserve",
   "Shaffer-Softworks/hyperhdr-ha",
   "shaiu/technicolor",
   "sHedC/homeassistant-leakbot",


### PR DESCRIPTION
## Summary

Adds [Shaffer-Softworks/Openobserve](https://github.com/Shaffer-Softworks/Openobserve) to the default integration list.

Home Assistant custom integration that forwards core logs and bus events to OpenObserve (`/_json` batching, config flow, diagnostic sensors).

## Repository checks

- hassfest + HACS validation workflow on the integration repo
- `hacs.json`, `info.md`, brand assets under `custom_components/openobserve/brand/`
- GitHub releases published (v0.2.0+)
- Repo description and topics configured

## Submitter

Repository owner / Shaffer-Softworks org — PR from personal fork `sickkick/HACS` per HACS guidelines.


Made with [Cursor](https://cursor.com)