### PR TITLE
Add brentb2529/ha-mitsubishi-ae200

### DIFF
--- a/integration
+++ b/integration
@@ -328,6 +328,7 @@
   "bremor/bonaire_myclimate",
   "bremor/bureau_of_meteorology",
   "bremor/public_transport_victoria",
+  "brentb2529/ha-mitsubishi-ae200",
   "brewmarsh/meraki-homeassistant",
   "brezlord/hass-waterco-electrochlor",
   "brianegge/home-assistant-sdnotify",


### PR DESCRIPTION
## Add custom integration: brentb2529/ha-mitsubishi-ae200

Home Assistant integration for **Mitsubishi Electric City Multi VRF systems** via the AE-200E / EW-50E local API (WebSocket, no cloud dependency).

**Domain:** `ae200`
**Repository:** https://github.com/brentb2529/ha-mitsubishi-ae200

### Eligibility checklist

- [x] `hacs.json` present
- [x] `manifest.json`: domain `ae200`, version `1.2.1`, `config_flow: true`, `iot_class: local_polling`, `codeowners: [@brentb2529]`
- [x] `documentation` and `issue_tracker` in manifest
- [x] README present
- [x] Tags present (`v1.2.1`, `v1.2.0`, `v1.1.0`)
- [ ] GitHub Release for `v1.2.1`: tag exists, release object pending creation
- [x] Issues enabled
- [x] Topics: `home-assistant`, `hacs`, `climate`, `hvac`, `mitsubishi`

### Note

A GitHub Release object needs to be created from the existing `v1.2.1` tag before the Releases check will pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)