### PR TITLE
Add 'naked-head/puffer-card' to plugin list

### DIFF
--- a/plugin
+++ b/plugin
@@ -378,6 +378,7 @@
   "mtheli/gardena-smart-system-card",
   "mtheli/toothbrush-card",
   "mutilator/homeassistant-solar-panel-preview",
+  "naked-head/puffer-card",
   "nathan-gs/ha-map-card",
   "nathanmarlor/foxess_modbus_charge_period_card",
   "nathkrill/lovelace-google-fonts-header-card",


### PR DESCRIPTION
## Checklist
- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links
Link to current release: https://github.com/naked-head/puffer-card/releases/tag/v1.0.0
Link to successful HACS action (without the `ignore` key): https://github.com/naked-head/puffer-card/actions/runs/27759322528
Link to successful hassfest action (if integration): N/A (plugin)