### PR TITLE
Add torvalstrom/hookii-neomow-ha

### DIFF
--- a/integration
+++ b/integration
@@ -2245,6 +2245,7 @@
   "toringer/home-assistant-metnowcast",
   "toringer/home-assistant-sildre",
   "toringer/home-assistant-thermostat-setback",
+  "torvalstrom/hookii-neomow-ha",
   "Toxo666/ha_froeling_modbus",
   "travisghansen/hass-pfsense",
   "trcyberoptic/hoval-connect-api",


### PR DESCRIPTION
Adds **torvalstrom/hookii-neomow-ha** to the integration default list.

A native (no-iframe) Home Assistant map card + integration for Hookii Neomow robot mowers; the integration subscribes to the Hookii Bridge's MQTT map data and serves it to a bundled Lovelace card. Works on all install types (HAOS, Supervised, Container, Core).

Repo: https://github.com/torvalstrom/hookii-neomow-ha

- `hacs.json`, valid `manifest.json` (domain `hookii_neomow`, config_flow, keys sorted)
- Releases (latest `v0.2.2`), MIT `LICENSE`, description + topics
- Brand images shipped in-integration at `custom_components/hookii_neomow/brand/` (HA 2026.3+ mechanism — the brands repo no longer accepts custom-integration icons)

(Replaces a previous PR that failed before the brand assets + manifest sort were fixed in v0.2.2.)