### PR TITLE
Add ABB Egon default integration

### DIFF
--- a/integration
+++ b/integration
@@ -2315,6 +2315,7 @@
   "viragelabs/virage_dashboard",
   "VitisEK/nibe_energy_conversion",
   "vivo/ha_vivohomebridge",
+  "VladinoUs/abb_egon",
   "vlumikero/home-assistant-securitas",
   "vmakeev/huawei_mesh_router",
   "vmarkovtsev/sistena_onix_ha",


### PR DESCRIPTION
## Required links
- Latest release: https://github.com/VladinoUs/abb_egon/releases/tag/0.1.0
- CI run 1: https://github.com/VladinoUs/abb_egon/actions/runs/27702541606
- CI run 2: https://github.com/VladinoUs/abb_egon/actions/runs/27702335779

## Checklist
- [x] I have read the publishing documentation.
- [x] I have added the HACS action to my repository.
- [x] I have added the hassfest action to my repository.
- [x] I have created a release.