### PR TITLE
Add Dwains Dashboard Next

### DIFF
--- a/plugin
+++ b/plugin
@@ -132,6 +132,7 @@
   "dropqube/pv-forecast-card",
   "DTekNO/lovelace-meteogram-card",
   "dvb6666/homed-zigbee-networkmap",
+  "dwainscheeren/dwains-dashboard-next",
   "dylandoamaral/uptime-card",
   "Edward13ruf/nationalrail-status-card",
   "Edward13ruf/tfl-status-card",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository. Not applicable, this is a plugin/dashboard repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/dwainscheeren/dwains-dashboard-next/releases/tag/v1.1.1>
Link to successful HACS action (without the `ignore` key): <https://github.com/dwainscheeren/dwains-dashboard-next/actions/runs/27973452408>
Link to successful hassfest action (if integration): <Not applicable, this is a plugin/dashboard repository.>