### PR TITLE
Add cnc-lasercraft/ha-theme-studio

### DIFF
--- a/integration
+++ b/integration
@@ -418,6 +418,7 @@
   "Cmajda/ha_golemio",
   "CMGeorge/homeassistant_sabiana_smart_energy",
   "cmgrayb/hass-dyson",
+  "cnc-lasercraft/ha-theme-studio",
   "cnecrea/cursbnr",
   "cnecrea/eonromania",
   "cnecrea/erovinieta",


### PR DESCRIPTION
Adds the **Theme Studio** integration (graphical HA theme editor). Resubmission after packaging + hassfest fixes (now v1.1.2). Repo passes hacs/action + hassfest; brand assets shipped in-repo; exactly one manifest.json.