### PR TITLE
Add prezervos/goodwe-wallbox-sems-home-assistant

### DIFF
--- a/integration
+++ b/integration
@@ -1780,6 +1780,7 @@
   "prairiesnpr/hass-tdameritrade",
   "pranjal-joshi/moodlights",
   "prestomation/resmed_myair_sensors",
+  "prezervos/goodwe-wallbox-sems-home-assistant",
   "PrimeAutomation/petnovations",
   "princekama/home-assistant-rako",
   "Prosono/SMARTi_BaseComponent",


### PR DESCRIPTION
## Checklist

- [x] I am the owner or a major contributor of the repository being submitted.
- [x] The repository is public and hosted on GitHub.
- [x] The repository has a description.
- [x] The repository has issues enabled.
- [x] The repository has topics defined.
- [x] The [HACS Action](https://github.com/hacs/action) GitHub Action passes without errors.
- [x] The [Hassfest](https://github.com/home-assistant/actions#hassfest) GitHub Action passes without errors.
- [x] At least one GitHub release has been created.
- [x] The entry is added in alphabetical order.

## Repository

**Link:** https://github.com/prezervos/goodwe-wallbox-sems-home-assistant

**Type:** Integration (custom component)

**Description:** Home Assistant integration for GoodWe EV wallbox chargers. Supports local Modbus control and GoodWe SEMS cloud API. Allows monitoring and controlling GoodWe/Solarman EV chargers directly from Home Assistant.

**Category:** `integration`

## Notes

- The integration domain is `sems_wallbox`.
- Supports both local Modbus polling and cloud SEMS API control.
- Co-owned by @prezervos and @pedrodivisez (I am a major contributor / co-owner).