### PR TITLE
Adds new integration [Echo000926/APsystemsStorageHAPublic]

### DIFF
--- a/integration
+++ b/integration
@@ -666,6 +666,7 @@
   "eburi/hass_ruuvi_gateway_bluetooth_proxy",
   "ec-blaster/magicswitchbot-homeassistant",
   "echocat/ha-companion-media-player",
+  "Echo000926/APsystemsStorageHAPublic",
   "edekeijzer/osrm_travel_time",
   "EdLeckert/ha-tmobilehome",
   "EdLeckert/wine-cellar",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/Echo000926/APsystemsStorageHAPublic/releases/tag/v1.0.0>
Link to successful HACS action (without the `ignore` key): <https://github.com/Echo000926/APsystemsStorageHAPublic/actions/workflows/hacs.yml>
Link to successful hassfest action (if integration): <https://github.com/Echo000926/APsystemsStorageHAPublic/actions/runs/27739810961>