### PR TITLE
Add gunkl/ClimateAdvisor

### DIFF
--- a/integration
+++ b/integration
@@ -881,6 +881,7 @@
   "guerrerotook/securitas-direct-new-api",
   "GuidoJeuken-6512/lambda_heat_pumps",
   "GuilleGF/hassio-ovh",
+  "gunkl/ClimateAdvisor",
   "gunnjr/ha-logger-manager",
   "gurrier/localvolts",
   "gurux13/hass-alarm",


### PR DESCRIPTION
## Description

Adding [Climate Advisor](https://github.com/gunkl/ClimateAdvisor) — a weather-aware HVAC automation integration for Home Assistant.

## Integration details

- **Repository:** gunkl/ClimateAdvisor
- **Category:** integration
- **Version:** v0.3.54
- **HA minimum:** 2024.6.0

## What it does

Climate Advisor automates HVAC management using weather forecasts, a physics-based thermal learning model, occupancy, and door/window sensors. It classifies each day (hot/warm/mild/cool/cold), adjusts thermostat setpoints accordingly, and sends a daily briefing explaining every decision in plain English.

Key features:
- Physics-based thermal learning (observes your home's specific heating/cooling rates)
- Occupancy-aware setpoints (home/away/vacation/guest modes)
- Door/window pause logic with hysteresis
- Daily plain-English briefing notifications
- Built-in dashboard with forecast chart and target band overlay
- Optional Claude AI investigator for activity analysis

## Checklist

- [x] The repository is public
- [x] One integration per repository (`custom_components/climate_advisor/`)
- [x] `hacs.json` is present and valid
- [x] `brand/icon.png` is present
- [x] GitHub releases published (latest: v0.3.54)
- [x] `manifest.json` includes `domain`, `name`, `documentation`, `issue_tracker`, `codeowners`, `version`
- [x] HACS validation action passes ✅
- [x] Hassfest validation passes ✅