### PR TITLE
Add TeroPihlaja/electrolux_ac

### DIFF
--- a/integration
+++ b/integration
@@ -2157,6 +2157,7 @@
   "teh-hippo/ha-porkbun",
   "tehlers/ha-drooff-fireplus",
   "TekniskSupport/home-assistant-resrobot",
+  "TeroPihlaja/electrolux_ac",
   "tetele/hvac_group",
   "TetianaKolpakova/save_eco_bot_air_quality",
   "tggm/rointe-radiators",


### PR DESCRIPTION
## Add TeroPihlaja/electrolux_ac

Adding the Electrolux AC integration for Home Assistant.

- **Repository:** https://github.com/TeroPihlaja/electrolux_ac
- **Integration type:** custom_component
- **Description:** Home Assistant integration for Electrolux portable air conditioners (COMFORT600/AZUL) via the Electrolux OneApp OCP API