### PR TITLE
Add Hollako/Tasmota-IR-Ready to integration list

### DIFF
--- a/integration
+++ b/integration
@@ -949,6 +949,7 @@
   "hoizi89/pv_management",
   "hoizi89/pv_management_fix",
   "hokiebrian/eia_hourly_demand",
+  "Hollako/Tasmota-IR-Ready",
   "hollowpnt92/lubelogger-ha",
   "home-assistant-HomeWhiz/home-assistant-HomeWhiz",
   "Home-Is-Where-You-Hang-Your-Hack/sensor.goveetemp_bt_hci",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/Hollako/Tasmota-IR-Ready/releases/latest>
Link to successful HACS action (without the `ignore` key): <https://github.com/Hollako/Tasmota-IR-Ready/actions/runs/26677793445/job/78632746658>
Link to successful hassfest action (if integration): <https://github.com/Hollako/Tasmota-IR-Ready/actions/runs/26677793445/job/78632746659>