### PR TITLE
Add jayzuccarelli/assist-chat-card

### DIFF
--- a/plugin
+++ b/plugin
@@ -249,6 +249,7 @@
   "javawizard/ha-navbar-position",
   "jayjojayson/bms-battery-cells-card",
   "jayjojayson/Sun-Position-Card",
+  "jayzuccarelli/assist-chat-card",
   "jcwillox/lovelace-canary",
   "jcwillox/lovelace-paper-buttons-row",
   "jeremywillans/lovelace-roomba-vacuum-card",


### PR DESCRIPTION
## Adds a new plugin

**Repository:** https://github.com/jayzuccarelli/assist-chat-card
**Category:** plugin (Lovelace dashboard card)

An inline chat card for Home Assistant — renders a conversation message stream + text input directly inside a dashboard card, bound to any `conversation.*` entity, so users can chat with their assistant/LLM agent without opening the Assist modal. Dependency-free vanilla JS, themes via HA CSS variables.

- [x] Repository is public
- [x] Has a description and topics
- [x] Contains `hacs.json`
- [x] Has a release (`v1.0.0`)
- [x] Passes the HACS Action validation (`category: plugin`)
