### PR TITLE
Add TheDave94/airwatch, TheDave94/pollenwatch, TheDave94/oriel-dashboard

### DIFF
--- a/integration
+++ b/integration
@@ -2190,6 +2190,8 @@
   "thecem/octopus_germany",
   "thecode/ha-onewire-sysbus",
   "thecode/ha-rpi_gpio",
+  "TheDave94/airwatch",
+  "TheDave94/pollenwatch",
   "thedeemling/hass-energa-my-meter",
   "thefunkygibbon/eafm-enhanced",
   "TheGui01/Frisquet-connect-for-home-assistant",

--- a/plugin
+++ b/plugin
@@ -528,6 +528,7 @@
   "tcarlsen/lovelace-light-with-profiles",
   "tdvtdv/ha-tdv-bar",
   "teuchezh/dynamic-weather-card",
+  "TheDave94/oriel-dashboard",
   "TheLuXoR/calendar-week-card",
   "TheRealEiskaffee/brightness-overlay",
   "TheScubadiver/camera-gallery-card",


### PR DESCRIPTION
<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

**TheDave94/airwatch** (integration)
Link to current release: https://github.com/TheDave94/airwatch/releases/tag/v1.0.1
Link to successful HACS action (without the `ignore` key): https://github.com/TheDave94/airwatch/actions/runs/27832935538/job/82373920150
Link to successful hassfest action (if integration): https://github.com/TheDave94/airwatch/actions/runs/27832935538/job/82373920189

**TheDave94/pollenwatch** (integration)
Link to current release: https://github.com/TheDave94/pollenwatch/releases/tag/v3.0.0
Link to successful HACS action (without the `ignore` key): https://github.com/TheDave94/pollenwatch/actions/runs/27832108831/job/82371185364
Link to successful hassfest action (if integration): https://github.com/TheDave94/pollenwatch/actions/runs/27832108831/job/82371185332

**TheDave94/oriel-dashboard** (plugin)
Link to current release: https://github.com/TheDave94/oriel-dashboard/releases/tag/v4.17.4
Link to successful HACS action (without the `ignore` key): https://github.com/TheDave94/oriel-dashboard/actions/runs/27829120358/job/82361059159
Link to successful hassfest action (if integration): n/a — plugin, no hassfest

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->