### PR TITLE
Add pos-ei-don/ha-recorder-throttle

### DIFF
--- a/integration
+++ b/integration
@@ -1857,6 +1857,7 @@
   "popeen/Home-Assistant-Custom-Component-TCL-Remote",
   "popeen/Home-Assistant-Custom-Component-Temperatur-Nu",
   "PorlyBe/glance_clock_ha",
+  "pos-ei-don/ha-recorder-throttle",
   "Poshy163/HomeAssistant-Sharesight",
   "postlund/dlink_hnap",
   "Pouzor/freebox_player",


### PR DESCRIPTION
Adds the **Recorder Throttle** integration.

- Repository: https://github.com/pos-ei-don/ha-recorder-throttle
- Category: integration (domain `recorder_throttle`)
- Throttles the Home Assistant recorder's database writes per entity via labels — coarse history instead of none, with a management card and a Repairs report.

Checklist:
- Public repo with description, topics and issues enabled
- README, `hacs.json` with name, minimum HA version
- Released (`v0.4.0`)
- Own brand icon shipped in `custom_components/recorder_throttle/brand/`
- GitHub Actions: hassfest + HACS validation passing (without `ignore: brands`)