### PR TITLE
Add zqs1qiwan/ha-mihomo-ctrl integration

### DIFF
--- a/integration
+++ b/integration
@@ -2405,6 +2405,7 @@
   "zigul/HomeAssistant-CEZdistribuce",
   "ziogref/TAS-Fuel-HA-Intergration",
   "zollak/homeassistant-syslog-receiver",
+  "zqs1qiwan/ha-mihomo-ctrl",
   "zubir2k/homeassistant-dailyhadith",
   "zubir2k/homeassistant-esolatgps",
   "zubir2k/homeassistant-esolattakwim",


### PR DESCRIPTION
Hi,

Please add `zqs1qiwan/ha-mihomo-ctrl` to the default HACS store.

It is a high-performance Home Assistant custom integration to monitor and control an external Mihomo (Clash) Core with built-in OpenClash physical switch support.

Changes in this submission:
- `manifest.json` keys are fully sorted per Hassfest standards.
- A standard `hacs.json` configuration is in place.
- Initial release `1.0.0` has been published on GitHub.
- Integration list is correctly sorted case-insensitively (`str.casefold`).

Thank you!