### PR TITLE
Add jacobbjerregaard/homeassistant-growatt-modbus

### DIFF
--- a/integration
+++ b/integration
@@ -1093,6 +1093,7 @@
   "JAAlperin/hass-bardolph",
   "JaccoR/hass-entso-e",
   "JackJPowell/hass-unfoldedcircle",
+  "jacobbjerregaard/homeassistant-growatt-modbus",
   "jaidenlabelle/tuya-vacuum-maps",
   "jamesshannon/thermoworks-ha",
   "jampez77/DVLA-Vehicle-Enquiry-Service",


### PR DESCRIPTION
Adds the **Growatt Modbus** integration to the HACS default store.

- Repository: https://github.com/jacobbjerregaard/homeassistant-growatt-modbus
- Domain: `growatt_modbus`
- Category: integration

A local-polling Home Assistant integration that talks to Growatt inverters directly over Modbus (serial / TCP / UDP) — sensors, writable controls (number/select/switch), battery time-of-use scheduling, per-module telemetry, and an optional EMHASS optimizer bridge.

### Requirements
- [x] Standalone repository (not a fork)
- [x] Brand merged in `home-assistant/brands` (`custom_integrations/growatt_modbus`: icon + logo)
- [x] `hacs.json` present
- [x] Published GitHub releases (latest `v0.20.0`)
- [x] Passes hassfest and HACS validation in CI
- [x] `manifest.json` with `documentation`, `issue_tracker`, `codeowners`, `version` (`quality_scale: platinum`)
- [x] Repository description and topics set
- [x] I am the author/maintainer

Single entry added to the `integration` list, inserted in sorted position.