### PR TITLE
makerwolf/ecoflow-river3-plus-usb

### DIFF
--- a/integration
+++ b/integration
@@ -1372,6 +1372,7 @@
   "maginawin/ha-azoula-smart",
   "maginawin/ha-dali-center",
   "make-all/metlink-nz",
+  "makerwolf/ecoflow-river3-plus-usb",
   "Makhuta/homeassistant-duolingo",
   "Makr91/ha_easgen",
   "malicaeus/Wigle-Stats-HA",


### PR DESCRIPTION
Adds the **EcoFlow River 3 Plus USB** integration to the HACS default store.

- Repository: https://github.com/makerwolf/ecoflow-river3-plus-usb
- Category: integration

A local, cloud-free Home Assistant integration for the EcoFlow River 3 Plus portable power station, reading battery, power and temperature data over USB (serial + HID). No EcoFlow cloud account and no MQTT required.

### Checklist
- [x] Repository has a description
- [x] Repository has topics
- [x] Repository is public and not archived/a fork
- [x] `hacs.json` and `manifest.json` are valid
- [x] Codeowner (`@makerwolf`) matches the repository owner
- [x] A published release exists (`v0.1.0`)
- [x] HACS Action and hassfest validation pass on the default branch
- [x] Brand assets submitted to home-assistant/brands