### PR TITLE
Add PXLJAKE/ROI-Tracker (integration)

### DIFF
--- a/integration
+++ b/integration
@@ -1789,6 +1789,7 @@
   "PTST/LibreView-HomeAssistant",
   "pveiga90/What-s-up-Docker-Updates-Monitor",
   "pvyleta/xcc-integration",
+  "PXLJAKE/ROI-Tracker",
   "py-smart-gardena/hass-gardena-smart-system",
   "pyalarmdotcom/alarmdotcom",
   "Pyhass/Hive-Custom-Component",


### PR DESCRIPTION
## Repository

https://github.com/PXLJAKE/ROI-Tracker

**Category:** Integration
**Domain:** `roi_tracker`

ROI Tracker is a return-on-investment calculator for solar PV systems in Home Assistant: amortization progress, savings from self-consumption and battery, feed-in revenue, break-even forecast – with support for dynamic price sensors (e.g. Tibber) and an included Lovelace dashboard card.

## Checklist

- [x] The repository is not a fork
- [x] First stable release published: [v0.3.0](https://github.com/PXLJAKE/ROI-Tracker/releases/tag/v0.3.0)
- [x] HACS Action (`hacs/action`) and hassfest run in CI and pass: [workflow](https://github.com/PXLJAKE/ROI-Tracker/actions/workflows/validate.yml)
- [x] Repository has a description and topics
- [x] README with installation and configuration documentation
- [x] Brands PR submitted: home-assistant/brands#10517
- [x] Added in alphabetical order to the `integration` file

🤖 Generated with [Claude Code](https://claude.com/claude-code)