### PR TITLE
Adds new integration [Echo000926/APsystemsStorageHAPublic]

### DIFF
--- a/integration
+++ b/integration
@@ -666,6 +666,7 @@
   "eburi/hass_ruuvi_gateway_bluetooth_proxy",
   "ec-blaster/magicswitchbot-homeassistant",
   "echocat/ha-companion-media-player",
+  "Echo000926/APsystemsStorageHAPublic",
   "edekeijzer/osrm_travel_time",
   "EdLeckert/ha-tmobilehome",
   "EdLeckert/wine-cellar",


### PR DESCRIPTION
Add [Echo000926/APsystemsStorageHAPublic](https://github.com/Echo000926/APsystemsStorageHAPublic) to HACS integrations.

- Repository passes HACS validation
- Integration uses `hacs.json` with correct categories and versioning
- Brand icon included (`/brand/icon.png`)
- Latest release: [v1.0.0](https://github.com/Echo000926/APsystemsStorageHAPublic/releases/tag/v1.0.0)

> Note: This is a new integration for APsystems storage (LAKE).