### PR TITLE
Add atvnotif/atvnotif-hass

### DIFF
--- a/integration
+++ b/integration
@@ -207,6 +207,7 @@
   "Athozs/hass-additional-ca",
   "attilaszasz/vonage-homeassistant",
   "aturri/ha-zcsazzurro",
+  "atvnotif/atvnotif-hass",
   "atxbyea/samsungrac",
   "atymic/project_three_zero_ha",
   "audiconnect/audi_connect_ha",


### PR DESCRIPTION
Adding Android TV Notifier integration to HACS default integrations list. The repository is compatible with HACS and has the hacs.json file.