### PR TITLE
Add rolladen-planner-card to HACS default registry

### DIFF
--- a/plugin
+++ b/plugin
@@ -257,6 +257,7 @@
   "jo-ket/compact-cover-control-card",
   "john-lazarus/HomeAssistantLGThinkQCards",
   "jonahkr/power-distribution-card",
+  "jonas59075/ha-rolladen-planner-card",
   "JonasDoebertin/ha-today-card",
   "jonkristian/entur-card",
   "joseluis9595/lovelace-navbar-card",


### PR DESCRIPTION
## Summary

Submission of Rolladen Planner Card to HACS default registry.

### Integration Details
- **Repository**: https://github.com/jonas59075/ha-rolladen-planner-card
- **Version**: 0.1.0
- **Type**: Lovelace Card
- **Target HA Version**: 2024.4.0+
- **License**: MIT

### Features
- Visual weekly schedule editor for cover/shutter automations
- Theme support (dark/light, accent colors, density modes)
- German/English localization
- WebSocket integration with scheduler-component

### Installation Instructions
1. HACS → Frontend → Search for "Rolladen Planner Card"
2. Install the card
3. Restart Home Assistant
4. Add to dashboard (type: `custom:rolladen-planner-card`)

### Verification
- [x] Repository is public
- [x] hacs.json with valid configuration
- [x] Release tag v0.1.0 with dist/ artifacts
- [x] README.md with installation instructions
- [x] MIT License present
- [x] All GitHub Actions passing