### PR TITLE
Add drake69/NeverDry

### DIFF
--- a/integration
+++ b/integration
@@ -636,6 +636,7 @@
   "doubleukay/godaikin-ha",
   "doudz/homeassistant-myjdownloader",
   "dphae/bsh",
+  "drake69/NeverDry",
   "drakhart/ha-super-soco-custom",
   "drc38/Fronius_solarweb",
   "Dregi56/digital_pendulum",


### PR DESCRIPTION
## Integration name
NeverDry — Smart irrigation for Home Assistant

## Repository
https://github.com/drake69/NeverDry

## Description
NeverDry tracks a real-time soil water deficit (FAO-56 simplified ET model) per zone and irrigates each zone only when needed. Supports per-zone crop coefficients (K<sub>c</sub>) across ten plant families with seasonal variation, three delivery modes (estimated flow, flow meter, volume preset on smart valves), reactive and scheduled automation, multi-zone sequential cycles with emergency stop, and a manual-valve detector that updates the deficit when the user opens the valve from the physical button or Zigbee app.

## Required checks
- [x] Repository has a release: latest is [v0.6.0](https://github.com/drake69/NeverDry/releases/tag/v0.6.0)
- [x] `manifest.json` with `domain`, `name`, `documentation`, `issue_tracker`, `codeowners`, `version`, `config_flow`, `iot_class`
- [x] `hacs.json` at repo root
- [x] LICENSE (MIT)
- [x] README.md and info.md with description, install, configuration
- [x] HACS Validation workflow passing
- [x] Hassfest workflow passing
- [x] Branding (`brand/icon.png`, `brand/icon.svg`, `brand/logo.png`)

## Notes
This supersedes #6897 which was auto-closed because it was opened from the fork's `master` branch.