### PR TITLE
Add virus18/fancontrol-iot

### DIFF
--- a/integration
+++ b/integration
@@ -2313,6 +2313,7 @@
   "vinnybad/choremander",
   "vinteo/hass-opensprinkler",
   "viragelabs/virage_dashboard",
+  "virus18/fancontrol-iot",
   "VitisEK/nibe_energy_conversion",
   "vivo/ha_vivohomebridge",
   "vlumikero/home-assistant-securitas",


### PR DESCRIPTION
## Add request

**Repository:** https://github.com/virus18/fancontrol-iot
**Latest release:** https://github.com/virus18/fancontrol-iot/releases/tag/v0.5.5
**CI action run:** https://github.com/virus18/fancontrol-iot/actions/runs/26658387926
**Category:** Integration

### What it does

Local Home Assistant integration for **Brogachy EUT** and compatible Smart-Farmers-app Tuya exhaust fans (EUT-100B / 150B / 200B / 250B / 300B). 100% LAN-only, no Tuya cloud traffic after pairing.

### Checklist

- [x] Public repository
- [x] README + info.md + hacs.json + LICENSE (MIT)
- [x] Releases tagged (v0.5.5 latest)
- [x] Brand icons in custom_components/fancontrol_iot/brand/ (per HA 2026.3 mechanism)
- [x] Repository description + topics set
- [x] CI passing: Hassfest + HACS Action both green
- [x] Follows HA architecture (config_flow, DataUpdateCoordinator, async)

### Entities (22 per device)

1× fan (auto-boost-aware), 1× select (mode), 3× sensors (temp/humid/countdown), 1× binary_sensor (alarm), 11× number (speed slider, brightness, 8 thresholds, 2 calibrations), 10× switch (8 triggers + child lock + display unit). Plus a Lovelace strategy that auto-generates a 3-view dashboard.