### PR TITLE
Add smcneece/ha-esunpower

### DIFF
--- a/integration
+++ b/integration
@@ -2039,6 +2039,7 @@
   "smarthomeblack/zalo_bot",
   "smartpricing/homeassistant-smartpms",
   "SmartyVan/hass-geolocator",
+  "smcneece/ha-esunpower",
   "Smiley73/ha-scheduler",
   "smkrv/ha-metar-weather",
   "smkrv/ha-text-ai",


### PR DESCRIPTION
Home Assistant integration for SunPower PVS5/PVS6 solar monitoring systems. Local API only, no cloud dependency. Supports SunVault battery monitoring and control, individual inverter health tracking, and WebSocket live data on PVS6.

- HACS Validation: passing
- Hassfest: passing
- Releases published since August 2025

Note: the only other SunPower integration (krbaker/hass-sunpower) does not support current PVS firmware and is no longer functional for most users on PVS5 or PVS6 hardware.