### PR TITLE
Add joyfulhouse/brilliant-mqtt

### DIFF
--- a/integration
+++ b/integration
@@ -1174,6 +1174,7 @@
   "joselcaguilar/azure-openai-ha",
   "josh-sanders/home-assistant-omnik-trannergy-pv-inverter",
   "joshdutcher/ourgroceries-kiosk-card",
+  "joyfulhouse/brilliant-mqtt",
   "joyfulhouse/eg4_web_monitor",
   "joyfulhouse/intellicenter",
   "joyfulhouse/moogo",


### PR DESCRIPTION
## Add `joyfulhouse/brilliant-mqtt`

**Category:** integration
**Repository:** https://github.com/joyfulhouse/brilliant-mqtt

Local MQTT bridge + Home Assistant integration for **Brilliant Smart Home Control**
in-wall touchscreen panels (Brilliant NextGen, brilliant.tech). Each panel's lights,
switches, scenes, and motion are exposed as local MQTT-Discovery entities; per-panel
management entities (bridge health, repair, agent update) run from the HA UI.

### Requirements met

- [x] Published GitHub release: `v0.2.0`
- [x] `hassfest` + `hacs` validation pass
- [x] Brand assets bundled in `custom_components/brilliant_mqtt/brand/` (HA 2026.3 brands proxy API) — no `home-assistant/brands` entry required
- [x] GitHub Issues enabled
- [x] Repository description + topics set
- [x] `quality_scale: platinum`
- [x] Entry added in alphabetical order

🤖 Generated with [Claude Code](https://claude.com/claude-code)