### PR TITLE
Add Flybrow/lovelace-kiosk-autoscroll

### DIFF
--- a/plugin
+++ b/plugin
@@ -171,6 +171,7 @@
   "flixlix/energy-gauge-bundle-card",
   "flixlix/energy-period-selector-plus",
   "flixlix/power-flow-card-plus",
+  "Flybrow/lovelace-kiosk-autoscroll",
   "flyrmyr/system-flow-card",
   "francois-le-ko4la/lovelace-entity-progress-card",
   "fratsloos/fr24_card",


### PR DESCRIPTION
## Add Flybrow/lovelace-kiosk-autoscroll

Lovelace plugin: kiosk auto-scroll for dashboards, enabled per-view via an invisible card.

- Category: plugin (Lovelace)
- Repo: https://github.com/Flybrow/lovelace-kiosk-autoscroll
- HACS validation passing, has releases, topics, description, image in README.
