### PR TITLE
Adds new integration [NirushaD/BOMWeather]

### DIFF
--- a/integration
+++ b/integration
@@ -1626,6 +1626,7 @@
   "NinDTendo/homeassistant_gradual_volume_control",
   "NinDTendo/tobi",
   "NirBY/ha-mashov",
+  "NirushaD/BOMWeather"
   "nitaybz/optimistic_feedback",
   "njobrien1006/hass_traeger",
   "nkvoll/home-assistant-qsys-qrc",
@@ -2416,4 +2417,4 @@
   "zulufoxtrot/ha-zyxel",
   "zupancicmarko/JellyHA",
   "Zwer2k/ha-pca301"
-]
+  ]

--- a/integration
+++ b/integration
@@ -1626,7 +1626,7 @@
   "NinDTendo/homeassistant_gradual_volume_control",
   "NinDTendo/tobi",
   "NirBY/ha-mashov",
-  "NirushaD/BOMWeather"
+  "NirushaD/BOMWeather",
   "nitaybz/optimistic_feedback",
   "njobrien1006/hass_traeger",
   "nkvoll/home-assistant-qsys-qrc",


### PR DESCRIPTION
Add BOM Weather integration for Australia

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/NirushaD/BOMWeather/releases/tag/v0.2.1>
Link to successful HACS action (without the `ignore` key): <https://github.com/NirushaD/BOMWeather/actions/workflows/hacs.yml>
Link to successful hassfest action (if integration): <https://github.com/NirushaD/BOMWeather/actions/workflows/hassfest.yml>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->