### PR TITLE
Adds new plugin [maxfok/nimbus-climate-scheduler]

### DIFF
--- a/integration
+++ b/integration
@@ -1449,6 +1449,7 @@
   "MattXcz/CEZ",
   "mawinkler/astroweather",
   "MaxensF/personal_weather_station",
+  "maxfok/nimbus-climate-scheduler",
   "maxi07/PicoW-Neopixel-Homeassistant-Integration",
   "Maxou44/ha-tiko-component",
   "maybetaken/Solar_Manager",


### PR DESCRIPTION
Adds [maxfok/nimbus-climate-scheduler](https://github.com/maxfok/nimbus-climate-scheduler) — a weekly heating & cooling thermostat scheduler shown as a Home Assistant sidebar panel.

- Category: **integration**
- Config flow: yes · IoT class: local_push
- Releases published (latest v0.2.4); HACS + hassfest validation green
- Brand icon shipped locally in the integration's `brand/` folder (HA 2026.3+ self-hosted brand images)

The integration registers a custom sidebar panel and a backend loop that applies saved per-zone schedules to `climate` entities.