### PR TITLE
Add Matbe34/veoliaHA

### DIFF
--- a/integration
+++ b/integration
@@ -965,6 +965,7 @@
   "Master13011/Mailcow-HA",
   "Master13011/vacances-scolaire-HA",
   "Mat931/digitalstrom-homeassistant",
+  "Matbe34/veoliaHA",
   "MateoGreil/homeassistant-comwatt",
   "matfroh/abl_emh1_modbus",
   "matfroh/sax_battery_ha",


### PR DESCRIPTION
## What

Adds [`Matbe34/veoliaHA`](https://github.com/Matbe34/veoliaHA) — **Veolia Water** — to the integration list.

## Description

Veolia / Sorea water consumption tracker. Authenticates against the customer
portal (`sorea.veolia.cat` by default; configurable for other Liferay-based
Veolia portals), parses the embedded JSON, and exposes ~20 sensors per
contract: meter index, period / daily / monthly consumption, rolling 7-day
average, month-to-date, last-invoice info, peak-flow telemetry, possible-leak
indicator, sync diagnostics. Imports 90 days of daily and 24 months of
monthly history as long-term statistics on first cycle.

Native config flow + options flow. No MQTT broker required.

## Checklist

- [x] Public repository with description and topics
- [x] `hacs.json` with `name`, `homeassistant` minimum version
- [x] `manifest.json` with `domain`, `name`, `version`, `documentation`,
      `issue_tracker`, `codeowners`, `iot_class`, `config_flow`, sorted keys
- [x] Tagged release ([`v1.0.0`](https://github.com/Matbe34/veoliaHA/releases/tag/v1.0.0))
- [x] HACS + Hassfest workflows passing on master
- [x] LICENSE (MIT)
- [x] README and CHANGELOG
- [x] Local brand assets (icon.png 256x256, icon@2x.png 512x512) — HA brands PR to follow