### PR TITLE
Add schmitzfabio/ha-ghn-maxlinear

### DIFF
--- a/integration
+++ b/integration
@@ -1982,6 +1982,7 @@
   "schmidtfx/ekz-tariffs",
   "schmidtfx/koch-ag-hass",
   "schmidtfx/swisscom-internetbox-hass",
+  "schmitzfabio/ha-ghn-maxlinear",
   "Schrolli91/heidelberg_energy_control",
   "schwarzenbergf/irtrans",
   "scottyphillips/echonetlite_homeassistant",


### PR DESCRIPTION
Adds **schmitzfabio/ha-ghn-maxlinear** to the integration list.

Local-polling Home Assistant integration for MaxLinear-based G.hn over-coax network adapters (e.g. Zinwell TGU-21) — reads link status from the device web GUI. No cloud.

- Repository: https://github.com/schmitzfabio/ha-ghn-maxlinear
- Category: integration
- `config_flow`: yes · `iot_class`: local_polling · domain: `ghn_maxlinear`
- Passes hassfest + HACS action (brand assets included in-repo); brands PR: home-assistant/brands#10562
- Release: v1.0.0