### PR TITLE
Add monxas/justeat-tracker

### DIFF
--- a/plugin
+++ b/plugin
@@ -372,6 +372,7 @@
   "Mofeywalker/openmensa-lovelace-card",
   "molant/device-monitor-card",
   "mon3y78/Lovelace-Bubble-room",
+  "monxas/justeat-tracker",
   "MrBartusek/MeteoalarmCard",
   "mrded/ha-air-comfort-card",
   "MrSjodin/HomeAssistant_Trafiklab_TravelSearch_Card",


### PR DESCRIPTION
Adding [monxas/justeat-tracker](https://github.com/monxas/justeat-tracker) as a Lovelace plugin.

## What it does

`justeat-card.js` is a Lovelace custom card that visualises the `sensor.justeat_tracking` entity pushed by the companion Docker tracker — order status, ETA, progress bar, history timeline, with auto-hide when no order is active.

## Compliance checklist

- ✅ Single bundled JS file at repo root (`justeat-card.js`, ~12KB, no build step, no deps)
- ✅ `hacs.json` at root with `filename` and `homeassistant` fields
- ✅ MIT licensed
- ✅ README with installation + configuration documented
- ✅ Card is functional (verified end-to-end with the companion Docker container)
- ✅ Registers with `window.customCards` API for the HA card picker
- ✅ Repo has description + topics for discoverability