### PR TITLE
Add marcintk/ha-planetary-solar-system-card

### DIFF
--- a/plugin
+++ b/plugin
@@ -340,6 +340,7 @@
   "mampfes/ha-knx-uf-iconset",
   "ManfredTremmel/lovelace-heat-pump-card",
   "marcelhoogantink/enhanced-shutter-card",
+  "marcintk/ha-planetary-solar-system-card",
   "marcokreeft87/formulaone-card",
   "Mariusthvdb/custom-attributes",
   "Mariusthvdb/custom-icon-color",
@@ -608,3 +609,4 @@
   "zanna-37/hass-swipe-navigation",
   "zeronounours/lovelace-energy-entity-row"
 ]
+


### PR DESCRIPTION
## Add marcintk/ha-planetary-solar-system-card

Home Assistant Lovelace card showing all 8 planets, Moon and comet Halley aligned around the Sun with real ephemeris data. Supports time navigation, zoom, and pan.

- **Category**: plugin
- **Repository**: https://github.com/marcintk/ha-planetary-solar-system-card
- **Demo**: https://marcintk.github.io/ha-planetary-solar-system-card/