### PR TITLE
Adds new plugin [jrhubott/adaptive-cover-pro-card]

### DIFF
--- a/plugin
+++ b/plugin
@@ -260,6 +260,7 @@
   "JonasDoebertin/ha-today-card",
   "jonkristian/entur-card",
   "joseluis9595/lovelace-navbar-card",
+  "jrhubott/adaptive-cover-pro-card",
   "jtbgroup/kodi-playlist-card",
   "jtbgroup/kodi-search-card",
   "jtubb/generator-hmi-card",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/jrhubott/adaptive-cover-pro-card/releases/tag/v2.8.0>
Link to successful HACS action (without the `ignore` key): <https://github.com/jrhubott/adaptive-cover-pro-card/actions/runs/27635238328>
Link to successful hassfest action (if integration): <N/A — plugin, not an integration>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->
