### PR TITLE
Add FARRUXMAYOR/ha-namoz-vaqtlari

### DIFF
--- a/integration
+++ b/integration
@@ -743,6 +743,7 @@
   "faizpuru/ha-meteofrance-montagne",
   "faizpuru/ha-pilot-wire-climate",
   "fapfaff/homeassistant-appwash",
+  "FARRUXMAYOR/ha-namoz-vaqtlari",
   "FaserF/ha-boulderwelt",
   "FaserF/ha-chefkoch",
   "FaserF/ha-db_infoscreen",


### PR DESCRIPTION
## Description
Custom integration for Islamic prayer times in Uzbekistan.

## Repository
https://github.com/FARRUXMAYOR/ha-namoz-vaqtlari

## Features
- Prayer times for 12 cities in Uzbekistan (Tashkent, Samarkand, Bukhara, etc.)
- 4 calculation methods
- 6 sensors per city: Fajr, Sunrise, Dhuhr, Asr, Maghrib, Isha
- Daily auto-update via aladhan.com open API
- UI config flow (city and method selection)
- Uzbek and English translations

## Checklist
- [x] The repository has a v1.0.0 release
- [x] The repository has the \hacs\ topic
- [x] The integration uses config_flow
- [x] Has translations (uz, en)