### PR TITLE
Adds new integration [kdosiodjinud/suez-water-remote]

### DIFF
--- a/integration
+++ b/integration
@@ -1193,6 +1193,7 @@
   "kcoffau/AUS_BOM_Space_Weather_Alert_System",
   "kcofoni/ha-netro-watering",
   "kcsoft/virtual-keys",
+  "kdosiodjinud/suez-water-remote",
   "kelvan/ha-nodeping-status",
   "kennethroe/vehiclevue",
   "kenyonj/kohler-konnect-ha",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: https://github.com/kdosiodjinud/suez-water-remote/releases/tag/v0.5.2
Link to successful HACS action (without the `ignore` key): https://github.com/kdosiodjinud/suez-water-remote/actions/runs/26560259238/job/78241274660
Link to successful hassfest action (if integration): https://github.com/kdosiodjinud/suez-water-remote/actions/runs/26560259238/job/78241274664

Adds [kdosiodjinud/suez-water-remote](https://github.com/kdosiodjinud/suez-water-remote) — a Home Assistant custom integration for the Suez Smart Solutions customer portal. Exposes water-meter readings, daily/monthly/yearly consumption, threshold alarms, a per-meter Refresh button, and imports per-day cumulative statistics so the Energy dashboard attributes consumption to the correct date even when the portal publishes data late. Brand icons are bundled in-repo (Home Assistant 2026.3 local-brand mechanism).
