### PR TITLE
Adds new integration [memphi2/ha-dhe-connect]

### DIFF
--- a/integration
+++ b/integration
@@ -1465,6 +1465,7 @@
   "Megarushing/ha-ld2410",
   "mejmo/hass-flybox-component",
   "meltingice1337/tedee_ble",
+  "memphi2/ha-dhe-connect",
   "merlijntishauser/unifi-network-maps-ha",
   "metbril/home-assistant-brandstofprijzen",
   "mguyard/hass-diagral",


### PR DESCRIPTION
Supersedes older submission.\n\n- Repository: https://github.com/memphi2/ha-dhe-connect\n- Latest release: v1.8.3\n- HACS/manifest/release checks pass in source repo.