### PR TITLE
Add mxkissnr/glp-order-card

### DIFF
--- a/plugin
+++ b/plugin
@@ -378,6 +378,7 @@
   "mtheli/gardena-smart-system-card",
   "mtheli/toothbrush-card",
   "mutilator/homeassistant-solar-panel-preview",
+  "mxkissnr/glp-order-card",
   "nathan-gs/ha-map-card",
   "nathanmarlor/foxess_modbus_charge_period_card",
   "nathkrill/lovelace-google-fonts-header-card",


### PR DESCRIPTION
Adds [mxkissnr/glp-order-card](https://github.com/mxkissnr/glp-order-card) to the `plugin` list.

- Category: plugin
- Passes HACS Action validation
- Has releases, description and topics set