### PR TITLE
Adds new integration [desyncdotdev/home-assistant-magnum-w-controller]

### DIFF
--- a/integration
+++ b/integration
@@ -584,6 +584,7 @@
   "derolli1976/HomeassistantCloudStash",
   "derspe/ha-easy-stock",
   "Desmond-Dong/zhipuai",
+  "desyncdotdev/home-assistant-magnum-w-controller",
   "devinslick/home-assistant-fmd",
   "dext0r/yandex_smart_home",
   "dfanica/vent-axia-svara-ble",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: https://github.com/desyncdotdev/home-assistant-magnum-w-controller/releases/tag/2026.5.0
Link to successful HACS action (without the `ignore` key): https://github.com/desyncdotdev/home-assistant-magnum-w-controller/actions/runs/26663225063/job/78592100406
Link to successful hassfest action (if integration): https://github.com/desyncdotdev/home-assistant-magnum-w-controller/actions/runs/26663225063/job/78592101063

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->
