### PR TITLE
Add finbom/HomeAssistantAdvancedUpdateManager

### DIFF
--- a/integration
+++ b/integration
@@ -758,6 +758,7 @@
   "ffunes/Marstek-Venus-Energy-Manager",
   "figorr/meteocat",
   "filipvh/hass-nhc2",
+  "finbom/HomeAssistantAdvancedUpdateManager",
   "finder39/ha-dockge",
   "fineemb/Colorfulclouds-weather",
   "fineemb/Smartmi-smart-heater",


### PR DESCRIPTION
## Description

Adding **Advanced Update Manager** — a Home Assistant integration that adds a dedicated Update Manager panel to the sidebar with enriched update information.

## Features

- All update types in one view (Core, HA OS, Add-ons, HACS, Device, Other)
- Real release dates fetched from GitHub API with persistent caching
- Direct links to release notes
- Backup before update
- Skip version functionality
- Real-time sync with native HA UI
- Multi-language support (English, Swedish)

## Repository

https://github.com/finbom/HomeAssistantAdvancedUpdateManager

## Checklist

- [x] HACS validation passing
- [x] Hassfest validation passing
- [x] Has a release (v1.0.0)
- [x] Has README with screenshot
- [x] Has LICENSE (MIT)
- [x] Has hacs.json
- [x] Has brand/icon.png
- [x] Repository has description and topics