### PR TITLE
Add kedube/ha-hellofresh

### DIFF
--- a/integration
+++ b/integration
@@ -1193,6 +1193,7 @@
   "kcoffau/AUS_BOM_Space_Weather_Alert_System",
   "kcofoni/ha-netro-watering",
   "kcsoft/virtual-keys",
+  "kedube/ha-hellofresh",
   "kelvan/ha-nodeping-status",
   "kennethroe/vehiclevue",
   "kenyonj/kohler-konnect-ha",


### PR DESCRIPTION
Adds the HelloFresh integration to the default HACS store.

- Repository: https://github.com/kedube/ha-hellofresh
- Category: integration
- HACS Action + hassfest validation passing on the repo's CI
- Public repo with description, topics, published releases, hacs.json and manifest.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)