### PR TITLE
Add martinbeyerlab/ha-zemismart

### DIFF
--- a/integration
+++ b/integration
@@ -1418,6 +1418,7 @@
   "marq24/ha-tibber-pulse-local",
   "marq24/ha-waterkotte",
   "martinarva/dynamic_energy_cost",
+  "martinbeyerlab/ha-zemismart",
   "martindell/ha-entity-notes",
   "MartinDybal/TapHome-HomeAssistant",
   "martinhoyer/ha-pre-hdo",


### PR DESCRIPTION
## Integration submission

**martinbeyerlab/ha-zemismart**

### Links (required)

- Repository: https://github.com/martinbeyerlab/ha-zemismart
- Latest release: https://github.com/martinbeyerlab/ha-zemismart/releases/tag/v0.3.0
- CI action run: https://github.com/martinbeyerlab/ha-zemismart/actions/runs/26382348905

### What it does

Controls the per-button display labels on **Zemismart Smart Screen Switch 208** (ZM208) WiFi switches directly from Home Assistant — no cloud required.

The ZM208 is a Matter-over-WiFi wall switch with a small display showing a custom label per button. This integration exposes those labels as writable `text` entities.

Protocol: plaintext JSON over UDP port 3678, discovered via AP-level packet capture. Works alongside the built-in Matter integration.

Supports: ZM208-1 through ZM208-4 (1–4 gang, horizontal and vertical, auto-detected).

### Checklist

- [x] The repository is public
- [x] hacs.json is present with required `name` key
- [x] manifest.json has all required fields
- [x] GitHub release v0.3.0 exists
- [x] README with installation instructions
- [x] GitHub Actions: HACS Action + Hassfest
- [x] No hardcoded credentials
- [x] iot_class: local_polling
- [x] Repository name does not contain 'HACS'
- [x] Added in alphabetical order
- [x] Unique domain: zemismart