### PR TITLE
Adds new integration [poli44poli44poli44-web/aquael_aquarium_integration]

### DIFF
--- a/integration
+++ b/integration
@@ -1766,6 +1766,7 @@
   "Pocke01/homeassistant-solamagic",
   "Poeschl/Remote-PicoTTS",
   "poldim/EG4-Inverter-Modbus",
+  "poli44poli44poli44-web/aquael_aquarium_integration",
   "popeen/Home-Assistant-Custom-Component-Brandrisk-Eldningsforbud",
   "popeen/Home-Assistant-Custom-Component-Hemglass",
   "popeen/Home-Assistant-Custom-Component-Luncha-I-Mjardevi",


### PR DESCRIPTION
## Links

- Repository: https://github.com/poli44poli44poli44-web/aquael_aquarium_integration
- Latest release: https://github.com/poli44poli44poli44-web/aquael_aquarium_integration/releases/tag/v0.0.1
- CI action runs: https://github.com/poli44poli44poli44-web/aquael_aquarium_integration/actions

## Description

Unofficial Home Assistant integration for Aquael aqu@rium / Aquael Link devices.

Works locally over LAN (UDP) — no cloud required.

**Supported devices:**
- HyperMAX Link ECU
- Thermometer Link
- Light Link
- Socket Link Duo