### PR TITLE
Adds new integration [moryoav/ha-panda]

### DIFF
--- a/integration
+++ b/integration
@@ -1786,6 +1786,7 @@
   "morosanmihail/HA-LondonTfL",
   "morotsgurka/garo-gctrl-homeassistant",
   "MortUK/Aferiy-PS240-Local-",
+  "moryoav/ha-panda",
   "mossipcams/autosnooze",
   "Motorline/ha-mconnect",
   "mousehome-net/keba_one_ev",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/moryoav/ha-panda/releases/tag/v0.1.12>
Link to successful HACS action (without the `ignore` key): <https://github.com/moryoav/ha-panda/actions/runs/28285879915>
Link to successful hassfest action (if integration): <https://github.com/moryoav/ha-panda/actions/runs/28285879923>

## Current release note

`v0.1.12` trims the HACS-installed integration package by moving optional fonts to `optional_fonts/` and publishing a lightweight `panda_esl.zip` release asset. The integration still supports user-installed fonts from `config/panda_esl/fonts/`, `config/www/fonts/`, and absolute paths.
