### PR TITLE
Add zyjsmile857/mofei_mqtt_bridge integration

### DIFF
--- a/integration
+++ b/integration
@@ -2415,5 +2415,6 @@
   "zubir2k/homeassistant-esolattakwim",
   "zulufoxtrot/ha-zyxel",
   "zupancicmarko/JellyHA",
-  "Zwer2k/ha-pca301"
+  "Zwer2k/ha-pca301",
+  "zyjsmile857/mofei_mqtt_bridge"
 ]


### PR DESCRIPTION
## Summary

Add `zyjsmile857/mofei_mqtt_bridge` to HACS default integrations.

Mofei MQTT Bridge is a Home Assistant integration that maps Mofei smart home commands to callable entities and sends control messages via MQTT.

## Checklist

- [x] I have checked that this repository is not in the [blacklist](https://github.com/hacs/default/blob/master/blacklist)
- [x] I have checked that this repository is not already in the default list
- [x] I have checked that this repository meets the [requirements](https://hacs.xyz/docs/publish/include#requirements)

## Repository links

- Repository: https://github.com/zyjsmile857/mofei_mqtt_bridge
- Latest release: https://github.com/zyjsmile857/mofei_mqtt_bridge/releases/tag/v0.1.0
- CI runs: https://github.com/zyjsmile857/mofei_mqtt_bridge/actions