### PR TITLE
Add ernetas/junghome

### DIFF
--- a/integration
+++ b/integration
@@ -717,6 +717,7 @@
   "eriknn/ha-pax_ble",
   "ErilovNikita/ha-domru",
   "ErilovNikita/ha-yainternetometr",
+  "ernetas/junghome",
   "esbenwiberg/easyiq",
   "eseglem/hass-wattbox",
   "eseverson/hass-balena",


### PR DESCRIPTION
Adds the Jung Home integration.

- Repository: https://github.com/ernetas/junghome
- Category: integration
- HACS + hassfest validation pass on the default branch (`.github/workflows/validate.yml`)
- Brand icons merged in home-assistant/brands (live at https://brands.home-assistant.io/junghome/icon.png)
- Latest release: v1.0.0

Local integration for JUNG HOME devices via the JUNG HOME Gateway (WebSocket + REST): lights, dimmers, tunable white, sockets with energy, rocker-switch events and status LEDs.