### PR TITLE
Add nishithdev/wled-taskmap (integration)

### DIFF
--- a/integration
+++ b/integration
@@ -1626,6 +1626,7 @@
   "NinDTendo/homeassistant_gradual_volume_control",
   "NinDTendo/tobi",
   "NirBY/ha-mashov",
+  "nishithdev/wled-taskmap",
   "nitaybz/optimistic_feedback",
   "njobrien1006/hass_traeger",
   "nkvoll/home-assistant-qsys-qrc",


### PR DESCRIPTION
## Add nishithdev/wled-taskmap (integration)

**Repository:** https://github.com/nishithdev/wled-taskmap

WLED Task Map maps Home Assistant entities, to-do lists, and errors to individual LEDs on a WLED strip, configured through a bundled visual Lovelace card (tap LEDs, pick entity/states/color — no YAML). Features include zeroconf discovery, per-LED gradients and fill (progress-bar) effects, quiet hours, flap protection, Repairs integration, and Logbook history.

Resubmission of #8387: the hassfest DEPENDENCIES error (logbook not declared) is fixed in release 0.12.1 (`after_dependencies: ["logbook"]`).

### Checklist
- [x] HACS-compatible repository structure (`custom_components/wled_taskmap`, `hacs.json` at root)
- [x] `manifest.json` with domain, name, codeowners, version, documentation, issue tracker
- [x] Config flow + zeroconf discovery; no YAML required
- [x] Tagged releases (current: 0.12.1)
- [x] Repository has a description and topics
- [x] README with installation and usage documentation, plus full docs in `docs/documentation.md`
- [x] Brand images ship inside the integration (`brand/` folder, HA 2026.3+ local brand images)
- [x] I am the owner of the repository