### PR TITLE
Add MarcinG81/SunSynk_HA_Integration

### DIFF
--- a/integration
+++ b/integration
@@ -1394,6 +1394,7 @@
   "Manschitz/brunner-eas-integration",
   "MarcelWepper/Inverter-Controller",
   "marcelwestrahome/home-assistant-niu-component",
+  "MarcinG81/SunSynk_HA_Integration",
   "marcoboers/home-assistant-quatt",
   "MarcoGos/davis_vantage",
   "MarcoGos/kleenex_pollenradar",


### PR DESCRIPTION
## MarcinG81/SunSynk_HA_Integration

### Description

Native Home Assistant integration for monitoring and controlling **Sunsynk** and **Deye** hybrid solar inverters via the Sunsynk cloud API.

The Sunsynk Wi-Fi dongle has no local API — it communicates exclusively with the Sunsynk cloud, so this integration uses cloud polling.

### Features

- Full Config Flow UI — no YAML required
- ~60 sensor entities per inverter (PV, battery, grid, load, temperatures)
- Dynamic discovery of MPPT strings, 3-phase data and parallel battery packs
- ~30 writable number entities (battery thresholds, charge/discharge current, time slots)
- ~25 writable switch entities (sell enable, time slots, active days, generator)
- Multi-inverter support (multiple serials in one config entry)
- Solar Forecast via Open-Meteo (free, no API key) — predicted kWh yield, cloud cover, precipitation, GHI/DNI
- Auto-generated Lovelace dashboard with bundled Sunsynk Power Flow Card
- Supports both Sunsynk (`api.sunsynk.net`) and Deye/Inteless (`pv.inteless.com`)

### Checklist

- [x] `hacs.json` present
- [x] `manifest.json` with all required fields (`domain`, `version`, `iot_class`, `codeowners`, `documentation`, `issue_tracker`, `config_flow`)
- [x] GitHub release with matching version tag (`v1.5.0`)
- [x] HACS validation workflow (hacs/action)
- [x] Hassfest validation workflow
- [x] `README.md` present
- [x] Public repository
