### PR TITLE
Add kdosiodjinud/suez-water-remote

### DIFF
--- a/integration
+++ b/integration
@@ -1193,6 +1193,7 @@
   "kcoffau/AUS_BOM_Space_Weather_Alert_System",
   "kcofoni/ha-netro-watering",
   "kcsoft/virtual-keys",
+  "kdosiodjinud/suez-water-remote",
   "kelvan/ha-nodeping-status",
   "kennethroe/vehiclevue",
   "kenyonj/kohler-konnect-ha",


### PR DESCRIPTION
Adds [kdosiodjinud/suez-water-remote](https://github.com/kdosiodjinud/suez-water-remote) — a Home Assistant custom integration for the Suez Smart Solutions customer portal (cz-sitr / fr-sitr / etc.). Exposes water-meter readings, daily/monthly/yearly consumption, threshold alarms, and imports per-day cumulative statistics so the Energy dashboard attributes consumption to the correct date even when the portal publishes it late.

Latest release: v0.5.1 (https://github.com/kdosiodjinud/suez-water-remote/releases/tag/v0.5.1)
HACS + hassfest validation: passing on the default branch.
Brand icons: bundled in-repo under `custom_components/suez_water_remote/brand/` (Home Assistant 2026.3 local-brand mechanism).