### PR TITLE
Add andrewtryder/ha-myq-garage integration

### DIFF
--- a/integration
+++ b/integration
@@ -151,6 +151,7 @@
   "andrew-codechimp/HA-Wasp-In-A-Box",
   "andrew-codechimp/tsmart_ha",
   "andrewjswan/SwatchTime",
+  "andrewtryder/ha-myq-garage",
   "andriensis/ha-1control",
   "andriensis/ha-amtab-bari",
   "andrzejchm/blebox_shutterbox_tilt",


### PR DESCRIPTION
## Summary
Adds the MyQ Garage custom integration to the default HACS integration catalog.

- Repository: https://github.com/andrewtryder/ha-myq-garage
- Domain: `myq_garage`
- Category: integration
- Release: https://github.com/andrewtryder/ha-myq-garage/releases/tag/v1.0.0

## Checklist
- [x] I am the owner of the repository
- [x] Repository has a GitHub release
- [x] Repository has description, topics, and issues enabled
- [x] HACS Action and hassfest validation workflows are configured
- [x] Entry added alphabetically to `./integration`

Made with [Cursor](https://cursor.com)