### PR TITLE
Add MUbeira0/lovelace-vigobus-card to default plugin repositories

### DIFF
--- a/plugin
+++ b/plugin
@@ -377,6 +377,7 @@
   "MrSjodin/HomeAssistant_Trafiklab_TravelSearch_Card",
   "mtheli/gardena-smart-system-card",
   "mtheli/toothbrush-card",
+  "MUbeira0/lovelace-vigobus-card",
   "mutilator/homeassistant-solar-panel-preview",
   "nathan-gs/ha-map-card",
   "nathanmarlor/foxess_modbus_charge_period_card",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository. (N/A: this is a dashboard card plugin)
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/MUbeira0/lovelace-vigobus-card/releases/tag/v2.0.4>
Link to successful HACS action (without the ignore key): <https://github.com/MUbeira0/lovelace-vigobus-card/actions/runs/26318858749>
Link to successful hassfest action (if integration): <N/A - dashboard card repository>