### PR TITLE
Add ange007/ha-sun-allocator

### DIFF
--- a/integration
+++ b/integration
@@ -160,6 +160,7 @@
   "andystewart999/ha_transportnsw",
   "andystewart999/qBittorrent_MkII",
   "aneeshd/schedule_state",
+  "ange007/ha-sun-allocator",
   "Angelius007/myfox-api",
   "anker-charging/ha-anker-solix-official",
   "ankohanse/hass-dab-pumps",


### PR DESCRIPTION
Adds the **SunAllocator** integration to the HACS default store.

- Repository: https://github.com/ange007/ha-sun-allocator
- Category: integration

SunAllocator estimates untapped solar (excess) power from PV power/voltage and
panel datasheet values via an MPPT model, then distributes that surplus to
prioritized loads (switches, lights, climate, ESPHome relays).

Checklist:
- [x] I am the owner of the repository (`@ange007`, manifest codeowner).
- [x] Public, non-archived repository with description, issues enabled and topics.
- [x] `hacs.json` and `manifest.json` are valid.
- [x] At least one published GitHub release (`v1.1.0`).
- [x] HACS Action passes without errors or ignores.
- [x] Hassfest passes.