### PR TITLE
Adds new plugin [TomTuTHub/tomtut-pool-dosing-vigipool-card]

### DIFF
--- a/plugin
+++ b/plugin
@@ -553,6 +553,7 @@
   "tmjo/charger-card",
   "tomasrudh/analogclock",
   "Tomer27cz/energy-line-gauge",
+  "TomTuTHub/tomtut-pool-dosing-vigipool-card",
   "tomvanswam/compass-card",
   "totaldebug/atomic-calendar-revive",
   "Tra1n84/compact-lawn-mower-card",


### PR DESCRIPTION
Lovelace card for the TomTuT Pool Dosing Vigipool integration (Vigipool Orpheo VP — Phileo VP + Oxeo VP, local MQTT).

Companion to integration PR #7666.