### PR TITLE
Add kayl-codes/homeassistant-truenas (TrueNAS CE)

### DIFF
--- a/integration
+++ b/integration
@@ -1261,6 +1261,7 @@
   "KartoffelToby/better_thermostat",
   "kasztp/hass_databricks",
   "kattcrazy/tuya_unsupported_sensors",
+  "kayl-codes/homeassistant-truenas",
   "kclif9/hassactronneo",
   "kcoffau/AUS_BOM_Space_Weather_Alert_System",
   "kcofoni/ha-netro-watering",


### PR DESCRIPTION
Adds the **TrueNAS CE** integration (`kayl-codes/homeassistant-truenas`) to the HACS default store.

TrueNAS CE monitors and controls a TrueNAS device (25.04+) from Home Assistant over the TrueNAS JSON-RPC WebSocket API — system, pools, datasets, disks, VMs, containers, apps, services, replication/cloudsync/rsync/snapshot tasks, UPS, alerts and more, plus actions (start/stop/restart, snapshot, dataset lock/unlock, reboot/shutdown).

- Domain: `truenas_ce`
- HA minimum: 2024.8.0
- Latest release: `2.0.0`
- Brand assets ship locally at `custom_components/truenas_ce/brand/`.

The repository passes the HACS Action validation (integration category) and is not a fork.