### PR TITLE
Add michaelggr/ha-printer-analytics integration

### DIFF
--- a/integration
+++ b/integration
@@ -1463,6 +1463,7 @@
   "mholzi/beatify",
   "Michael-Civitillo/trimlight-edge-ha",
   "michaeldwan/ha-cloudflare-ai-gateway",
+  "michaelggr/ha-printer-analytics",
   "michaellunzer/Home-Assistant-Custom-Component-Fortnite",
   "MichaelPihlblad/flowerhub_homeassistant_integration",
   "MichelFR/ha_ghostfolio",


### PR DESCRIPTION
## Add Printer Analytics integration

### Repository
https://github.com/michaelggr/ha-printer-analytics

### Description
Printer Analytics is a Home Assistant custom integration for monitoring and analyzing 3D printers (BambuLab P2S, A1 Mini, etc.).

### Features
- Real-time print monitoring with progress, filament, and chamber temp
- Server-side pagination for 5000+ history records via WebSocket
- Server-side filtering (status, color, date range, search, combined)
- Multi-printer data merge
- Color and filament type usage charts
- Print activity heatmap
- Filament success rate statistics
- Failure stage distribution analysis
- CSV export

### Checklist
- [x] Public GitHub repository
- [x] Repository description set
- [x] Valid hacs.json in root
- [x] Valid README.md
- [x] Valid LICENSE (MIT)
- [x] Valid manifest.json with all required keys
- [x] GitHub release (v5.11.0)
- [x] icon.svg in integration directory
- [x] config_flow enabled