### PR TITLE
Add r11a/homeii-music-flow to plugin defaults

### DIFF
--- a/plugin
+++ b/plugin
@@ -454,6 +454,7 @@
   "queimadus/last-changed-element",
   "r-renato/ha-card-waze-travel-time",
   "r-renato/ha-card-weather-conditions",
+  "r11a/homeii-music-flow",
   "ratava/advanced-energy-card",
   "rautesamtr/thermal_comfort_icons",
   "RayzorST/Universal-Device-Card",


### PR DESCRIPTION
Adds HOMEii Music Flow as a default HACS plugin repository.

Repository: https://github.com/r11a/homeii-music-flow

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository. N/A, this is a plugin/dashboard card.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/r11a/homeii-music-flow/releases/tag/v5.9.0>
Link to successful HACS action (without the `ignore` key): <https://github.com/r11a/homeii-music-flow/actions/runs/26885219867>
Link to successful hassfest action (if integration): <N/A - plugin/dashboard card>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->