### PR TITLE
Add kashar0/growatt-cloud

### DIFF
--- a/integration
+++ b/integration
@@ -1188,6 +1188,7 @@
   "Kaptensanders/skolmat",
   "Kartax/home-assistant-binance",
   "KartoffelToby/better_thermostat",
+  "kashar0/growatt-cloud",
   "kattcrazy/tuya_unsupported_sensors",
   "kclif9/hassactronneo",
   "kcoffau/AUS_BOM_Space_Weather_Alert_System",


### PR DESCRIPTION
Adds **Growatt Cloud** integration to the HACS default store.

**Repository:** https://github.com/kashar0/growatt-cloud

**Description:** Home Assistant integration for Growatt solar inverters. Polls the Growatt cloud API to expose 30+ sensors (live power, daily/total energy, voltage, current, temperature, etc.) directly as HA entities - no MQTT or Node.js required.

**Supported devices:**
- On-grid string inverters (MOD, MIN, MAC series)
- Hybrid/MIX inverters
- TLX series inverters
- Works with any inverter visible in ShinePhone / server.growatt.com

**Features:**
- UI config flow (no YAML)
- Auto-discovers plants and inverters from your account
- Regional server selector (Global, Europe, China, API endpoint)
- Configurable poll interval (2-60 min)

**HACS requirements met:**
- hacs.json present
- manifest.json with all required fields
- config_flow: true
- GitHub release v1.0.3