### PR TITLE
Add buchuman/hisense_vrf

### DIFF
--- a/integration
+++ b/integration
@@ -337,6 +337,7 @@
   "brott8/ha-crowdsec",
   "Brunas/meteo_lt_by_brunas",
   "bscholer/home-assistant-comma-ai",
+  "buchuman/hisense_vrf",
   "buggedcom/Enion-hass",
   "bvweerd/dynamic_energy_contract_calculator",
   "bvweerd/simple_pid_controller",


### PR DESCRIPTION
Adds [buchuman/hisense_vrf](https://github.com/buchuman/hisense_vrf) as an integration.

## About the integration

A custom Home Assistant integration for **Hisense VRF** indoor units controlled through an i-Modkit Modbus TCP gateway (HCPC-H2M1C).

- **Quality scale: Platinum** — every applicable rule of HA's Integration Quality Scale (Bronze → Platinum) implemented or formally exempt. See [\`quality_scale.yaml\`](https://github.com/buchuman/hisense_vrf/blob/main/custom_components/hisense_vrf/quality_scale.yaml).
- **193 tests, 96% coverage; \`mypy --strict\` passes** with 0 errors.
- **License**: MIT.
- **Releases tagged**: \`v1.0.0\`, \`v1.1.0\`.
- **Dependency** \`pyacmodbus\` published on PyPI (declared in manifest as a normal requirement).
- **Brand assets** ship locally with the integration (via the new brands-proxy-api, per [the 2026-02-24 announcement](https://developers.home-assistant.io/blog/2026/02/24/brands-proxy-api)).

CI green: pytest (3.13 + 3.14), mypy strict, hassfest, HACS validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)