### PR TITLE
Add TheDave94/oriel-dashboard

### DIFF
--- a/plugin
+++ b/plugin
@@ -528,6 +528,7 @@
   "tcarlsen/lovelace-light-with-profiles",
   "tdvtdv/ha-tdv-bar",
   "teuchezh/dynamic-weather-card",
+  "TheDave94/oriel-dashboard",
   "TheLuXoR/calendar-week-card",
   "TheRealEiskaffee/brightness-overlay",
   "TheScubadiver/camera-gallery-card",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Summary

Adds **TheDave94/oriel-dashboard** (v4.17.4) — a Lovelace dashboard strategy for Home Assistant that auto-generates dashboards from area/device/entity metadata, with a visual editor. Public, not archived, issues enabled, description + topics set, MIT-licensed.

## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: https://github.com/TheDave94/oriel-dashboard/releases/tag/v4.17.4
Link to successful HACS action (without the `ignore` key): https://github.com/TheDave94/oriel-dashboard/actions/runs/27829120358/job/82361059159
Link to successful hassfest action (if integration): n/a — plugin, no hassfest

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->