### PR TITLE
Add ABovsh/eveus

### DIFF
--- a/integration
+++ b/integration
@@ -28,6 +28,7 @@
   "abnvle/ha-imgw-pib-monitor",
   "abnvle/ha-matomo",
   "AboveColin/HA-Philips-Pet-Series",
+  "ABovsh/eveus",
   "absent42/Aqara-Advanced-Lighting",
   "aburow/apc-modbus-snmp-ha",
   "aburow/cyberpower-modbus-ha",


### PR DESCRIPTION
Adds the **Eveus EV charger** integration to the default store.

- Repository: https://github.com/ABovsh/eveus
- Domain `eveus`, `iot_class: local_polling`, `integration_type: device`, local-only (LAN) — no cloud.
- Latest release: `v4.9.2`.
- Brand images live in `custom_components/eveus/brand/` (HA 2026.3 brand directory).

The repo's CI (`.github/workflows/validate.yaml`) runs `hacs/action` (category: integration) and `hassfest`; the latest run on `main` passed both. Entry inserted alphabetically into `integration`.