### PR TITLE
Add pcs-agent/pcs-agent-ha

### DIFF
--- a/integration
+++ b/integration
@@ -1778,6 +1778,7 @@
   "pawkakol1/worlds-air-quality-index",
   "pcourbin/ecodevices_rt2",
   "pcourbin/imaprotect",
+  "pcs-agent/pcs-agent-ha",
   "pdw-mb/tsmart_ha",
   "Pehesi97/intelbras-amt-home-assistant",
   "pekur/amit_ha_integration",


### PR DESCRIPTION
Adds the PC Agent integration.

- Repository: https://github.com/pcs-agent/pcs-agent-ha
- Control a Windows/macOS PC from Home Assistant (power, volume, monitor, lock, apps, modes) with real-time state sync.
- Has description, topics, hacs.json, releases and README.
- Brand icons submitted: home-assistant/brands#10579