### PR TITLE
Add CoreTex/homeassistant-eebus

### DIFF
--- a/integration
+++ b/integration
@@ -435,6 +435,7 @@
   "connorgallopo/Superior-Plus-Propane",
   "contextablemark/home-agui-agent",
   "CooLajz/ha-zivy-obraz",
+  "CoreTex/homeassistant-eebus",
   "corporategoth/ha-powerpetdoor",
   "cowboyrushforth/home-assistant-molekule",
   "cozify/han-home-assistant",


### PR DESCRIPTION
Adds the EEBUS integration: an EEBUS (SHIP/SPINE) bridge for Home Assistant (LPC/LPP limit handling, MPC monitoring, inverter/battery via VAPD/VABD).

- Repo: https://github.com/CoreTex/homeassistant-eebus
- Category: integration
- Passes HACS Action + Hassfest in CI
- Has full releases (latest v0.1.5)
- Ships a local brand icon at custom_components/eebus/brand/icon.png
- Repository has description and topics set