### PR TITLE
Adds new integration silenthooligan/localsky-hacs

### DIFF
--- a/integration
+++ b/integration
@@ -2010,6 +2010,7 @@
   "Sian-Lee-SA/Home-Assistant-Switch-Manager",
   "sibest19/hass-meteoam",
   "signalkraft/mypyllant-component",
+  "silenthooligan/localsky-hacs",
   "sillyfrog/Automate-Pulse-v2",
   "sillymoi/homeassistant-infometric",
   "silvanfischer/tuya_sensors",


### PR DESCRIPTION
Home Assistant integration for LocalSky, a self-hosted local-first weather + smart irrigation server.

- Repository: https://github.com/silenthooligan/localsky-hacs
- Release: v0.6.0
- Docs: https://localsky.io/docs/hacs
- Brands PR: <link the PR from step 2>

Checklist: hacs.json present, GitHub release published, repo public, issues enabled, README rendered.