### PR TITLE
Add dk-1983/Modbus_Devices to integration list

### DIFF
--- a/integration
+++ b/integration
@@ -607,6 +607,7 @@
   "djbulsink/panasonic_ac",
   "djerik/beolink-ha",
   "djerik/wavinsentio-ha",
+  "dk-1983/Modbus_Devices",
   "djlactose/smartslydr",
   "djtimca/harocketlaunchlive",
   "djtimca/hasatellitetracker",


### PR DESCRIPTION
Add Modbus Devices integration.

https://github.com/dk-1983/Modbus_Devices/releases/tag/v0.1.1
https://github.com/dk-1983/Modbus_Devices/actions/runs/26713120488
