### PR TITLE
Adds new plugin [kkilchrist/ha-color-ext-card]

### DIFF
--- a/plugin
+++ b/plugin
@@ -288,6 +288,7 @@
   "KipK/openevse-card",
   "kirbo/ha-lovelace-elapsed-time-card",
   "kizza/magic-home-party-card",
+  "kkilchrist/ha-color-ext-card",
   "konnectedvn/lovelace-vertical-slider-cover-card",
   "krissen/pollenprognos-card",
   "krissen/sixdegrees-card",


### PR DESCRIPTION
Lovelace custom card for the `input_color` Home Assistant helper integration. Renders a swatch + Color/White segmented toggle, with a color picker in chromatic mode and a Kelvin slider in white mode. Debounced 150ms service calls to `input_color.set_color`.

- Repo: https://github.com/kkilchrist/ha-color-ext-card
- Latest release: https://github.com/kkilchrist/ha-color-ext-card/releases/tag/v0.1.0 (24.9 KB minified `input-color-card.js`)
- CI: green
- Companion integration: https://github.com/kkilchrist/ha-color-ext (separate PR for the `integration` list — hacs/default#8029)

Stack: Lit 3 + TypeScript + Rollup. v1 scope is intentionally narrow (picker + Kelvin toggle); brightness slider and apply-to-lights surface are deferred.