### PR TITLE
Add martinbeyerlab/zemismart-hacs

### DIFF
--- a/integration
+++ b/integration
@@ -1418,6 +1418,7 @@
   "marq24/ha-tibber-pulse-local",
   "marq24/ha-waterkotte",
   "martinarva/dynamic_energy_cost",
+  "martinbeyerlab/zemismart-hacs",
   "martindell/ha-entity-notes",
   "MartinDybal/TapHome-HomeAssistant",
   "martinhoyer/ha-pre-hdo",


### PR DESCRIPTION
## Integration submission

**martinbeyerlab/zemismart-hacs**

### What it does

Controls the per-button display labels on **Zemismart ZM208 WiFi smart switches** directly from Home Assistant, via a local UDP protocol on port 3678 — no cloud required.

The ZM208 is a Matter-over-WiFi light switch with a small display showing a custom label per button. This integration lets you set those labels from HA as writable `text` entities, controllable from the device page and automations.

### Protocol

Discovered May 2026 by AP-level packet capture: plain JSON over UDP port 3678, no authentication. Full technical write-up: https://github.com/martinbeyerlab/homelab/blob/main/infrastructure/network/zm208-display-research.md

### Features

- Local-only, no cloud
- Works alongside the built-in Matter integration (Matter handles on/off; this adds labels)
- Auto-discovers ZM208s already paired via Matter
- Supports ZM208-1 through ZM208-4 (1–4 gang, auto-detected)
- `text` entities per button on the correct HA device page

### Checklist

- [x] The repository is public
- [x] `hacs.json` is present and valid
- [x] `manifest.json` has all required fields including `config_flow: true`
- [x] GitHub release exists (v0.2.9)
- [x] README with installation and usage instructions
- [x] GitHub Actions (HACS Action + Hassfest) added
- [x] No hardcoded credentials or secrets
- [x] `iot_class: local_polling`
- [x] Added in alphabetical order