### PR TITLE
Adds new theme [jbsky/ha-glass-dashboard]

### DIFF
--- a/theme
+++ b/theme
@@ -48,6 +48,7 @@
   "home-assistant-community-themes/vaporwave-pink",
   "houtknots/UglyChristmas-Theme",
   "iosue-iulianus/homeassistant-pipboy-theme",
+  "jbsky/ha-glass-dashboard",
   "JOHLC/transparentblue",
   "JuanMTech/google-theme",
   "JuanMTech/google_dark_theme",


### PR DESCRIPTION
## Repository: [jbsky/ha-glass-dashboard](https://github.com/jbsky/ha-glass-dashboard)

### Description
Glass-morphism theme for Home Assistant with weather-reactive backgrounds (15 conditions, sun-aware) and 33 button-card templates as reusable components.

### Features
- Dynamic backgrounds for 15 weather conditions (day/night aware)
- Glass-morphism via card-mod (backdrop-filter blur on all ha-cards)
- 33 button-card templates (climate widget, cover, garage, remote, graphs, sensors)
- HACS compatible with proper hacs.json
- MIT licensed
- Released as v1.0.0

### Checklist
- [x] The repository has a description
- [x] The repository has topics set (home-assistant, hacs, theme, lovelace, glass-morphism, button-card, dashboard, smart-home)
- [x] The repository has a release with a tag (v1.0.0)
- [x] The repository has a hacs.json file
- [x] The repository is not a fork
- [x] The repository is not archived
- [x] The theme file exists in the expected location