### PR TITLE
Add wheezer256/satchel-one

### DIFF
--- a/integration
+++ b/integration
@@ -2341,6 +2341,7 @@
   "werthdavid/homeassistant-pulsatrix-local-mqtt",
   "wez/govee-lan-hass",
   "wheeller123/Tineco-Integration",
+  "wheezer256/satchel-one",
   "Wibias/hass-variables",
   "WickedGhost/avinor_flight_data",
   "widewing/ha-toyota-na",


### PR DESCRIPTION
Adds the **Satchel One** integration to the HACS default integration store.

- Repo: https://github.com/wheezer256/satchel-one
- Category: integration
- Latest release: v1.1.0
- HACS Action passes with no ignores; hassfest passes; brand icon present at `custom_components/satchel_one/brand/icon.png`.

A companion PR to home-assistant/brands is also open so the icon renders in the HA UI.

A Home Assistant custom integration that surfaces per-child Satchel One school data (homework, behaviour credits/demerits, detentions) as entities and events. Unofficial; uses a reverse-engineered API.