### PR TITLE
Add siedi/ha-fairland

### DIFF
--- a/integration
+++ b/integration
@@ -2009,6 +2009,7 @@
   "Shulyaka/telegram_bot_conversation",
   "Sian-Lee-SA/Home-Assistant-Switch-Manager",
   "sibest19/hass-meteoam",
+  "siedi/ha-fairland",
   "signalkraft/mypyllant-component",
   "sillyfrog/Automate-Pulse-v2",
   "sillymoi/homeassistant-infometric",


### PR DESCRIPTION
## Add the Fairland (iGarden) integration

Adds [`siedi/ha-fairland`](https://github.com/siedi/ha-fairland) to the `integration` list.

Home Assistant custom integration for **Fairland (iGarden)** pool heat pumps and pool pumps (incl. OEM rebrands such as Madimack). Connects directly to Fairland's iGarden cloud API (not Tuya).

### Checklist
- [x] Repository is public and not archived; issues enabled
- [x] Repository has a description and topics
- [x] HACS Action passes with **zero ignores** ([run](https://github.com/siedi/ha-fairland/actions/runs/26651016544))
- [x] Hassfest passes
- [x] Full GitHub release exists, created after the actions passed ([v0.3.2](https://github.com/siedi/ha-fairland/releases/tag/v0.3.2))
- [x] `hacs.json` with `name`; valid `manifest.json`
- [x] Brand assets shipped locally in `custom_components/fairland/brand/` (HA 2026.3+ local brand support)
- [x] Single integration per repository
- [x] Entry inserted alphabetically
