### PR TITLE
Add carjufi/ha-air-quality-card-plus

### DIFF
--- a/plugin
+++ b/plugin
@@ -51,6 +51,7 @@
   "brunosabot/streamline-card",
   "c-kick/hnl-flow-bars-card",
   "Cangos655/vehicle-card",
+  "carjufi/ha-air-quality-card-plus",
   "cataseven/Alarm-and-Security-Card",
   "cataseven/google-map-card",
   "cataseven/Navigate-Anywhere",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/carjufi/ha-air-quality-card-plus/releases/tag/v2.12.1>
Link to successful HACS action (without the `ignore` key): <https://github.com/carjufi/ha-air-quality-card-plus/actions/runs/27826821438>
Link to successful hassfest action (if integration): <Not applicable - plugin/dashboard repository>
