### PR TITLE
Adds new integration silenthooligan/localsky-hacs

### DIFF
--- a/integration
+++ b/integration
@@ -2010,6 +2010,7 @@
   "Sian-Lee-SA/Home-Assistant-Switch-Manager",
   "sibest19/hass-meteoam",
   "signalkraft/mypyllant-component",
+  "silenthooligan/localsky-hacs",
   "sillyfrog/Automate-Pulse-v2",
   "sillymoi/homeassistant-infometric",
   "silvanfischer/tuya_sensors",


### PR DESCRIPTION
Home Assistant integration for LocalSky, a self-hosted local-first weather + smart irrigation server.

- Repository: https://github.com/silenthooligan/localsky-hacs
- Latest release: v0.6.1
- Documentation: https://localsky.io/docs/hacs
- Brand assets: shipped in-repo per the HA 2026.3 mechanism (custom_components/localsky/brand/)

Previous submission (#8398) was closed by the bot on validation failures that are fixed in v0.6.1: brand assets now ship inside the integration, and the hassfest translation errors (URLs in error strings) are resolved.