### PR TITLE
Add javaDevJT/ha-rccl

### DIFF
--- a/integration
+++ b/integration
@@ -944,6 +944,7 @@
   "jasonmx/philips-hue-smooth-dimmer",
   "jasonwragg/home-assistant-readynaslocal",
   "jasperslits/haithowifi",
+  "javaDevJT/ha-rccl",
   "JayBlackedOut/hass-nhlapi",
   "jaycollett/OpenIRBlaster",
   "jaydeethree/Home-Assistant-weatherdotcom",


### PR DESCRIPTION
Adds the Royal Caribbean custom integration to the HACS default integration list.\n\nRepository: https://github.com/javaDevJT/ha-rccl\nRelease: https://github.com/javaDevJT/ha-rccl/releases/tag/v0.1.0\nValidation: HACS, Hassfest, and Tests are passing on v0.1.0.