### PR TITLE
Add watari-dev/simui-lovelace

### DIFF
--- a/plugin
+++ b/plugin
@@ -585,6 +585,7 @@
   "wassy92x/lovelace-digital-clock",
   "wassy92x/lovelace-entities-btn-group",
   "wassy92x/lovelace-ha-dashboard",
+  "watari-dev/simui-lovelace",
   "weedpump/timeline-card",
   "weirdtangent/pulse-photo-card",
   "WickedGhost/avinor-flight-card",


### PR DESCRIPTION
## Add a new repository to HACS

- **Repository:** https://github.com/watari-dev/simui-lovelace
- **Category:** plugin (Lovelace cards)

SimUI Cards — seven minimalist, Apple-Home / UI-Lovelace-Minimalist custom Lovelace cards (light, climate, sensor, history graph, cover, lock, media). React in a shadow-DOM web component, shipped as a single ES module.

Public, MIT-licensed, topics set, README + screenshot, tagged release **v0.1.1** with `simui-lovelace.js` attached. The repo's own `hacs/action` (category plugin) validation passes. All cards are UI-editable (ha-form), theme-aware, and keyboard-accessible.