### PR TITLE
Add technoo10201/hacs-aps-ds3

### DIFF
--- a/integration
+++ b/integration
@@ -2152,6 +2152,7 @@
   "tcareyintx/skybellgen",
   "tcarwash/home-assistant_noaa-space-weather",
   "tdragon/reef-pi-hass-custom",
+  "technoo10201/hacs-aps-ds3",
   "tefinger/hass-brematic",
   "teh-hippo/ha-govee-led-ble",
   "teh-hippo/ha-porkbun",


### PR DESCRIPTION
Adds `technoo10201/hacs-aps-ds3`, a Home Assistant custom integration for APsystems DS3 micro-inverters using a direct CC2530+CC2591 Zigbee dongle running Kadsol firmware. No ECU, no cloud, no ESP32 bridge — local polling over USB serial. Config flow with EN+FR translations, integration type `hub`, IoT class `local_polling`.

- Repo: https://github.com/technoo10201/hacs-aps-ds3
- Latest release: v0.2.0 (https://github.com/technoo10201/hacs-aps-ds3/releases/tag/v0.2.0)
- License: MIT
