### PR TITLE
Add carjufi/ha-air-quality-card-plus

### DIFF
--- a/plugin
+++ b/plugin
@@ -51,6 +51,7 @@
   "brunosabot/streamline-card",
   "c-kick/hnl-flow-bars-card",
   "Cangos655/vehicle-card",
+  "carjufi/ha-air-quality-card-plus",
   "cataseven/Alarm-and-Security-Card",
   "cataseven/google-map-card",
   "cataseven/Navigate-Anywhere",


### PR DESCRIPTION
## Checklist

- [x] Read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] Added the [HACS action](https://hacs.xyz/docs/publish/action) to the repository.
- [x] Hassfest is not applicable; this is a plugin/dashboard repository, not an integration.
- [x] The actions are passing without any disabled checks in the repository.
- [x] Added a link to the action run on the repository below in the links section.
- [x] Created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/carjufi/ha-air-quality-card-plus/releases/tag/v2.12.1>
Link to successful HACS action (without the `ignore` key): <https://github.com/carjufi/ha-air-quality-card-plus/actions/runs/27826821438>
Link to successful hassfest action (if integration): <N/A - plugin/dashboard repository>
