### PR TITLE
Add jerrit/ha-base-power

### DIFF
--- a/integration
+++ b/integration
@@ -1078,6 +1078,7 @@
   "jeroenterheerdt/grillbuddy",
   "jeroenterheerdt/HADailySensor",
   "jeroenterheerdt/HAsmartirrigation",
+  "jerrit/ha-base-power",
   "jesserockz/ha-leafspy",
   "Jezza34000/homeassistant_petkit",
   "Jezza34000/homeassistant_veolia",


### PR DESCRIPTION
## Checklist

- [x] I have read the [HACS contribution guidelines](https://hacs.xyz/docs/publish/start)
- [x] The repository is available on GitHub
- [x] The repository has a release
- [x] HACS validation passes
- [x] Hassfest validation passes

## Repository

https://github.com/jerrit/ha-base-power

## Category

Integration

## Description

Unofficial Home Assistant integration for Base Power home battery systems. Monitors battery level, power usage, backup time, and energy consumption. Supports single and dual battery configurations (25 kWh per unit), full Energy Dashboard compatibility.