### PR TITLE
Add seadillpicklerooster/hass-lea-amp

### DIFF
--- a/integration
+++ b/integration
@@ -1966,6 +1966,7 @@
   "Sdahl1234/Sunseeker-lawn-mower",
   "SDR3078/ps3-home-assistant",
   "sdrapha/home-assistant-custom-components-pfsense-gateways",
+  "seadillpicklerooster/hass-lea-amp",
   "seanharsh/HA-DelOH-Refuse-Schedule",
   "seanmccabe/bgg-sync",
   "Seba101288/home-assistant-ever-ups",


### PR DESCRIPTION
Adds the **LEA Professional amplifiers** integration (`lea_amp`).

- Repo: https://github.com/seadillpicklerooster/hass-lea-amp
- Local-polling integration for LEA Connect-series networked amps (leaApi WebSocket, no cloud).
- Passes the HACS Action + hassfest (CI green); bundled brand icon; v1.0.1 release.