### PR TITLE
Add cnc-lasercraft/ha-theme-studio

### DIFF
--- a/integration
+++ b/integration
@@ -418,6 +418,7 @@
   "Cmajda/ha_golemio",
   "CMGeorge/homeassistant_sabiana_smart_energy",
   "cmgrayb/hass-dyson",
+  "cnc-lasercraft/ha-theme-studio",
   "cnecrea/cursbnr",
   "cnecrea/eonromania",
   "cnecrea/erovinieta",


### PR DESCRIPTION
Adds the **Theme Studio** integration to the HACS default list. (Resubmission of #8459 after packaging fixes.)

- Repository: https://github.com/cnc-lasercraft/ha-theme-studio
- Category: integration
- A graphical editor for Home Assistant themes — manages all CSS variables with live preview, JSON-schema plugins (HA core, Bubble Card, Mushroom), and a HACS-aware fork-guard.

Fixes since #8459 (released as v1.1.1):
- Brand assets now shipped in the release at `custom_components/theme_studio/brand/icon.png` + `icon@2x.png`.
- Frontend plugin metadata renamed `manifest.json` → `plugin.json`, so the repo contains exactly one `manifest.json` (the integration).

Checklist:
- [x] Public repo, not archived, issues enabled, description + topics
- [x] Valid `custom_components/theme_studio/manifest.json` + `hacs.json`
- [x] Released (latest `v1.1.1`)
- [x] Brand assets present
- [x] Passes `hacs/action` (category integration)