### PR TITLE
Add FNIRSI FNB58 Home Assistant integration

### DIFF
--- a/integration
+++ b/integration
@@ -2393,6 +2393,7 @@
   "youdroid/home-assistant-gogs",
   "youdroid/home-assistant-sickchill",
   "yunusp01/auto_utility_meter",
+  "ZL1LAC/homeassistant-fnb58",
   "ZacheryThomas/homeassistant-smartrent",
   "zachowj/hass-node-red",
   "zacs/ha-energycalc",


### PR DESCRIPTION
## Summary
Adds [ZL1LAC/homeassistant-fnb58](https://github.com/ZL1LAC/homeassistant-fnb58) — Home Assistant integration for the FNIRSI FNB58 USB Fast Charge Tester (read-only BLE monitoring).

## Repository checks
- Hassfest and HACS validation workflows pass
- manifest documentation/issue_tracker, LICENSE, release v1.7.0
- Brand icon at custom_components/fnb58/brand/icon.png

Made with [Cursor](https://cursor.com)