### PR TITLE
Add totalcodingpl/ha-neoglow-icons

### DIFF
--- a/plugin
+++ b/plugin
@@ -554,6 +554,7 @@
   "tomasrudh/analogclock",
   "Tomer27cz/energy-line-gauge",
   "tomvanswam/compass-card",
+  "totalcodingpl/ha-neoglow-icons",
   "totaldebug/atomic-calendar-revive",
   "Tra1n84/compact-lawn-mower-card",
   "troinine/ha-weather-forecast-card",


### PR DESCRIPTION
Hello! Please add the NeoGlow Icons plugin to HACS default database. It is a custom iconset featuring fully animated and multi-color gradient icons for Home Assistant. The repository has been verified to be fully compatible with HACS, and has the latest v1.0.3 release with correct manifest files.