### PR TITLE
Add asherbfromtheministry/ha-lmkw integration

### DIFF
--- a/integration
+++ b/integration
@@ -196,6 +196,8 @@
   "asantaga/lightwaverf_HA_EnergySensor",
   "asantaga/wiserHomeAssistantPlatform",
   "asev/homeassistant-helios",
+ "asherbfromtheministry/ha-lmkw",
+
   "Ashus/hass-openwrt-wakeonlan",
   "aspenrt78/button-builder",
   "astrandb/miele",


### PR DESCRIPTION
## Summary
Adds the Let Me Know When Home Assistant integration (`ha-lmkw`).

- Repository: https://github.com/asherbfromtheministry/ha-lmkw
- Category: integration
- HACS validation: passing
- Hassfest: passing
- Release: https://github.com/asherbfromtheministry/ha-lmkw/releases/tag/v0.1.6

## Checklist
- [x] I am the owner of the repository
- [x] HACS Action passes without ignored checks
- [x] Hassfest passes
- [x] GitHub release published
- [x] Repository has description, topics, and issues enabled
- [x] Brand icon in `custom_components/lmkw/brand/icon.png`