### PR TITLE
Adds new integration [Shaffer-Softworks/Tripp-light]

### DIFF
--- a/integration
+++ b/integration
@@ -2371,6 +2371,7 @@
   "Shaffer-Softworks/GlobalCache",
   "Shaffer-Softworks/hyperhdr-ha",
   "Shaffer-Softworks/Openobserve",
+  "Shaffer-Softworks/Tripp-light",
   "shaiu/technicolor",
   "sHedC/homeassistant-leakbot",
   "sHedC/homeassistant-mastertherm",


### PR DESCRIPTION
### Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://github.com/hacs/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://github.com/home-assistant/actions/blob/master/hassfest/action.yml) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

### Note for reviewers: Brand images (Home Assistant 2026.3+)

Home Assistant no longer accepts PRs for new **custom** integrations in home-assistant/brands. As of **Home Assistant 2026.3**, custom integrations are expected to ship their own brand assets in-repo.

This integration does that: **`custom_components/tripp_lite_srcool/brand/`** contains `icon.png`, `icon@2x.png`, `logo.png`, and `logo@2x.png`. HA 2026.3+ uses these at runtime (Settings → Integrations, device UI, etc.). The integration is not listed in `home-assistant/brands`; brand assets are local to the repo per current HA guidance.

### Integration summary

Home Assistant custom integration for the Tripp Lite **SRCOOLNET** SNMP Webcard Interface Module (Remote Cooling Management for SRCOOL12K / SRXCOOL12K) over Telnet. Provides climate control (setpoint, fan, power) and status sensors.

### Links

- Link to current release: https://github.com/Shaffer-Softworks/Tripp-light/releases/tag/v1.0.1
- Link to successful CI run (HACS + hassfest): https://github.com/Shaffer-Softworks/Tripp-light/actions/runs/30677105405

---

_Repository: Shaffer-Softworks/Tripp-light_