### PR TITLE
Add wheezer256/satchel-one

### DIFF
--- a/integration
+++ b/integration
@@ -2341,6 +2341,7 @@
   "werthdavid/homeassistant-pulsatrix-local-mqtt",
   "wez/govee-lan-hass",
   "wheeller123/Tineco-Integration",
+  "wheezer256/satchel-one",
   "Wibias/hass-variables",
   "WickedGhost/avinor_flight_data",
   "widewing/ha-toyota-na",


### PR DESCRIPTION
Adds the **Satchel One** integration to the HACS default integration store.

- Repo: https://github.com/wheezer256/satchel-one
- Category: integration
- Latest release: **v1.1.1** (bundles the brand icon at `custom_components/satchel_one/brand/icon.png`, 256×256)
- HACS Action, hassfest and CI all pass with no ignores.

Brand icons also submitted to home-assistant/brands (PR #10450, checks green).

A Home Assistant custom integration that surfaces per-child Satchel One school data (homework, behaviour credits/demerits, detentions) as entities and events. Unofficial; uses a reverse-engineered API.

(Re-submission of #8225, which was auto-closed when validation ran against the pre-icon release v1.1.0; v1.1.1 now bundles the icon.)