### PR TITLE
Make checks workflow label-driven via run-type output

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -31,10 +31,10 @@ jobs:
     outputs:
       repository: ${{ steps.repository.outputs.repository }}
       category: ${{ steps.category.outputs.category }}
-      run-type: ${{ steps.run-type.outputs.run-type }}
+      run_type: ${{ steps.run_type.outputs.run_type }}
     steps:
       - name: Determine run type
-        id: run-type
+        id: run_type
         env:
           HAS_REMOVAL: ${{ contains(github.event.pull_request.labels.*.name, 'remove-repositories') }}
           HAS_NEW_REPO: ${{ contains(github.event.pull_request.labels.*.name, 'New default repository') }}
@@ -51,44 +51,44 @@ jobs:
           fi
 
           if [ "$HAS_REMOVAL" == "true" ]; then
-            echo "run-type=removal" >> $GITHUB_OUTPUT
+            echo "run_type=removal" >> $GITHUB_OUTPUT
           elif [ "$HAS_NEW_REPO" == "true" ]; then
-            echo "run-type=new-repository" >> $GITHUB_OUTPUT
+            echo "run_type=new-repository" >> $GITHUB_OUTPUT
           elif [ "$HAS_RENAMED" == "true" ]; then
-            echo "run-type=rename" >> $GITHUB_OUTPUT
+            echo "run_type=rename" >> $GITHUB_OUTPUT
           else
-            echo "run-type=unknown" >> $GITHUB_OUTPUT
+            echo "run_type=unknown" >> $GITHUB_OUTPUT
           fi
 
       - name: Check out repository
-        if: steps.run-type.outputs.run-type == 'new-repository'
+        if: steps.run_type.outputs.run_type == 'new-repository'
         uses: actions/checkout@v6.0.2
 
       - name: Set up Python
-        if: steps.run-type.outputs.run-type == 'new-repository'
+        if: steps.run_type.outputs.run_type == 'new-repository'
         uses: actions/setup-python@v6.2.0
         with:
           python-version-file: ".python-version"
 
       - name: Clone origin
-        if: steps.run-type.outputs.run-type == 'new-repository'
+        if: steps.run_type.outputs.run_type == 'new-repository'
         run: git clone --depth 1 https://github.com/hacs/default /tmp/repositories/default
 
       - name: Set repository
         id: repository
-        if: steps.run-type.outputs.run-type == 'new-repository'
+        if: steps.run_type.outputs.run_type == 'new-repository'
         run: echo "repository=$(python3 -m scripts.changed.repo)" >> $GITHUB_OUTPUT
 
       - name: Set category
         id: category
-        if: steps.run-type.outputs.run-type == 'new-repository'
+        if: steps.run_type.outputs.run_type == 'new-repository'
         run: echo "category=$(python3 -m scripts.changed.category)" >> $GITHUB_OUTPUT
 
   owner:
     runs-on: ubuntu-latest
     name: Owner
     needs: preflight
-    if: needs.preflight.outputs.run-type == 'new-repository'
+    if: needs.preflight.outputs.run_type == 'new-repository'
     steps:
       - name: Check out repository
         uses: actions/checkout@v6.0.2
@@ -134,7 +134,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Releases
     needs: preflight
-    if: needs.preflight.outputs.run-type == 'new-repository'
+    if: needs.preflight.outputs.run_type == 'new-repository'
     steps:
       - name: Check out repository
         uses: actions/checkout@v6.0.2
@@ -159,7 +159,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Removed repository
     needs: preflight
-    if: needs.preflight.outputs.run-type == 'new-repository'
+    if: needs.preflight.outputs.run_type == 'new-repository'
     steps:
       - name: Check out repository
         uses: actions/checkout@v6.0.2
@@ -183,7 +183,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Existing repository
     needs: preflight
-    if: needs.preflight.outputs.run-type == 'new-repository'
+    if: needs.preflight.outputs.run_type == 'new-repository'
     steps:
       - name: Check out repository
         uses: actions/checkout@v6.0.2
@@ -207,7 +207,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Hassfest
     needs: preflight
-    if: needs.preflight.outputs.category == 'integration' && needs.preflight.outputs.run-type == 'new-repository'
+    if: needs.preflight.outputs.category == 'integration' && needs.preflight.outputs.run_type == 'new-repository'
     steps:
       - name: Check out repository
         uses: actions/checkout@v6.0.2
@@ -228,7 +228,7 @@ jobs:
     runs-on: ubuntu-latest
     name: HACS action
     needs: preflight
-    if: needs.preflight.outputs.run-type == 'new-repository'
+    if: needs.preflight.outputs.run_type == 'new-repository'
     steps:
       - name: HACS action
         uses: hacs/action@main

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -40,22 +40,12 @@ jobs:
           HAS_NEW_REPO: ${{ contains(github.event.pull_request.labels.*.name, 'New default repository') }}
           HAS_RENAMED: ${{ contains(github.event.pull_request.labels.*.name, 'renamed-repositories') }}
         run: |
-          count=0
-          [ "$HAS_REMOVAL" == "true" ] && count=$((count + 1))
-          [ "$HAS_NEW_REPO" == "true" ] && count=$((count + 1))
-          [ "$HAS_RENAMED" == "true" ] && count=$((count + 1))
-
-          if [ "$count" -gt 1 ]; then
-            echo "::error::Only one of the labels 'remove-repositories', 'New default repository', 'renamed-repositories' may be set" >&2
-            exit 1
-          fi
-
-          if [ "$HAS_REMOVAL" == "true" ]; then
-            echo "run_type=removal" >> $GITHUB_OUTPUT
-          elif [ "$HAS_NEW_REPO" == "true" ]; then
+          if [ "$HAS_NEW_REPO" == "true" ]; then
             echo "run_type=new-repository" >> $GITHUB_OUTPUT
           elif [ "$HAS_RENAMED" == "true" ]; then
             echo "run_type=rename" >> $GITHUB_OUTPUT
+          elif [ "$HAS_REMOVAL" == "true" ]; then
+            echo "run_type=removal" >> $GITHUB_OUTPUT
           else
             echo "run_type=unknown" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -6,6 +6,7 @@ on:
       - opened
       - synchronize
       - reopened
+      - labeled
       - unlabeled
     branches:
       - master
@@ -30,39 +31,64 @@ jobs:
     outputs:
       repository: ${{ steps.repository.outputs.repository }}
       category: ${{ steps.category.outputs.category }}
-      removal: ${{ steps.removal.outputs.removal }}
+      run-type: ${{ steps.run-type.outputs.run-type }}
     steps:
+      - name: Determine run type
+        id: run-type
+        env:
+          HAS_REMOVAL: ${{ contains(github.event.pull_request.labels.*.name, 'remove-repositories') }}
+          HAS_NEW_REPO: ${{ contains(github.event.pull_request.labels.*.name, 'New default repository') }}
+          HAS_RENAMED: ${{ contains(github.event.pull_request.labels.*.name, 'renamed-repositories') }}
+        run: |
+          count=0
+          [ "$HAS_REMOVAL" == "true" ] && count=$((count + 1))
+          [ "$HAS_NEW_REPO" == "true" ] && count=$((count + 1))
+          [ "$HAS_RENAMED" == "true" ] && count=$((count + 1))
+
+          if [ "$count" -gt 1 ]; then
+            echo "::error::Only one of the labels 'remove-repositories', 'New default repository', 'renamed-repositories' may be set" >&2
+            exit 1
+          fi
+
+          if [ "$HAS_REMOVAL" == "true" ]; then
+            echo "run-type=removal" >> $GITHUB_OUTPUT
+          elif [ "$HAS_NEW_REPO" == "true" ]; then
+            echo "run-type=new-repository" >> $GITHUB_OUTPUT
+          elif [ "$HAS_RENAMED" == "true" ]; then
+            echo "run-type=renamed" >> $GITHUB_OUTPUT
+          else
+            echo "run-type=unknown" >> $GITHUB_OUTPUT
+          fi
+
       - name: Check out repository
+        if: steps.run-type.outputs.run-type == 'new-repository'
         uses: actions/checkout@v6.0.2
 
       - name: Set up Python
+        if: steps.run-type.outputs.run-type == 'new-repository'
         uses: actions/setup-python@v6.2.0
         with:
           python-version-file: ".python-version"
 
       - name: Clone origin
+        if: steps.run-type.outputs.run-type == 'new-repository'
         run: git clone --depth 1 https://github.com/hacs/default /tmp/repositories/default
 
       - name: Set repository
         id: repository
+        if: steps.run-type.outputs.run-type == 'new-repository'
         run: echo "repository=$(python3 -m scripts.changed.repo)" >> $GITHUB_OUTPUT
 
       - name: Set category
         id: category
+        if: steps.run-type.outputs.run-type == 'new-repository'
         run: echo "category=$(python3 -m scripts.changed.category)" >> $GITHUB_OUTPUT
-
-      - name: Check removal
-        id: removal
-        run: |
-          if [ "${{ steps.repository.outputs.repository }}" == "Bad data []" ]; then
-            echo "removal=true" >> $GITHUB_OUTPUT
-          fi
 
   owner:
     runs-on: ubuntu-latest
     name: Owner
     needs: preflight
-    if: needs.preflight.outputs.removal != 'true'
+    if: needs.preflight.outputs.run-type == 'new-repository'
     steps:
       - name: Check out repository
         uses: actions/checkout@v6.0.2
@@ -108,7 +134,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Releases
     needs: preflight
-    if: needs.preflight.outputs.removal != 'true'
+    if: needs.preflight.outputs.run-type == 'new-repository'
     steps:
       - name: Check out repository
         uses: actions/checkout@v6.0.2
@@ -133,7 +159,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Removed repository
     needs: preflight
-    if: needs.preflight.outputs.removal != 'true'
+    if: needs.preflight.outputs.run-type == 'new-repository'
     steps:
       - name: Check out repository
         uses: actions/checkout@v6.0.2
@@ -157,7 +183,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Existing repository
     needs: preflight
-    if: needs.preflight.outputs.removal != 'true'
+    if: needs.preflight.outputs.run-type == 'new-repository'
     steps:
       - name: Check out repository
         uses: actions/checkout@v6.0.2
@@ -181,7 +207,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Hassfest
     needs: preflight
-    if: needs.preflight.outputs.category == 'integration' && needs.preflight.outputs.removal != 'true'
+    if: needs.preflight.outputs.category == 'integration' && needs.preflight.outputs.run-type == 'new-repository'
     steps:
       - name: Check out repository
         uses: actions/checkout@v6.0.2
@@ -202,7 +228,7 @@ jobs:
     runs-on: ubuntu-latest
     name: HACS action
     needs: preflight
-    if: needs.preflight.outputs.removal != 'true'
+    if: needs.preflight.outputs.run-type == 'new-repository'
     steps:
       - name: HACS action
         uses: hacs/action@main

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -10,13 +10,6 @@ on:
       - unlabeled
     branches:
       - master
-    paths:
-      - appdaemon
-      - integration
-      - plugin
-      - python_script
-      - template
-      - theme
 
 concurrency:
   group: checks-${{ github.ref }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -55,7 +55,7 @@ jobs:
           elif [ "$HAS_NEW_REPO" == "true" ]; then
             echo "run-type=new-repository" >> $GITHUB_OUTPUT
           elif [ "$HAS_RENAMED" == "true" ]; then
-            echo "run-type=renamed" >> $GITHUB_OUTPUT
+            echo "run-type=rename" >> $GITHUB_OUTPUT
           else
             echo "run-type=unknown" >> $GITHUB_OUTPUT
           fi


### PR DESCRIPTION
Replace the fragile 'removal' detection (which inferred removals from a 'Bad data []' parse-error sentinel) with an explicit, label-driven run-type output on the preflight job:

- remove-repositories   -> removal
- New default repository -> new-repository
- renamed-repositories  -> rename
- no known label        -> unknown
