### PR TITLE
Add theharshl/htd-ha-card

### DIFF
--- a/plugin
+++ b/plugin
@@ -526,6 +526,7 @@
   "tcarlsen/lovelace-light-with-profiles",
   "tdvtdv/ha-tdv-bar",
   "teuchezh/dynamic-weather-card",
+  "theharshl/htd-ha-card",
   "TheLuXoR/calendar-week-card",
   "TheRealEiskaffee/brightness-overlay",
   "TheScubadiver/camera-gallery-card",


### PR DESCRIPTION
## Description

Adds `theharshl/htd-ha-card` to the plugin (Dashboard) list.

This is a Lovelace dashboard card for controlling a single HTD (Home Theater Direct) whole-home audio zone via the [htd-home-assistant](https://github.com/theharshl/htd-home-assistant) integration.

## Checklist

- [x] `hacs.json` present in repository root
- [x] `dist/htd-zone-card.js` present (filename specified in `hacs.json`)
- [x] GitHub release published (v0.1.0) with JS asset attached
- [x] Repository is public
- [x] GitHub topics set (`home-assistant`, `hacs`, `lovelace`, `lovelace-card`, etc.)
- [x] README with installation instructions and screenshot

## Repository

https://github.com/theharshl/htd-ha-card