### PR TITLE
chore: 🗑️ remove "mguyard/appdaemon-coversmanager" from appdaemon list

### DIFF
--- a/appdaemon
+++ b/appdaemon
@@ -24,7 +24,6 @@
   "joBr99/nspanel-lovelace-ui",
   "kprestel/appdaemon-climate",
   "madchap/energiapro_gas_consumption",
-  "mguyard/appdaemon-coversmanager",
   "Mohlsson/ReplayLightsHistory",
   "nechry/elco-remocon-net-appdaemon",
   "nickneos/Appdaemon-Ring-Doorbell-Automations",


### PR DESCRIPTION
* Cleaned up the appdaemon integration list by removing an archived entry.

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [X] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [X] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [X] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [X] The actions are passing without any disabled checks in my repository.
- [X] I've added a link to the action run on my repository below in the links section.
- [X] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <>
Link to successful HACS action (without the `ignore` key): <>
Link to successful hassfest action (if integration): <>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->