### PR TITLE
Add WeatherWise plugin

### DIFF
--- a/plugin
+++ b/plugin
@@ -529,6 +529,7 @@
   "TheLuXoR/calendar-week-card",
   "TheRealEiskaffee/brightness-overlay",
   "TheScubadiver/camera-gallery-card",
+  "TheWillMiller/weather-wise",
   "tholgir/TodoIst-Task-List",
   "thomasloven/lovelace-auto-entities",
   "thomasloven/lovelace-badge-card",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/).
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: https://github.com/TheWillMiller/weather-wise/releases/tag/v0.2.0-beta.8
Link to successful HACS action (without the `ignore` key): https://github.com/TheWillMiller/weather-wise/actions/runs/27413770092
Link to successful hassfest action (if integration): Not applicable, this is a dashboard plugin.

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->