### PR TITLE
Add dk-1983/Modbus_Devices to integration list

### DIFF
--- a/integration
+++ b/integration
@@ -607,6 +607,7 @@
   "djbulsink/panasonic_ac",
   "djerik/beolink-ha",
   "djerik/wavinsentio-ha",
+  "dk-1983/Modbus_Devices",
   "djlactose/smartslydr",
   "djtimca/harocketlaunchlive",
   "djtimca/hasatellitetracker",


### PR DESCRIPTION
Add Modbus Devices integration.

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

https://github.com/dk-1983/Modbus_Devices/releases/tag/v0.1.6
https://github.com/dk-1983/Modbus_Devices/actions/runs/26715088214
https://github.com/dk-1983/Modbus_Devices/actions/runs/26715088216

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->