### PR TITLE
Adds new integration [kkilchrist/ha-color-ext]

### DIFF
--- a/integration
+++ b/integration
@@ -1216,6 +1216,7 @@
   "KiraPC/ha-switchbot-remote",
   "kirei/hass-chargeamps",
   "kirill-k2/hass-guk-krasnodar",
+  "kkilchrist/ha-color-ext",
   "klacol/homeassistant-clage_homeserver",
   "klaptafel/ha-previous-state-tracker",
   "klatka/nc-talk-bot-component",


### PR DESCRIPTION
A reusable color value as a Home Assistant helper entity — like `input_number` or `input_boolean`, but the value is a color.

- Repo: https://github.com/kkilchrist/ha-color-ext
- Latest release: https://github.com/kkilchrist/ha-color-ext/releases/tag/v0.1.0
- CI: green (hassfest, HACS Action, ruff, pytest — 51 tests)

Canonical state is CIE xyY (device-independent across light vendors), with a `kind ∈ {chromatic, white}` flag for color-temperature inputs. Services: `set_color` (accepts hex/rgb/hs/xy/kelvin/color_name), `set_brightness`, `clear_brightness`, `apply_to` (dispatches to one or more lights with optional explicit brightness override). Scene support via `reproduce_state`.

A companion Lovelace card lives at https://github.com/kkilchrist/ha-color-ext-card (separate PR for the `plugin` list).