### PR TITLE
Add r11a/homeii-music-flow to plugin defaults

### DIFF
--- a/plugin
+++ b/plugin
@@ -454,6 +454,7 @@
   "queimadus/last-changed-element",
   "r-renato/ha-card-waze-travel-time",
   "r-renato/ha-card-weather-conditions",
+  "r11a/homeii-music-flow",
   "ratava/advanced-energy-card",
   "rautesamtr/thermal_comfort_icons",
   "RayzorST/Universal-Device-Card",


### PR DESCRIPTION
Adds HOMEii Music Flow as a default HACS plugin repository.

Repository: https://github.com/r11a/homeii-music-flow
Latest stable release: https://github.com/r11a/homeii-music-flow/releases/tag/v5.9.0
Validation workflow: https://github.com/r11a/homeii-music-flow/actions/runs/26885219867

This repository is already installable as a custom HACS plugin repository. Including it in the default plugin list will allow users to find and install it directly from HACS without manually adding a custom repository.