### PR TITLE
Add x1marc/homeassistant-judo-idos

### DIFF
--- a/integration
+++ b/integration
@@ -2367,6 +2367,7 @@
   "wrodie/ha_behringer_mixer",
   "WulfgarW/homeassistant-pycupra",
   "wuwentao/midea_ac_lan",
+  "x1marc/homeassistant-judo-idos",
   "xannor/ha_reolink_discovery",
   "xathon/Allianz-BonusDrive-HomeAssistant",
   "Xerolux/idm-heatpump-hass",


### PR DESCRIPTION
Adds the **JUDO i-dos** custom integration (water dosing device, cloud polling via the OptiSoft relay).

- Repo: https://github.com/x1marc/homeassistant-judo-idos
- Domain: `myjudo`
- Hassfest + HACS Action passing, brand assets included, full releases.