### PR TITLE
Add Gaming Status Cards to default store

### DIFF
--- a/plugin
+++ b/plugin
@@ -8,6 +8,7 @@
   "abmantis/ozw-network-visualization-card",
   "abualy/philips-tv-remote-card",
   "adamf83/lovelace-my-rail-commute-card",
+  "adamjthompson/Gaming-Status-Cards",
   "adaxi/ha-teamtracker-badge",
   "adizanni/floor3d-card",
   "aex351/home-assistant-neerslag-card",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [X] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [X] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [X] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [X] The actions are passing without any disabled checks in my repository.
- [X] I've added a link to the action run on my repository below in the links section.
- [X] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/adamjthompson/Gaming-Status-Cards>
Link to successful HACS action (without the `ignore` key): <https://github.com/adamjthompson/Gaming-Status-Cards/actions/runs/28113340662>
Link to successful hassfest action (if integration): <>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->