### PR TITLE
Add samilbeden/ha-tplink-cpe

### DIFF
--- a/integration
+++ b/integration
@@ -1923,6 +1923,7 @@
   "rzulian/lutron_lip",
   "salihinsaealal/home-assistant-tnb-calculator",
   "SamAthanas/user-rbac",
+  "samilbeden/ha-tplink-cpe",
   "samjsmart/ha-zone4",
   "samoswall/polaris-mqtt",
   "samspade21/vacasa-ha",


### PR DESCRIPTION
Adds the **TP-Link CPE (SSH)** integration (`tplink_cpe`).

- Repository: https://github.com/samilbeden/ha-tplink-cpe
- Category: integration
- Monitors TP-Link Pharos CPE devices over SSH (sensors) and reboots them via the device web API; multiple devices via config flow.
- Passes the HACS Action (hassfest + HACS validation) and ships brand assets under `custom_components/tplink_cpe/brand/`.
- Latest release: v0.3.0. Tested on CPE220 and CPE510.