### PR TITLE
Adds new integration [MichelFR/ha-abrp]

### DIFF
--- a/integration
+++ b/integration
@@ -1474,6 +1474,7 @@
   "michaeldwan/ha-cloudflare-ai-gateway",
   "michaellunzer/Home-Assistant-Custom-Component-Fortnite",
   "MichaelPihlblad/flowerhub_homeassistant_integration",
+  "MichelFR/ha-abrp",
   "MichelFR/ha_ghostfolio",
   "Michsior14/ha-venta",
   "mickeyschwab/haven-hass",


### PR DESCRIPTION
Adds [MichelFR/ha-abrp](https://github.com/MichelFR/ha-abrp).

**ABRP** — an unofficial integration for [A Better Route Planner](https://abetterrouteplanner.com). It reads a vehicle's live telemetry *from* ABRP (via an OBD2 dongle or a connected cloud provider) and exposes it as Home Assistant entities, plus editable route-planning preferences.

- Public repository, addable as a custom repository.
- HACS Action + Hassfest pass.
- Full GitHub releases published (latest `v0.2.0`).
- Ships local brand images (`custom_components/abrp_mate/brand/icon.png`).
