### PR TITLE
Add hudsonbrendon/starlink-card

### DIFF
--- a/plugin
+++ b/plugin
@@ -213,6 +213,7 @@
   "homeassistant-extras/room-summary-card",
   "homeassistant-extras/toolbar-status-chips",
   "homeassistant-extras/zwave-card-set",
+  "hudsonbrendon/starlink-card",
   "Hugo0485/DoubleCurtainCard",
   "hulkhaugen/hass-bha-icons",
   "hyperb1iss/hyper-light-card",


### PR DESCRIPTION
Adds [hudsonbrendon/starlink-card](https://github.com/hudsonbrendon/starlink-card) as a Lovelace **plugin**.

An animated Lovelace card for Home Assistant's native `starlink` integration (in the spirit of vacuum-card): real Starlink Standard dish artwork with state-driven animations (online signal, obstructed, melting snow, overheating, sleeping, stowed, offline), live Download/Upload/Ping stats, GUI editor, EN + pt-BR.

- Category: `plugin`
- Release: `v1.0.0` with `starlink-card.js` attached
- `hacs.json` present, `hacs/action` validation passing on the repo
- Repository has description and topics

Checklist:
- [x] The repository is public
- [x] The repository has a description and topics
- [x] The repository has a published release
- [x] The repository passes the HACS validation action