### PR TITLE
Add der-seemann/ha-broetje

### DIFF
--- a/integration
+++ b/integration
@@ -615,6 +615,7 @@
   "denysdovhan/ha-check-weather",
   "denysdovhan/ha-lun-misto-air",
   "denysdovhan/ha-yasno-outages",
+  "der-seemann/ha-broetje",
   "dermotduffy/hass-web-proxy-integration",
   "derolli1976/enpal",
   "derolli1976/HomeassistantCloudStash",


### PR DESCRIPTION
Adds der-seemann/ha-broetje to the HACS default integration list.