### PR TITLE
Add brentb2529/ha-akvo-floor

### DIFF
--- a/integration
+++ b/integration
@@ -328,6 +328,7 @@
   "bremor/bonaire_myclimate",
   "bremor/bureau_of_meteorology",
   "bremor/public_transport_victoria",
+  "brentb2529/ha-akvo-floor",
   "brewmarsh/meraki-homeassistant",
   "brezlord/hass-waterco-electrochlor",
   "brianegge/home-assistant-sdnotify",


### PR DESCRIPTION
## Add custom integration: brentb2529/ha-akvo-floor

Home Assistant integration for **AKVO Spiralift movable pool floors** via Modbus (monitor + PLC-validated presets, read-heavy, actuation gated).

**Domain:** `akvo`
**Repository:** https://github.com/brentb2529/ha-akvo-floor

### Eligibility checklist

- [x] `hacs.json` present
- [x] `manifest.json`: domain `akvo`, version `0.3.1`, `config_flow: true`, `iot_class: local_polling`, `codeowners: [@bbensten]`
- [x] `documentation` in manifest
- [x] README present
- [x] Tags present (`v0.3.1`, `v0.3.0`, `v0.2.0`)
- [ ] GitHub Release for `v0.3.1`: tag exists, release object pending creation
- [x] Issues enabled
- [x] Topics: `home-assistant`, `hacs`, `modbus`, `pool`

### Note

A GitHub Release object needs to be created from the existing `v0.3.1` tag before the Releases check will pass. The manifest is also missing an `issue_tracker` field (issues are enabled on the repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)