### PR TITLE
Adds new integration [Fistacho/ha-netatmo-bubendorff]

### DIFF
--- a/integration
+++ b/integration
@@ -766,6 +766,7 @@
   "finity69x2/nws_alerts",
   "firstof9/ha-gasbuddy",
   "firstof9/ha-openei",
+  "Fistacho/ha-netatmo-bubendorff",
   "FL550/dwd_weather",
   "flame4ever/eeve_mower_willow",
   "flame4ever/homeassistant-controme-integration",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: https://github.com/Fistacho/ha-netatmo-bubendorff/releases/tag/v1.5.3
Link to successful HACS action (without the `ignore` key): https://github.com/Fistacho/ha-netatmo-bubendorff/actions/runs/27490232580/job/81253785768
Link to successful hassfest action (if integration): https://github.com/Fistacho/ha-netatmo-bubendorff/actions/runs/27490232580/job/81253785780