### PR TITLE
Add hudsonbrendon/ha-gbs-control

### DIFF
--- a/integration
+++ b/integration
@@ -967,6 +967,7 @@
   "hstrohmaier/ha_comfoconnectpro",
   "htlemos/keeplink-homeassistant",
   "hudsonbrendon/HA-drivvo",
+  "hudsonbrendon/ha-gbs-control",
   "hudsonbrendon/HA-solar-plus-intelbras",
   "hudsonbrendon/ha_epic_games",
   "hugobloem/stateful_scenes",


### PR DESCRIPTION
Adds [hudsonbrendon/ha-gbs-control](https://github.com/hudsonbrendon/ha-gbs-control) — a Home Assistant integration for the [GBS Control](https://github.com/ramapcsx2/gbs-control) video upscaler (GBS-8200/8220, ESP firmware).

- Local push integration (WebSocket state + HTTP commands); zeroconf discovery.
- Passes HACS validation (hassfest + hacs/action) and ships a local brand icon.
- Released: v0.1.0.