### PR TITLE
Add VladinoUs/abb_egon to default HACS integrations

### DIFF
--- a/integration
+++ b/integration
@@ -2315,6 +2315,7 @@
   "viragelabs/virage_dashboard",
   "VitisEK/nibe_energy_conversion",
   "vivo/ha_vivohomebridge",
+  "VladinoUs/abb_egon",
   "vlumikero/home-assistant-securitas",
   "vmakeev/huawei_mesh_router",
   "vmarkovtsev/sistena_onix_ha",


### PR DESCRIPTION
Adding abb_egon to the HACS default integration list. HACS validation completed.