### PR TITLE
Add "general-galactic/home-assistant-crystal-water-monitor" integration

### DIFF
--- a/integration
+++ b/integration
@@ -830,6 +830,7 @@
   "geertmeersman/yoin",
   "geertmeersman/youfone",
   "GeiserX/genieacs-ha",
+  "general-galactic/home-assistant-crystal-water-monitor",
   "gensyn/ssh_command",
   "gensyn/ssh_docker",
   "gensyn/task_tracker",


### PR DESCRIPTION
Added the 'general-galactic/home-assistant-crystal-water-monitor' integration for the Crystal Water Monitor Pool and Hot Tub chemistry monitor.

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: [v1.0.14](https://github.com/general-galactic/home-assistant-crystal-water-monitor/releases/tag/v1.0.14)
Link to successful HACS action (without the `ignore` key): [run](https://github.com/general-galactic/home-assistant-crystal-water-monitor/actions/runs/27033319827/job/79790894620)
Link to successful hassfest action (if integration): [run](https://github.com/general-galactic/home-assistant-crystal-water-monitor/actions/runs/27033319827/job/79790894471)

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->