### PR TITLE
Add alextangson/janus

### DIFF
--- a/integration
+++ b/integration
@@ -88,6 +88,7 @@
   "alexlenk/ecowitt_local",
   "alexlenk/ha-dev-tools",
   "alexlenk/ha-everhome",
+  "alextangson/janus",
   "Alexwijn/SAT",
   "AlexxIT/Jura",
   "AlexxIT/SonoffLAN",


### PR DESCRIPTION
Adds `alextangson/janus` (integration).

Janus — an AI safety gatekeeper between any LLM and Home Assistant: the model proposes, deterministic code decides. HA conversation agent with `config_flow`, local (Ollama) or cloud (Anthropic) backends.

- Repo: https://github.com/alextangson/janus (MIT)
- Release: v0.1.0
- HACS + hassfest validation green; brand icon submitted at home-assistant/brands#10569
