### PR TITLE
Add bdlcalvin/ha-american-standard-comfortlink

### DIFF
--- a/integration
+++ b/integration
@@ -246,6 +246,7 @@
   "bbckr/ha-synology-tasks",
   "bbr111/byd_hvs",
   "bcpearce/homeassistant-gtfs-realtime",
+  "bdlcalvin/ha-american-standard-comfortlink",
   "bdunn44/hass-jellyfish-lighting",
   "Beat-YT/hydropeak-ha",
   "Beat2er/homeassistant-trmnl-battery",


### PR DESCRIPTION
Adds the American Standard ComfortLink heat pump water heater integration.

- Repository: https://github.com/bdlcalvin/ha-american-standard-comfortlink
- Category: integration

Checklist
- [x] Repository is public
- [x] Passes the HACS Action (Validate workflow green)
- [x] Has a published release (v1.0.1)
- [x] README and info.md present
- [x] Repository description and topics set
- [x] Brand icon shipped locally (brand/ folder, HA 2026.3 brands proxy)
