### PR TITLE
Skip repository-specific checks for renamed-repositories PRs

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -6,6 +6,7 @@ on:
       - opened
       - synchronize
       - reopened
+      - labeled
       - unlabeled
     branches:
       - master
@@ -27,6 +28,7 @@ jobs:
   preflight:
     runs-on: ubuntu-latest
     name: Preflight
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'renamed-repositories') }}
     outputs:
       repository: ${{ steps.repository.outputs.repository }}
       category: ${{ steps.category.outputs.category }}


### PR DESCRIPTION
- Guard the preflight job (and via the needs cascade, all repository-specific jobs) with a label condition so that PRs labelled 'renamed-repositories' skip the new-addition validation.
- Add the 'labeled' trigger type so applying the label re-evaluates the workflow.