### PR TITLE
Add ha-entergy

### DIFF
--- a/integration
+++ b/integration
@@ -540,6 +540,7 @@
   "dave-code-ruiz/uponorX265",
   "davesmeghead/visonic",
   "DavidBilodeau1/saguenay_collection",
+  "daviddelahoz/ha-entergy",
   "davidepalleschi/zepp2hass",
   "davidrapan/ha-solarman",
   "dawg-io/noaa_it_all",


### PR DESCRIPTION
## Repository

https://github.com/daviddelahoz/ha-entergy

## Checklist

- [x] I am the owner of this repository.
- [x] The repository is public and hosted on GitHub.
- [x] The repository can be added to HACS as a custom repository.
- [x] HACS validation passes.
- [x] Hassfest validation passes.
- [x] A GitHub release has been created: https://github.com/daviddelahoz/ha-entergy/releases/tag/v0.1.0
- [x] Brand assets are included in the integration repository.
- [x] The repository is limited to the United States and has country set in hacs.json.
