### PR TITLE
Add VladinoUs/abb_egon to default HACS integrations 

### DIFF
--- a/integration
+++ b/integration
@@ -2315,6 +2315,7 @@
   "viragelabs/virage_dashboard",
   "VitisEK/nibe_energy_conversion",
   "vivo/ha_vivohomebridge",
+  "VladinoUs/abb_egon",
   "vlumikero/home-assistant-securitas",
   "vmakeev/huawei_mesh_router",
   "vmarkovtsev/sistena_onix_ha",


### PR DESCRIPTION
### Checklist
- [x] I have read the publishing documentation.
- [x] I have added the HACS action to my repository.
- [x] I have added the hassfest action to my repository.
- [x] I have created a release.

### Required links
- https://github.com/VladinoUs/default/releases/latest
- https://github.com/VladinoUs/default/actions/workflows/validate.yml
- https://github.com/VladinoUs/default/actions/workflows/hassfest.yml

Adding abb_egon to the HACS default integration list. HACS validation completed.