### PR TITLE
Add HACS compatibility for custom Frank Energie and Buienalarm integr…

### DIFF
--- a/integration
+++ b/integration
@@ -634,6 +634,8 @@
   "heyajohnny/afvalinfo",
   "heyajohnny/cryptoinfo",
   "hg1337/homeassistant-dwd",
+  "HiDiHo01/home-assistant-frank_energie",
+  "HiDiHo01/Buienalarm",
   "hif2k1/battery_sim",
   "hitchin999/protector_net",
   "hitchin999/YidCal",


### PR DESCRIPTION
…ation

This commit prepares the `home-assistant-frank_energie`  and `Buienalarm` repository for inclusion in HACS (Home Assistant Community Store).

Changes:
- Added required GitHub repository topics: `hacs`, `integration`, `home-assistant`, etc.
- Ensured manifest.json includes `integration_type` and `version` keys as required by HACS.
- Validated repository structure is compatible with HACS expectations.
- Confirmed that the integration can be added as a custom repository through the HACS UI.

Next steps (if public distribution is desired):
- Submit this repository to the HACS default list: https://github.com/hacs/default

This allows users to easily install and update the integration via the HACS interface in Home Assistant.

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [ ] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [ ] The actions are passing without any disabled checks in my repository.
- [ ] I've added a link to the action run on my repository below in the links section.
- [ ] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <>
Link to successful HACS action (without the `ignore` key): <>
Link to successful hassfest action (if integration): <>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->