### PR TITLE
Add Briochorama/tesla-smart-routes

### DIFF
--- a/integration
+++ b/integration
@@ -334,6 +334,7 @@
   "brianegge/homeassistant-magewell",
   "brianegge/homeassistant-obs-studio",
   "briis/weatherflow_forecast",
+  "Briochorama/tesla-smart-routes",
   "brott8/ha-crowdsec",
   "Brunas/meteo_lt_by_brunas",
   "bscholer/home-assistant-comma-ai",


### PR DESCRIPTION
## tesla-smart-routes

Send multi-stop navigation routes to Tesla vehicles from Home Assistant with one button press, scheduled via automations.

- **Repository:** https://github.com/Briochorama/tesla-smart-routes
- **Category:** integration
- **HA version:** 2026.3.2+
- **HACS validation:** passing ✅
- **Hassfest validation:** passing ✅