### PR TITLE
Add piep-projects/GardenESP

### DIFF
--- a/integration
+++ b/integration
@@ -1729,6 +1729,7 @@
   "Pho3niX90/solis_modbus",
   "phoinixgrr/sigma_connect_ha",
   "physje/waterinfo",
+  "piep-projects/GardenESP",
   "Pigotka/ha-cc-jablotron-cloud",
   "piitaya/home-assistant-qubino-wire-pilot",
   "pikipixel/hass-one-pocket",


### PR DESCRIPTION
Adds the **GardenESP** integration to the default store.

- Repository: https://github.com/piep-projects/GardenESP
- Category: integration
- Home Assistant irrigation controller (sidebar panel + Lovelace card) for ESPHome-based ESP32 hardware: irrigation lines, water sources (cistern level / mains meter), schedules, rain/soil blocking, on-device emergency shutdown.

Checklist:
- [x] Public repository with description and topics
- [x] Released version (`v0.13.35`)
- [x] Passes `hacs/action` validation (HACS + hassfest green)
- [x] Brand assets shipped in-component (`custom_components/gardenesp/brand/`, Brands Proxy API)
- [x] Documentation: https://piep-projects.github.io/GardenESP/
