### PR TITLE
Add simsoum95/freeform-dashboard

### DIFF
--- a/plugin
+++ b/plugin
@@ -499,6 +499,7 @@
   "silentbil/silent-remotes-card",
   "silvanocerza/light-card-hue-feature",
   "silviokennecke/ha-public-transport-connection-card",
+  "simsoum95/freeform-dashboard",
   "skydarc/Venus-OS-Dashboard",
   "slipx06/sunsynk-power-flow-card",
   "snootched/cb-lcars",


### PR DESCRIPTION
Adds a new plugin: **simsoum95/freeform-dashboard**

A drag-and-drop overlay editor for Lovelace — move, resize and restyle any dashboard card freely, no YAML; the card's content scales as you resize it. Includes magnetic alignment guides, per-card style presets, layout scenes per breakpoint, undo/redo, and English/French/Hebrew (LTR + RTL).

Repository: https://github.com/simsoum95/freeform-dashboard

- Category: `plugin`
- `hacs.json` present (name + filename)
- Tagged release `v7.0.2` with the JS file attached as a release asset
- README with demo GIF, MIT license, description + topics set
- HACS validation workflow added to the repository