### PR TITLE
Adds new integration [bairnhard/closest-plane-ha]

### DIFF
--- a/integration
+++ b/integration
@@ -226,6 +226,7 @@
   "B5r1oJ0A9G/teufel_raumfeld",
   "bacco007/sensor.opennem",
   "bacco007/sensor.waternsw",
+  "bairnhard/closest-plane-ha",
   "bairnhard/fishing_assistant",
   "bairnhard/home-assistant-google-aqi",
   "banter240/hdg_bavaria_homeassistant",


### PR DESCRIPTION
Look mommy, there's planes up in the sky.


An integration that gets data about the nearest aircraft and provides them as sensors, for y'all aviation geeks.

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/bairnhard/closest-plane-ha/releases/tag/v1.1.0>
Link to successful HACS action (without the `ignore` key): <https://github.com/bairnhard/closest-plane-ha/actions/runs/26715584983/job/78733488282>
Link to successful hassfest action (if integration): <https://github.com/bairnhard/closest-plane-ha/actions/runs/26715584983/job/78733488287>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->