### PR TITLE
Add mac-lucky/pushward-hass

### DIFF
--- a/integration
+++ b/integration
@@ -1361,6 +1361,7 @@
   "lymanepp/ha-epson-workforce",
   "M1R4G376/New_bestway_spa",
   "m3tac0de/home-assistant-sofabaton-x1s",
+  "mac-lucky/pushward-hass",
   "mac8005/xiaozhi-mcp-ha",
   "maciej-or/hikvision_next",
   "macxq/foxess-ha",


### PR DESCRIPTION
Adds the `pushward` custom integration.

- **Repository:** https://github.com/mac-lucky/pushward-hass
- **Domain:** `pushward` (integration type: service, `cloud_push`)
- **What it does:** mirrors Home Assistant entities and automations to iPhone Live Activities (Dynamic Island + Lock Screen) and notifications, via the hosted PushWard API.

Requirements:
- [x] Public repo, not archived, with description, topics, and issues enabled
- [x] `hacs.json` with `name`
- [x] `manifest.json` with domain, name, codeowners, documentation, issue_tracker, version
- [x] HACS Action + hassfest pass
- [x] Published GitHub releases (latest v0.23.0)
- [x] Brand icon shipped in-component (`custom_components/pushward/icon.png` + `icon@2x.png`) per HA 2026.3.0 (home-assistant/brands no longer accepts custom-integration icons)
- [x] Added to `integration` alphabetically