### PR TITLE
Add ipod86/lovelace-agentdvr-card

### DIFF
--- a/plugin
+++ b/plugin
@@ -235,6 +235,7 @@
   "Inter-Raptor/raptor-todo-hub-card",
   "Inter-Raptor/raptor-youtube-feed-card",
   "iot7m/septic-card",
+  "ipod86/lovelace-agentdvr-card",
   "ironsheep/lovelace-lightning-detector-card",
   "ironsheep/lovelace-rpi-monitor-card",
   "isabellaalstrom/lovelace-grocy-chores-card",


### PR DESCRIPTION
## Checklist

- [x] I have read the [HACS contribution guidelines](https://hacs.xyz/docs/publish/plugin)
- [x] The repository has a `hacs.json` file
- [x] The repository has at least one release
- [x] The `agentdvr-card.js` is attached to the release
- [x] The README is complete and in English

## About this plugin

**Repository:** https://github.com/ipod86/lovelace-agentdvr-card

A Lovelace custom card for Home Assistant that displays [AgentDVR](https://www.ispyconnect.com/) recordings as a responsive thumbnail gallery with a built-in lightbox video player.

**Features:**
- Thumbnail gallery with configurable tile size
- Date grouping (Today / Yesterday / weekday / date)
- Relative time display
- Lightbox player with prev/next navigation and keyboard control
- Live camera tile with animated status badge (Live / REC / Offline)
- Search & tag filter (collapsible)
- Smart auto-refresh with diff detection
- Graphical editor in Lovelace (no YAML required)
- Multi-language (German / English, auto-detected from HA locale)
- Theme-aware (all colors from active Lovelace theme)