### PR TITLE
Adds new integration [dk-1983/Modbus_Devices]

### DIFF
--- a/integration
+++ b/integration
@@ -607,6 +607,7 @@
   "djbulsink/panasonic_ac",
   "djerik/beolink-ha",
   "djerik/wavinsentio-ha",
+  "dk-1983/Modbus_Devices",
   "djlactose/smartslydr",
   "djtimca/harocketlaunchlive",
   "djtimca/hasatellitetracker",


### PR DESCRIPTION
Add Modbus Devices integration.

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [v ] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [v ] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ v] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [v ] The actions are passing without any disabled checks in my repository.
- [ v] I've added a link to the action run on my repository below in the links section.
- [ v] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

https://github.com/dk-1983/Modbus_Devices/releases/tag/v0.1.8
https://github.com/dk-1983/Modbus_Devices/actions/runs/26717226966
https://github.com/dk-1983/Modbus_Devices/actions/runs/26717226967

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->