### PR TITLE
Update plugin - weather-radar-card repo loction

### DIFF
--- a/plugin
+++ b/plugin
@@ -335,7 +335,7 @@
   "maglerod/andy-stats-clock",
   "maglerod/andy-temperature-card",
   "Makin-Things/bom-radar-card",
-  "Makin-Things/platinum-weather-card"
+  "Makin-Things/platinum-weather-card",
   "malcolmrigg/wizard-clock-card",
   "mampfes/ha-knx-uf-iconset",
   "ManfredTremmel/lovelace-heat-pump-card",

--- a/plugin
+++ b/plugin
@@ -260,6 +260,7 @@
   "JonasDoebertin/ha-today-card",
   "jonkristian/entur-card",
   "joseluis9595/lovelace-navbar-card",
+  "jpettitt/weather-radar-card",
   "jtbgroup/kodi-playlist-card",
   "jtbgroup/kodi-search-card",
   "jtubb/generator-hmi-card",
@@ -334,8 +335,7 @@
   "maglerod/andy-stats-clock",
   "maglerod/andy-temperature-card",
   "Makin-Things/bom-radar-card",
-  "Makin-Things/platinum-weather-card",
-  "Makin-Things/weather-radar-card",
+  "Makin-Things/platinum-weather-card"
   "malcolmrigg/wizard-clock-card",
   "mampfes/ha-knx-uf-iconset",
   "ManfredTremmel/lovelace-heat-pump-card",


### PR DESCRIPTION
Repo ownership transferred from Makin-Things to jpettitt, github is redirecting this is housekeeping  PR to point to the right place directly.

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: https://github.com/jpettitt/weather-radar-card/releases/tag/v3.6.2
Link to successful HACS action (without the `ignore` key):  https://github.com/jpettitt/weather-radar-card/actions/runs/26322324000
Link to successful hassfest action (if integration):  <>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->
                                                                              