### PR TITLE
Add porech/samsung_ac_dplug

### DIFF
--- a/integration
+++ b/integration
@@ -1772,6 +1772,7 @@
   "popeen/Home-Assistant-Custom-Component-MotalaVattenAvfall",
   "popeen/Home-Assistant-Custom-Component-TCL-Remote",
   "popeen/Home-Assistant-Custom-Component-Temperatur-Nu",
+  "porech/samsung_ac_dplug",
   "PorlyBe/glance_clock_ha",
   "Poshy163/HomeAssistant-Sharesight",
   "postlund/dlink_hnap",


### PR DESCRIPTION
Adds [`porech/samsung_ac_dplug`](https://github.com/porech/samsung_ac_dplug) to the **integration** category.

Local control for old Samsung air conditioners (DPLUG / AC14K protocol, TLS port 2878) — the SmartThings-dropped AR\*\*HSFS generation. Config-flow setup with DHCP discovery, climate + sensors/switches/numbers/selects, on-device scheduler services, live push updates.

- `hacs/action` validation passes (integration); hassfest passes.
- Brand images shipped (local `brand/` for HA 2026.3+, and PR home-assistant/brands#10535).
- Released `v1.0.0`, `mypy --strict` + pytest (~99%) in CI, quality_scale.yaml complete.