### PR TITLE
Add MUbeira0/vigobus-integration to default integration repositories

### DIFF
--- a/integration
+++ b/integration
@@ -1547,6 +1547,7 @@
   "MTrab/landroid_cloud",
   "MTrab/stromligning",
   "MTrab/webastoconnect",
+  "MUbeira0/vigobus-integration",
   "mudape/iphonedetect",
   "muhlba91/onyx-homeassistant-integration",
   "mukaschultze/ha-must-inverter",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/MUbeira0/vigobus-integration/releases/tag/v2.0.11>
Link to successful HACS action (without the ignore key): <https://github.com/MUbeira0/vigobus-integration/actions/runs/26318967814>
Link to successful hassfest action (if integration): <https://github.com/MUbeira0/vigobus-integration/actions/runs/26318968310>