### PR TITLE
Add gwenaelnavez/owserver-ha integration

### DIFF
--- a/integration
+++ b/integration
@@ -890,6 +890,7 @@
   "GuyLewin/home-assistant-crunch-o-meter",
   "GuySie/ha-meural",
   "gvigroux/hon",
+  "gwenaelnavez/owserver-ha",
   "GyroGearl00se/ha_froeling_lambdatronic_modbus",
   "h4de5/home-assistant-toshiba_ac",
   "h4de5/home-assistant-vimar",


### PR DESCRIPTION
## Integration

- **Repository**: gwenaelnavez/owserver-ha
- **Category**: integration
- **Description**: Home Assistant integration for EDS OW-SERVER, a 1-Wire to Ethernet server.

## Links

- **Latest release**: https://github.com/gwenaelnavez/owserver-ha/releases/tag/v1.0.0
- **HACS Action**: https://github.com/gwenaelnavez/owserver-ha/actions/runs/27784658261
- **Hassfest**: https://github.com/gwenaelnavez/owserver-ha/actions/runs/27784658243

## Checklist

- [x] Repository is public
- [x] Repository has description and topics
- [x] Repository has a valid hacs.json
- [x] Repository has brand assets
- [x] Repository has a valid manifest.json
- [x] Repository has a GitHub release
- [x] HACS Action passes
- [x] Hassfest passes
- [x] Entry is added alphabetically
- [x] PR is editable by maintainers