### PR TITLE
Add MauroDruwel/Weathercloud-HA

### DIFF
--- a/integration
+++ b/integration
@@ -1447,6 +1447,7 @@
   "MattieGit/qube_heatpump",
   "mattrayner/pod-point-home-assistant-component",
   "MattXcz/CEZ",
+  "MauroDruwel/Weathercloud-HA",
   "mawinkler/astroweather",
   "MaxensF/personal_weather_station",
   "maxi07/PicoW-Neopixel-Homeassistant-Integration",


### PR DESCRIPTION
## Add MauroDruwel/Weathercloud-HA

**Repository:** https://github.com/MauroDruwel/Weathercloud-HA
**Category:** Integration

### Description
Home Assistant HACS integration for [Weathercloud](https://weathercloud.net) personal weather stations. Fetches live weather data and exposes it as sensors in Home Assistant.

### HACS Requirements Checklist
- [x] Public GitHub repository
- [x] MIT License
- [x] `hacs.json` present with `name`, `render_readme`, and `homeassistant` fields
- [x] `manifest.json` with all required fields (domain, name, codeowners, config_flow, documentation, issue_tracker, version)
- [x] Topics include `hacs` and `hacs-integration`
- [x] `validate.yml` workflow with both hassfest and HACS action checks passing
- [x] GitHub release published (v1.0.0)
- [x] README.md present
- [x] Translations (en.json)
- [x] Config flow UI setup