### PR TITLE
Add Folkman/ha-fcast

### DIFF
--- a/integration
+++ b/integration
@@ -773,6 +773,7 @@
   "flexopus/flexopus-hass-sensor",
   "Flo-Schilli/ha-grohe_smarthome",
   "florianbaethge/simple_irrigation",
+  "Folkman/ha-fcast",
   "fondberg/spotcast",
   "Foxi352/pollen_lu",
   "FoxXxHater/leasing-tracker",


### PR DESCRIPTION
Adds the `fcast` integration to the HACS default store.

- **Repository:** https://github.com/Folkman/ha-fcast
- **Category:** integration
- **What it is:** **FCast** exposes [FCast](https://fcast.org) receivers (FUTO's open, DRM-free casting protocol) as Home Assistant `media_player` entities — on-screen announcements, camera snapshots & live streams, arbitrary URLs, playlists, photo slideshows, and a live location map. Zeroconf-discovered, local push.

Checklist:
- [x] I am the author/owner of the repository.
- [x] The repository is public, active, and not a fork.
- [x] HACS Action and hassfest both pass.
- [x] `hacs.json`, `manifest.json`, README, description, topics, and a `brand/` icon are all present.
- [x] A full GitHub release exists (latest: `v0.2.7`).