### PR TITLE
Add HASolarDev - Animated Solar Card for Home Assistant

### DIFF
--- a/plugin
+++ b/plugin
@@ -198,6 +198,7 @@
   "gurbyz/power-wheel-card",
   "GyroGearl00se/lovelace-froeling-card",
   "hacf-fr/EcoleDirecteHACards",
+  "surcix20284-hue/HASolarDev",
   "Haluska77/solar-gauge-card",
   "Hamper/meshtastic-card",
   "harmonie-durrant/harmonie-changelogs",


### PR DESCRIPTION
A beautiful animated solar dashboard card for Home Assistant built with custom:button-card.

Features:
- 10 dynamic backgrounds from before sunrise to late night
- Animated sun arc and realistic moon
- Live energy flow beams
- Battery, grid, and temperature display

Repository: https://github.com/surcix20284-hue/HASolarDev