### PR TITLE
Adds new plugin [steuerlexi/shopping-list-card]

### DIFF
--- a/plugin
+++ b/plugin
@@ -531,6 +531,7 @@
   "Springvar/home-assistant-flightradar24-card",
   "starwarsfan/qclock-card",
   "stefmde/HomeAssistant-TwitchFollowedLiveStreamsCard",
+  "steuerlexi/shopping-list-card",
   "studiobts/device-pulse-table-card",
   "studiobts/device-pulse-timeline-card",
   "superdingo101/skylight-calendar-card",


### PR DESCRIPTION
Adds the shopping-list-card custom Lovelace card to the HACS default store.

https://github.com/steuerlexi/shopping-list-card