### PR TITLE
Add hiSweid/ha-auto-organizer

### DIFF
--- a/integration
+++ b/integration
@@ -973,6 +973,7 @@
   "hiall-fyi/tado_ce",
   "hif2k1/battery_sim",
   "hilman2/ha-sunspec2",
+  "hiSweid/ha-auto-organizer",
   "hitchin999/protector_net",
   "hitchin999/YidCal",
   "hiteule/rte-jours-signales",


### PR DESCRIPTION
Adds **Entity Auto-Organizer** (`hiSweid/ha-auto-organizer`) as an integration.

Automatically labels and organizes Home Assistant entities (labels + areas), rule-based, DE/EN, with UI controls. Passes the HACS validation (hassfest, HACS, tests; brand assets included).