### PR TITLE
Add homeassistant-discord to integration list

### DIFF
--- a/integration
+++ b/integration
@@ -263,6 +263,7 @@
   "Bennett-Wendorf/hass-uplift-desk",
   "bennydiamond/vertiv_powerassist",
   "BenPru/novus300_Rs485",
+  "bensonrodney/homeassistant-discord",
   "benvanmierloo/ha-vitotrol",
   "benwittbrodt/Metra-Tracker",
   "Beormund/tascam-bdmp4k",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [y] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [y] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [y] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [y] The actions are passing without any disabled checks in my repository.
- [y] I've added a link to the action run on my repository below in the links section.
- [y] I've created a new release of the repository after the validation actions were run successfully.

## Links
<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/bensonrodney/homeassistant-discord/releases/tag/1.0.0>
Link to successful HACS action (without the `ignore` key): <https://github.com/bensonrodney/homeassistant-discord/actions/runs/27459500474>
Link to successful hassfest action (if integration): <https://github.com/bensonrodney/homeassistant-discord/actions/runs/27459500463>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->