### PR TITLE
Add dercvne_bus integration

### DIFF
--- a/integration
+++ b/integration
@@ -2415,5 +2415,6 @@
   "zubir2k/homeassistant-esolattakwim",
   "zulufoxtrot/ha-zyxel",
   "zupancicmarko/JellyHA",
-  "Zwer2k/ha-pca301"
+  "Zwer2k/ha-pca301",
+  "Benjamin-LY777/dercvne_bus"
 ]


### PR DESCRIPTION
Add Dercvne Bus integration for Home Assistant.

This integration provides support for Dercvne Bus smart home devices including:
- Relay control
- Single color and CCT lighting
- Curtain control
- Keypad panels
- Occupancy sensors
- IO modules
- VRV air conditioning
- Thermostat panels
- DALI scenes