### PR TITLE
Add Fistacho/ha-netatmo-bubendorff

### DIFF
--- a/integration
+++ b/integration
@@ -766,6 +766,7 @@
   "finity69x2/nws_alerts",
   "firstof9/ha-gasbuddy",
   "firstof9/ha-openei",
+  "Fistacho/ha-netatmo-bubendorff",
   "FL550/dwd_weather",
   "flame4ever/eeve_mower_willow",
   "flame4ever/homeassistant-controme-integration",


### PR DESCRIPTION
Adds Fistacho/ha-netatmo-bubendorff to the HACS default integration list.

## Links

- Repository: https://github.com/Fistacho/ha-netatmo-bubendorff
- Latest release: https://github.com/Fistacho/ha-netatmo-bubendorff/releases/tag/v1.5.3
- CI action runs: https://github.com/Fistacho/ha-netatmo-bubendorff/actions/runs/27490232580

## Checklist

- [x] Repository has a description
- [x] Repository has topics
- [x] Repository is public and not archived/a fork
- [x] `hacs.json` and `manifest.json` are valid
- [x] Codeowner (`@Fistacho`) matches the repository owner
- [x] A published release exists (`v1.5.3`)
- [x] HACS Action and hassfest validation pass on the default branch
- [x] Brand assets submitted to home-assistant/brands