### PR TITLE
Add virus18/fancontrol-iot

### DIFF
--- a/integration
+++ b/integration
@@ -2313,6 +2313,7 @@
   "vinnybad/choremander",
   "vinteo/hass-opensprinkler",
   "viragelabs/virage_dashboard",
+  "virus18/fancontrol-iot",
   "VitisEK/nibe_energy_conversion",
   "vivo/ha_vivohomebridge",
   "vlumikero/home-assistant-securitas",


### PR DESCRIPTION
## Add request

**Repository:** https://github.com/virus18/fancontrol-iot
**Category:** Integration

### What it does

Local Home Assistant integration for **Brogachy EUT** and compatible Smart-Farmers-app Tuya exhaust fans (EUT-100B / 150B / 200B / 250B / 300B). 100% LAN-only, no Tuya cloud after pairing.

### Checklist

- [x] Public repository
- [x] README + info.md + hacs.json + LICENSE (MIT)
- [x] At least one release (v0.5.4)
- [x] Brand icons in custom_components/fancontrol_iot/brand/ (per HA 2026.3 mechanism)
- [x] Repository description + topics set
- [x] Follows HA architecture (config_flow, DataUpdateCoordinator, async)

### Entities (22 per device)

fan, select, 3 sensors, 1 binary_sensor, 11 numbers, 10 switches — incl. hardware-alarm-aware fan state, auto-converted °C threshold inputs, and an auto-generating Lovelace strategy.