### PR TITLE
Adds new integration [Herbertmt978/Norman_Gen1_HA_Integration]

### DIFF
--- a/integration
+++ b/integration
@@ -961,6 +961,7 @@
   "helv-io/ha-gif",
   "HenkieThee/clash_royale",
   "henricm/ha-ferroamp",
+  "Herbertmt978/Norman_Gen1_HA_Integration",
   "herikw/home-assistant-custom-components",
   "Hermesiss/itchio_homeassistant",
   "herruzo99/ista-calista",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/Herbertmt978/Norman_Gen1_HA_Integration/releases/tag/v0.3.3>
Link to successful HACS action (without the ignore key): <https://github.com/Herbertmt978/Norman_Gen1_HA_Integration/actions/runs/29363815282>
Link to successful hassfest action (if integration): <https://github.com/Herbertmt978/Norman_Gen1_HA_Integration/actions/runs/29363814786>

This submission is for the current v0.3.3 release of a Home Assistant custom integration for Norman Gen 1 shutter hubs. It communicates with the hub over the local network and exposes room and panel shutter controls together with diagnostic battery sensors for the physical motors reported by the hub.

It has been tested against a physical Norman Gen 1 hub. Gen 2 compatibility is not claimed, and the project is not affiliated with or endorsed by Norman.

Thank you for considering it.