### PR TITLE
Adds new integration [technoo10201/ha-apsystems-ds3]

### DIFF
--- a/integration
+++ b/integration
@@ -2152,6 +2152,7 @@
   "tcareyintx/skybellgen",
   "tcarwash/home-assistant_noaa-space-weather",
   "tdragon/reef-pi-hass-custom",
+  "technoo10201/ha-apsystems-ds3",
   "tefinger/hass-brematic",
   "teh-hippo/ha-govee-led-ble",
   "teh-hippo/ha-porkbun",


### PR DESCRIPTION
Adds `technoo10201/ha-apsystems-ds3`, a Home Assistant custom integration for APsystems DS3 micro-inverters using a direct CC2530+CC2591 Zigbee dongle running Kadsol firmware. No ECU, no cloud, no ESP32 bridge — local polling over USB serial. Config flow with EN+FR translations, integration type `hub`, IoT class `local_polling`.

## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

- Repo: https://github.com/technoo10201/ha-apsystems-ds3
- Link to current release: https://github.com/technoo10201/ha-apsystems-ds3/releases/tag/v0.2.1
- Link to successful HACS action (without the `ignore` key): https://github.com/technoo10201/ha-apsystems-ds3/actions/workflows/validate.yml
- Link to successful hassfest action (if integration): https://github.com/technoo10201/ha-apsystems-ds3/actions/workflows/validate.yml
- License: MIT
