### PR TITLE
Add prism-3d-card

### DIFF
--- a/plugin
+++ b/plugin
@@ -607,4 +607,5 @@
   "zanac/temperature-heatmap-card",
   "zanna-37/hass-swipe-navigation",
   "zeronounours/lovelace-energy-entity-row"
+  "MCChang-cmyk/prism-3d-card"
 ]


### PR DESCRIPTION
A 3D prism data visualization card designed for Home Assistant. 
It offers modular i18n support, advanced entity precision handling, and a custom projection engine for dynamic data visualization.

## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: https://github.com/MCChang-cmyk/Prism-3D-Data-Card/releases/latest
Link to successful HACS action without the ignore key):  https://github.com/MCChang-cmyk/Prism-3D-Data-Card/actions
Link to successful hassfest action (if integration): N/A (Lovelace Plugin)