### PR TITLE
Add zyjsmile857/mofei-remote-card plugin

### DIFF
--- a/plugin
+++ b/plugin
@@ -606,5 +606,6 @@
   "yuri-val/th-sensor-card",
   "zanac/temperature-heatmap-card",
   "zanna-37/hass-swipe-navigation",
-  "zeronounours/lovelace-energy-entity-row"
+  "zeronounours/lovelace-energy-entity-row",
+  "zyjsmile857/mofei-remote-card"
 ]


### PR DESCRIPTION
## Summary

Add `zyjsmile857/mofei-remote-card` to HACS default plugins.

Mofei Remote Card is a Lovelace custom card for Mofei smart home remote control, with built-in page switching for scenes, media, facilities, and KTV.

## Checklist

- [x] I have checked that this repository is not in the [blacklist](https://github.com/hacs/default/blob/master/blacklist)
- [x] I have checked that this repository is not already in the default list
- [x] I have checked that this repository meets the [requirements](https://hacs.xyz/docs/publish/include#requirements)

## Repository links

- Repository: https://github.com/zyjsmile857/mofei-remote-card
- Latest release: https://github.com/zyjsmile857/mofei-remote-card/releases/tag/v0.1.0