### PR TITLE
Add norwegian-parcel-tracker-card to plugin

### DIFF
--- a/plugin
+++ b/plugin
@@ -213,6 +213,7 @@
   "homeassistant-extras/room-summary-card",
   "homeassistant-extras/toolbar-status-chips",
   "homeassistant-extras/zwave-card-set",
+  "Homie-Assistance/norwegian-parcel-tracker-card",
   "Hugo0485/DoubleCurtainCard",
   "hulkhaugen/hass-bha-icons",
   "hyperb1iss/hyper-light-card",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/Homie-Assistance/norwegian-parcel-tracker-card/releases/tag/v1.3.1>
Link to successful HACS action (without the `ignore` key): <https://github.com/Homie-Assistance/norwegian-parcel-tracker-card/actions/runs/26132441688/job/76860709051>
Link to successful hassfest action (if integration): <N/A>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->