### PR TITLE
Add 8408323/ha-plejd

### DIFF
--- a/integration
+++ b/integration
@@ -16,6 +16,7 @@
   "5high/phicomm-dc1-homeassistant",
   "62fixolab/HA-Panda-PWR",
   "83noit/ha-hue-entertainment",
+  "8408323/ha-plejd",
   "8none1/lednetwf_ble",
   "9a4gl/hass-centrometal-boiler",
   "a-mavrides/roomba_v4",


### PR DESCRIPTION
Adds [8408323/ha-plejd](https://github.com/8408323/ha-plejd) — an unofficial Home Assistant integration for **Plejd** BLE-mesh lighting and relays.

- Category: **integration** (domain `plejd`, `iot_class: local_push`)
- Local Bluetooth-mesh control + optional remote gateway transport; setup via a one-time Plejd cloud login.
- Latest release: **v0.5.0**; `hacs.json` present; brands icon already in `home-assistant/brands` (`custom_integrations/plejd`).
- Repo passes HACS validation + hassfest in CI; description, topics, and README are in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)