### PR TITLE
Add Energy-Waterfall-Card to plugin list

### DIFF
--- a/plugin
+++ b/plugin
@@ -94,6 +94,7 @@
   "DanChaltiel/heatzy-pilote-card",
   "danimart1991/pvpc-hourly-pricing-card",
   "DanteWinters/lux-power-distribution-card",
+  "DocBig/Energy-Waterfall-Card",
   "daredoes/default-dashboard",
   "daredoes/linked-lovelace-ui",
   "davet2001/energy-sankey",


### PR DESCRIPTION
Add Energy Waterfall Card

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/DocBig/Energy-Waterfall-Card/releases/tag/v1.0.0>
Link to successful HACS action (without the `ignore` key): <https://github.com/DocBig/Energy-Waterfall-Card/actions/runs/26336268089>
Link to successful hassfest action (if integration): <>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->