### PR TITLE
Add integration: hiSweid/last_changed_keeper

### DIFF
--- a/integration
+++ b/integration
@@ -973,6 +973,7 @@
   "hiall-fyi/tado_ce",
   "hif2k1/battery_sim",
   "hilman2/ha-sunspec2",
+  "hiSweid/last_changed_keeper",
   "hitchin999/protector_net",
   "hitchin999/YidCal",
   "hiteule/rte-jours-signales",


### PR DESCRIPTION
Adds [Last Changed Keeper](https://github.com/hiSweid/last_changed_keeper) — it restores the real `last_changed` time of entities after a Home Assistant restart, read from the recorder and written directly on the entity (no extra sensors).

- Public repository, release `v0.5.6`, topics set
- hassfest + HACS validation in CI
- Category: integration
