### PR TITLE
Add BeardedTech0o/ha-luxcloud

### DIFF
--- a/integration
+++ b/integration
@@ -247,6 +247,7 @@
   "bbr111/byd_hvs",
   "bcpearce/homeassistant-gtfs-realtime",
   "bdunn44/hass-jellyfish-lighting",
+  "BeardedTech0o/ha-luxcloud",
   "Beat-YT/hydropeak-ha",
   "Beat2er/homeassistant-trmnl-battery",
   "Bebbssos/ha-defa-power",


### PR DESCRIPTION
## BeardedTech0o/ha-luxcloud

### Description
Home Assistant integration for LuxPower hybrid solar inverters via the LuxPower cloud API.

Provides real-time monitoring of solar generation, battery state of charge, grid import/export, and home consumption. Supports EU and Global server regions.

### Checklist
- [x] Integration has a unique domain: `luxcloud`
- [x] Valid `hacs.json` present
- [x] Valid `manifest.json` present (domain, codeowners, version, iot_class, config_flow)
- [x] At least one release published (v1.0.0)
- [x] HACS validation passes
- [x] hassfest validation passes
- [x] Repository is public
- [x] `README.md` with installation instructions present
