### PR TITLE
Add mosandlt/Bosch-Smart-Home-Camera-Tool-HomeAssistant

### DIFF
--- a/integration
+++ b/integration
@@ -1522,6 +1522,7 @@
   "moralmunky/Home-Assistant-Mail-And-Packages",
   "morosanmihail/HA-LondonTfL",
   "morotsgurka/garo-gctrl-homeassistant",
+  "mosandlt/Bosch-Smart-Home-Camera-Tool-HomeAssistant",
   "mossipcams/autosnooze",
   "Motorline/ha-mconnect",
   "mousehome-net/keba_one_ev",


### PR DESCRIPTION
Adds `mosandlt/Bosch-Smart-Home-Camera-Tool-HomeAssistant` to the `integration` category — a single-line, alphabetically-ordered addition (between `morotsgurka/...` and `mossipcams/...`).

Fresh single-commit PR off the current `master` to replace #7247, whose automated CHANGES_REQUESTED was triggered by a duplicate line in an intermediate commit (later removed). This branch has clean history and no duplicate.

The repository is a HACS-compatible Home Assistant integration (custom_components/bosch_shc_camera) with brands, hacs.json, releases and CI.