### PR TITLE
Add MarkAtwood/ha-mqtt-device-sync

### DIFF
--- a/integration
+++ b/integration
@@ -1402,6 +1402,7 @@
   "mariusz-ostoja-swierczynski/tech-controllers",
   "markaggar/ha-media-index",
   "markaggar/Water-Monitor",
+  "MarkAtwood/ha-mqtt-device-sync",
   "markfrancisonly/ha-cameralux",
   "markgdev/home-assistant_OctopusAgile",
   "markuzzi/somfy_cul_integration",


### PR DESCRIPTION
## New Integration: MQTT Device Sync

**Repository:** https://github.com/MarkAtwood/ha-mqtt-device-sync

### What does it do?

MQTT Device Sync solves a long-standing limitation in Home Assistant: **`suggested_area` from MQTT discovery is only applied on first discovery**. After that, devices never get their area updated, even when the MQTT source changes `suggested_area`.

This affects every MQTT-based integration: Zigbee2MQTT, Tasmota, ESPHome, rtl-haos, and any custom MQTT device.

### The Problem (5+ Years of Requests)

This has been a pain point in the community for years:

- **2023**: [Tasmota: support for suggested_area](https://community.home-assistant.io/t/tasmota-support-for-suggested-area/616843) - Users requesting area sync for Tasmota devices
- **2023**: [MQTT auto discovery - missing suggested_area per entity](https://community.home-assistant.io/t/mqtt-auto-discovery-missing-suggested-area-per-entity/524205) - Frustration that area assignment doesn't persist
- **2022**: [WTH Can we not assign "area" to all entities/devices in configuration.yaml?](https://community.home-assistant.io/t/wth-can-we-not-assign-area-to-all-entities-devices-in-configurationyaml/468570) - Users wanting declarative area assignment
- **2023**: [Zigbee2MQTT Area Assignment](https://community.home-assistant.io/t/zigbee2mqtt-area-assignment/627164) - Ongoing confusion about why areas don't sync
- **2026**: [Newly discovered devices via MQTT are no more in the suggested_area](https://github.com/home-assistant/core/issues/162557) - Still being reported as a problem
- **2018**: [Feature Request: Incorporate Home Assistant device registry attributes](https://github.com/Koenkk/zigbee2mqtt/issues/646) - One of the earliest requests for proper area/registry sync

The core issue: Home Assistant "preserves user customizations" by ignoring subsequent `suggested_area` updates. But for users who **want** their MQTT source to be the source of truth for device areas, there's been no solution.

### How This Integration Solves It

MQTT Device Sync runs alongside the standard MQTT integration and:

1. **Subscribes to MQTT discovery topics** (`homeassistant/+/+/config`)
2. **Applies `suggested_area`** to the device registry using HA's internal APIs
3. **Auto-creates missing areas** when needed
4. **Optionally syncs device names** as well
5. **Parses area from device names** for sources that don't support `suggested_area` (e.g., "Living Room / Plug" → area: Living Room)

### Configuration Options

- Sync area (on/off)
- Sync name (on/off)
- Overwrite existing values (on/off)
- Parse area from device name (on/off, for Tasmota-style naming)
- Custom discovery prefix
- Custom name delimiters

### Requirements Met

- [x] Public GitHub repository with description and topics
- [x] Works as HACS custom repository
- [x] Has README with usage instructions
- [x] Has at least one release (v0.2.0)
- [x] Passes HACS validation
- [x] Valid manifest.json
- [x] Brand/icon in home-assistant/brands (uses MQTT icon)

### Links

- **Repository**: https://github.com/MarkAtwood/ha-mqtt-device-sync
- **Documentation**: https://github.com/MarkAtwood/ha-mqtt-device-sync#readme
- **Releases**: https://github.com/MarkAtwood/ha-mqtt-device-sync/releases
