### PR TITLE
Add onedrive-backup-machine-integration entry

### DIFF
--- a/integration
+++ b/integration
@@ -210,6 +210,7 @@
   "atxbyea/samsungrac",
   "atymic/project_three_zero_ha",
   "audiconnect/audi_connect_ha",
+  "augleao/onedrive-backup-machine-integration",
   "augustas2/eldes",
   "aunefyren/bluesound_alt",
   "avishorp/sync_group",


### PR DESCRIPTION
This repository provides a Home Assistant custom integration to handle automated backups to Microsoft OneDrive.

Note to reviewers: This is a fresh submission following the closure of my previous PR (#6310). I have created a brand new, clean repository to address all the issues raised by @frenck:

Security: The leaked Stripe credential was immediately revoked on Stripe's dashboard, and the repository was completely recreated from scratch to ensure the code is entirely gone from the git history.

Architecture: I have completely removed the Supervisor Add-on files from this repository. This repo now strictly contains the custom_components integration for HACS. The Add-on will be distributed separately via the HA Supervisor store.

Release: A proper GitHub Release has been created and linked.

Cache files: All pycache directories were removed and added to .gitignore.

Assets: The placeholder files for icon.png and logo.png were replaced with real images.

Requirements: The minimum Home Assistant version in hacs.json was updated to a recent, realistic version.

Thank you for your time and the feedback on the previous submission!

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: [COLE_O_LINK_DA_SUA_RELEASE_AQUI]
Link to successful HACS action (without the `ignore` key): https://github.com/augleao/onedrive-backup-machine-integration/actions/runs/26247024833
Link to successful hassfest action (if integration): https://github.com/augleao/onedrive-backup-machine-integration/actions/runs/26247024839

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->