### PR TITLE
Add Solst1cee/HA-PC-control-card

### DIFF
--- a/plugin
+++ b/plugin
@@ -503,6 +503,7 @@
   "slipx06/sunsynk-power-flow-card",
   "snootched/cb-lcars",
   "soestin/hass_periodic_card_reload",
+  "Solst1cee/HA-PC-control-card",
   "sonite/particle-cloud-card",
   "sopelj/lovelace-kanji-clock-card",
   "starwarsfan/qclock-card",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: https://github.com/Solst1cee/HA-PC-control-card/releases/latest
Link to successful HACS action (without the `ignore` key): https://github.com/Solst1cee/HA-PC-control-card/actions/runs/26360700454
Link to successful hassfest action (if integration): N/A — this is a plugin, not an integration