### PR TITLE
Add nb3rt/Aquilo-HomeAssistant-HACS

### DIFF
--- a/integration
+++ b/integration
@@ -1648,6 +1648,7 @@
   "natekspencer/ha-vivint",
   "nathanmarlor/foxess_modbus",
   "Nazze/ha_best_bottrop_garbage_collection",
+  "nb3rt/Aquilo-HomeAssistant-HACS",
   "nbogojevic/homeassistant-midea-air-appliances-lan",
   "ndesgranges/bing-wallpaper",
   "ndesgranges/simple-plant",


### PR DESCRIPTION
Adds the Aquilo integration to the default HACS store.

- Repository: https://github.com/nb3rt/Aquilo-HomeAssistant-HACS
- Category: integration
- Local-polling integration for Aquilo water-level sensors (config flow, device per sensor, EN/PL translations).
- Repository validation (hacs/action + hassfest) passes on the default branch, and v1.0.0 is released.