### PR TITLE
Adds new integration [CRZTFR/bindicator] 

### DIFF
--- a/integration
+++ b/integration
@@ -444,6 +444,7 @@
   "Crazy-Duck/home-assistant-fiftyfive",
   "CreasolTech/home-assistant-creasol-dombus",
   "cryptotomte/ev-load-balancer",
+  "CRZTFR/bindicator-hacs",
   "CubicPill/china_southern_power_grid_stat",
   "CumpsD/home-assistant-leo-ntp",
   "Currency-One/walutomat-ha",


### PR DESCRIPTION
- [X] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [X] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [X] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [X] The actions are passing without any disabled checks in my repository.
- [X] I've added a link to the action run on my repository below in the links section.
- [X] I've created a new release of the repository after the validation actions were run successfully.

## Links
Link to current release: <https://github.com/CRZTFR/bindicator/releases/tag/v0.1.5>
Link to successful HACS action (without the `ignore` key): <https://github.com/CRZTFR/bindicator/actions/runs/26207049257/job/77109058036>
Link to successful hassfest action (if integration): <https://github.com/CRZTFR/bindicator/actions/runs/26207049257/job/77109058019>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->