### PR TITLE
Add wleonhardt/ha-ipp-print

### DIFF
--- a/integration
+++ b/integration
@@ -2360,6 +2360,7 @@
   "WJDDesigns/ultra-card-connect",
   "WLANThermo-nano/homeassistant",
   "wlcrs/huawei_solar",
+  "wleonhardt/ha-ipp-print",
   "wolffshots/hass-audiobookshelf",
   "Woulve/phonetrack",
   "Wouter0100/homeassistant-nanokvm",


### PR DESCRIPTION
Adds the **IPP Print** custom integration.

**Repo**: https://github.com/wleonhardt/ha-ipp-print
**Release**: https://github.com/wleonhardt/ha-ipp-print/releases/tag/v0.1.0

Home Assistant custom integration that submits PDFs directly to any IPP-capable network printer (no CUPS, no filesystem queue) and exposes per-job state via `sensor.printer_current_job` and bus events. Ships with a Lovelace upload card. Config-flow based, no YAML required.

Validation:
- ✅ `hassfest` passes
- ✅ `hacs/action` validation passes
- ✅ Brand assets included in `custom_components/ipp_print/brand/`
- ✅ Tagged release v0.1.0
- ✅ MIT licensed