### PR TITLE
Add SlimHuys/slimhuys-homeassistant

### DIFF
--- a/integration
+++ b/integration
@@ -2121,6 +2121,7 @@
   "slesinger/HomeAssistant-PREdistribuce",
   "SLG/home-assistant-whatpulse",
   "sli-cka/karakeep-homeassistant",
+  "SlimHuys/slimhuys-homeassistant",
   "SlyBase/homeassistant-openmediavault",
   "slydiman/sscpoe",
   "smart-ishhome/temperature_alarm",


### PR DESCRIPTION
## Add new default repository

**Repository:** https://github.com/SlimHuys/slimhuys-homeassistant
**Latest release:** https://github.com/SlimHuys/slimhuys-homeassistant/releases/tag/v0.7.1
**CI action run:** https://github.com/SlimHuys/slimhuys-homeassistant/actions/runs/27950898164

### Checklist

- [x] I am the owner of the repository being submitted
- [x] The repository is publicly hosted on GitHub
- [x] The repository can be added as a custom repository in HACS
- [x] HACS Action passes without errors
- [x] Hassfest passes
- [x] The repository has at least one GitHub release (v0.7.1)