### PR TITLE
Add Schneider SELogic integration

### DIFF
--- a/integration
+++ b/integration
@@ -1500,6 +1500,7 @@
   "madpilot/hass-amber-electric",
   "madslundt/huligennem_ha",
   "maeek/ha-aux-cloud",
+  "magicbear/schneider_selogic_hacs",
   "magiczoom2/HA-Leneda-Power",
   "maginawin/ha-azoula-smart",
   "maginawin/ha-dali-center",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

- Link to current release: https://github.com/magicbear/schneider_selogic_hacs/releases/tag/v1.0.0
- Link to successful HACS action (without the `ignore` key): https://github.com/magicbear/schneider_selogic_hacs/actions/runs/28172842623
- Link to successful hassfest action: https://github.com/magicbear/schneider_selogic_hacs/actions/runs/28172842795

## Integration summary

**Repository:** `magicbear/schneider_selogic_hacs`  
**Domain:** `schneider_selogic`  
**Category:** Integration

Home Assistant custom integration for Schneider Electric SELogic / PM2xxx series power meters via Modbus/TCP.

### Features

- Config flow with connection validation
- 37 selectable sensors (voltage, current, power, power factor, frequency, energy, demand)
- Optimized Modbus polling (only reads register blocks for enabled sensors)
- Reconfigure flow
- Energy dashboard support (`total_increasing`)
- English and Simplified Chinese translations

### Supported devices

EM6400 NG, PM2120, PM2130, PM2220, PM2230 (PMC register map)

### Requirements

- Home Assistant 2023.9.0+
- pymodbus >= 3.10.0

### Maintainer

I am the repository owner and primary maintainer (@magicbear).