### PR TITLE
Add cnc-lasercraft/ha-theme-studio

### DIFF
--- a/integration
+++ b/integration
@@ -418,6 +418,7 @@
   "Cmajda/ha_golemio",
   "CMGeorge/homeassistant_sabiana_smart_energy",
   "cmgrayb/hass-dyson",
+  "cnc-lasercraft/ha-theme-studio",
   "cnecrea/cursbnr",
   "cnecrea/eonromania",
   "cnecrea/erovinieta",


### PR DESCRIPTION
Adds the **Theme Studio** integration to the HACS default list.

- Repository: https://github.com/cnc-lasercraft/ha-theme-studio
- Category: integration
- A graphical editor for Home Assistant themes — manages all CSS variables with live preview, JSON-schema plugins (HA core, Bubble Card, Mushroom), and a HACS-aware fork-guard (derive/edit/delete forks, set default, merge upstream).

Checklist:
- [x] Public repository, not archived, issues enabled
- [x] Description and topics set
- [x] `custom_components/theme_studio/manifest.json` valid (domain, name, documentation, issue_tracker, codeowners, version, iot_class)
- [x] `hacs.json` with `name`
- [x] Released (latest tag `v1.1.0`)
- [x] Brand assets present (`custom_components/theme_studio/brand/icon.png` + `icon@2x.png`)
- [x] Repo passes the HACS validation workflow (`hacs/action`, category `integration`) — all checks green