### PR TITLE
Add DelBierzo/porcentaje_panadero integration

### DIFF
--- a/integration
+++ b/integration
@@ -569,6 +569,7 @@
   "Dekadinious/trsdm_custom_device_tracker_for_home_assistant",
   "DeKaN/ha-boneco",
   "deler-aziz/fuel_prices_sweden",
+  "DelBierzo/porcentaje_panadero",
   "delize/home-assistant-loggamera-integration",
   "delphiki/hass-pronote",
   "delphiki/hass-tarif-edf",


### PR DESCRIPTION
Add DelBierzo/porcentaje_panadero integration

## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Description
Hi! I would like to add my custom integration "Baker's Percentage" (`porcentaje_panadero`) to the HACS default list. It complies with all `hacs.json` and structural requirements. Thank you!

## Links

Link to current release: https://github.com
Link to successful HACS action (without the `ignore` key): https://github.com
Link to successful hassfest action (if integration): https://github.com
