### PR TITLE
Add dgshue/TabloHARemote

### DIFF
--- a/integration
+++ b/integration
@@ -589,6 +589,7 @@
   "dfanica/vent-axia-svara-ble",
   "dgomes/ha_erse",
   "dgomes/ha_generic_water_heater",
+  "dgshue/TabloHARemote",
   "dhover/ha-cumulusmx",
   "dhover/ha-iungo",
   "dib0/ha-elro-connects-realtime",


### PR DESCRIPTION
Adds [**dgshue/TabloHARemote**](https://github.com/dgshue/TabloHARemote) (domain `tablo_remote`) as an **integration**.

_Tablo Meets Home Assistant_ — a Home Assistant integration for Tablo 4th-gen OTA DVRs: change channels, expose a media_player + current-channel sensor, and a one-call power-on + launch + deep-link flow to a Roku.

- Public repo with description and topics
- Valid `hacs.json` and `manifest.json` (domain, name, version, documentation, issue_tracker, codeowners)
- README included
- Brand icon bundled in-repo (`custom_components/tablo_remote/brand/`) per the HA 2026.3 brands-proxy model