### PR TITLE
Adds new integration [brentb2529/ha-mitsubishi-ae200]

### DIFF
--- a/integration
+++ b/integration
@@ -328,6 +328,7 @@
   "bremor/bonaire_myclimate",
   "bremor/bureau_of_meteorology",
   "bremor/public_transport_victoria",
+  "brentb2529/ha-mitsubishi-ae200",
   "brewmarsh/meraki-homeassistant",
   "brezlord/hass-waterco-electrochlor",
   "brianegge/home-assistant-sdnotify",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/brentb2529/ha-mitsubishi-ae200/releases/tag/v1.2.2>
Link to successful HACS action (without the `ignore` key): <https://github.com/brentb2529/ha-mitsubishi-ae200/actions/runs/27217858953/job/80364337039>
Link to successful hassfest action (if integration): <https://github.com/brentb2529/ha-mitsubishi-ae200/actions/runs/27217858953/job/80364337145>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->