### PR TITLE
Add dkk54/ha-aseko-cloud (integration)

### DIFF
--- a/integration
+++ b/integration
@@ -612,6 +612,7 @@
   "djtimca/hasatellitetracker",
   "dkarv/ha-bwt-perla",
   "dkarv/ha-komodo",
+  "dkk54/ha-aseko-cloud",
   "dknowles2/ha-pitboss",
   "dlarrick/hass-kumo",
   "dlashua/templatebinarysensor",


### PR DESCRIPTION
Adding the official **Aseko Cloud** integration to the HACS default catalog.

- Repository: https://github.com/dkk54/ha-aseko-cloud
- Description: Official Home Assistant integration for Aseko ASIN AQUA pool units, using the public Aseko integrator API.
- License: Apache-2.0
- Latest release: [`v0.1.1`](https://github.com/dkk54/ha-aseko-cloud/releases/tag/v0.1.1)
- HACS validation: ✅ ([CI run](https://github.com/dkk54/ha-aseko-cloud/actions))
- Hassfest: ✅
- Topics: home-assistant, home-assistant-integration, hacs, hacs-integration, aseko, aseko-pool, asin-aqua, pool
- Brand assets: shipped in-repo at `custom_components/aseko_cloud/brand/` per the HA 2026.3+ convention

This is the vendor-built integration (maintained by Aseko) built on the official public Aseko integrator API at https://api.aseko.cloud/api/v1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)