### PR TITLE
Add hasolardev

### DIFF
--- a/plugin
+++ b/plugin
@@ -198,6 +198,7 @@
   "gurbyz/power-wheel-card",
   "GyroGearl00se/lovelace-froeling-card",
   "hacf-fr/EcoleDirecteHACards",
+  "surcix20284-hue/HASolarDev",
   "Haluska77/solar-gauge-card",
   "Hamper/meshtastic-card",
   "harmonie-durrant/harmonie-changelogs",


### PR DESCRIPTION
Adds surcix20284-hue/HASolarDev as a Lovelace plugin repository for HACS default list.