### PR TITLE
Adds new plugin [simsoum95/freeform-dashboard]

### DIFF
--- a/plugin
+++ b/plugin
@@ -499,6 +499,7 @@
   "silentbil/silent-remotes-card",
   "silvanocerza/light-card-hue-feature",
   "silviokennecke/ha-public-transport-connection-card",
+  "simsoum95/freeform-dashboard",
   "skydarc/Venus-OS-Dashboard",
   "slipx06/sunsynk-power-flow-card",
   "snootched/cb-lcars",


### PR DESCRIPTION
Adds a new plugin: **simsoum95/freeform-dashboard** — a drag-and-drop overlay editor for Lovelace (move, resize & restyle any card, no YAML; content scales as you resize).

## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: https://github.com/simsoum95/freeform-dashboard/releases/tag/v7.0.3
Link to successful HACS action (without the `ignore` key): https://github.com/simsoum95/freeform-dashboard/actions/runs/27506712237
Link to successful hassfest action (if integration): N/A — this is a plugin, not an integration.
