### PR TITLE
Add cnc-lasercraft/ha-theme-studio

### DIFF
--- a/integration
+++ b/integration
@@ -418,6 +418,7 @@
   "Cmajda/ha_golemio",
   "CMGeorge/homeassistant_sabiana_smart_energy",
   "cmgrayb/hass-dyson",
+  "cnc-lasercraft/ha-theme-studio",
   "cnecrea/cursbnr",
   "cnecrea/eonromania",
   "cnecrea/erovinieta",


### PR DESCRIPTION
Graphical Home Assistant theme editor. Resubmission after fixes (now v1.1.3): passes hacs/action + hassfest, brand assets in-repo, single manifest.json, manifest keys sorted.