### PR TITLE
Add daviddelahoz/ha-hondalink

### DIFF
--- a/integration
+++ b/integration
@@ -540,6 +540,7 @@
   "dave-code-ruiz/uponorX265",
   "davesmeghead/visonic",
   "DavidBilodeau1/saguenay_collection",
+  "daviddelahoz/ha-hondalink",
   "davidepalleschi/zepp2hass",
   "davidrapan/ha-solarman",
   "dawg-io/noaa_it_all",


### PR DESCRIPTION
Adds daviddelahoz/ha-hondalink as a default HACS integration repository.\n\nValidation status in source repository:\n- HACS action: passing\n- hassfest: passing\n- Release: v0.1.0