### PR TITLE
Add torvalstrom/hookii-neomow-ha

### DIFF
--- a/integration
+++ b/integration
@@ -2245,6 +2245,7 @@
   "toringer/home-assistant-metnowcast",
   "toringer/home-assistant-sildre",
   "toringer/home-assistant-thermostat-setback",
+  "torvalstrom/hookii-neomow-ha",
   "Toxo666/ha_froeling_modbus",
   "travisghansen/hass-pfsense",
   "trcyberoptic/hoval-connect-api",


### PR DESCRIPTION
Adds **torvalstrom/hookii-neomow-ha** to the integration default list.

**What it is:** a native (no-iframe) Home Assistant map card + integration for Hookii Neomow robot mowers. The integration subscribes to the Hookii Bridge's republished MQTT map data and serves it to a bundled, dependency-free Lovelace card. Works on all install types (HAOS, Supervised, Container, Core).

Repository: https://github.com/torvalstrom/hookii-neomow-ha

Checklist:
- [x] Repository has a description and topics (`home-assistant`, `hacs`, ...)
- [x] `hacs.json` present
- [x] Integration in `custom_components/hookii_neomow/` with a valid `manifest.json` (domain `hookii_neomow`, `config_flow`, version)
- [x] Published releases (latest `v0.2.1`)
- [x] MIT `LICENSE`
- [x] Brand images submitted to home-assistant/brands: home-assistant/brands#10528 (pending merge)

Note: the brands PR (#10528) is open; this can merge once brand images are in.