### PR TITLE
Add mxkissnr/glp-integration

### DIFF
--- a/integration
+++ b/integration
@@ -1559,6 +1559,7 @@
   "mvdwetering/huesyncbox",
   "mvdwetering/yamaha_ynca",
   "mweinelt/ha-prometheus-sensor",
+  "mxkissnr/glp-integration",
   "myhades/ha-clash-controller",
   "myhomeiot/DahuaVTO",
   "myny-git/smappee_ev",


### PR DESCRIPTION
Adds [mxkissnr/glp-integration](https://github.com/mxkissnr/glp-integration) to the `integration` list.

- Category: integration
- Passes HACS Action validation
- Has releases, description and topics set