### PR TITLE
Adds new plugin [rudizl/platinum-weather-card-plus-charts]

### DIFF
--- a/plugin
+++ b/plugin
@@ -473,6 +473,7 @@
   "roman-16/better-miflora-card",
   "RomRider/apexcharts-card",
   "royto/logbook-card",
+  "rudizl/platinum-weather-card-plus-charts",
   "rusty4444/recently-added-media-card",
   "s5zone/weasley-clock-card",
   "SalvatoreITA/domhouse-weather-card",


### PR DESCRIPTION
## Checklist

- [x] I am the owner of the repository being submitted, or a significant contributor
- [x] The repository is public and hosted on GitHub
- [x] The repository has a description
- [x] The repository has topics defined
- [x] The repository has issues enabled
- [x] The repository has a README with information about usage and screenshots
- [x] `hacs.json` is present with at least a `name` key
- [x] There is a `.js` file in the `dist/` directory matching the `filename` key in `hacs.json`
- [x] The [HACS Action](https://github.com/hacs/action) passes without errors or ignores
- [x] There is at least one GitHub release
- [x] The entry is added alphabetically

## Description

**Platinum Weather Card Plus Charts** is a mashup of two popular but unmaintained HA weather cards — [Platinum Weather Card](https://github.com/tommyjlong/platinum-weather-card) and [Weather Chart Card](https://github.com/mlamberts78/weather-chart-card).

Key features over the originals:
- **Integrated Charts section** — temperature lines (max/min) and precipitation bars rendered directly below the daily forecast strip
- **Hover tooltips** on both forecast columns and chart columns — date, condition, max/min temp (colored), precipitation, wind
- **Multiple icon packs** — built-in animated SVG, Meteocons Fill/Line (MIT, CDN), amCharts Weather Icons (CC BY 4.0), or custom path
- **Full editor i18n** — 112 strings in EN + BG; locale dropdown for 12 languages
- **HA 2026.5/2026.6 compatible** — `ha-input`, WebAwesome tokens, no deprecated components
- Active maintenance with GitHub CI (HACS action + build check on every push)