### PR TITLE
Add grm/homeassistant-nina

### DIFF
--- a/integration
+++ b/integration
@@ -872,6 +872,7 @@
   "grimmpp/home-assistant-eltako",
   "Griswoldlabs/span-panel-ha",
   "gritaro/gigachain",
+  "grm/homeassistant-nina",
   "grotan1/denon-avr-3805",
   "gstrike/ha-xlights_scheduler",
   "gtjadsonsantos/consul",


### PR DESCRIPTION
## Adding a new repository

Repository: grm/homeassistant-nina
Category: integration

[NINA Polaris](https://github.com/grm/homeassistant-nina) is a Home Assistant integration connecting to [NINA (Nighttime Imaging 'N' Astronomy)](https://nighttime-imaging.eu/) via its REST API and WebSocket interface, exposing camera, mount, guider, focuser and sequence telemetry as entities.

### Checklist
- [x] I'm the author or a major contributor of the repository.
- [x] The repository is public and hosted on GitHub.
- [x] The repository can be added as a custom repository in HACS and works.
- [x] The repository passes the HACS Action and hassfest validation.
- [x] There is at least one published GitHub release.
- [x] Brand icons are bundled in the integration (`custom_components/nina_polaris/brand/`), per the HA 2026.3 local brand support.
- [x] The entry was inserted alphabetically.
- [x] This PR is from a branch on my personal fork, not master.