### PR TITLE
Add coffeerunhobby/ha-digi-rds-rcs

### DIFF
--- a/integration
+++ b/integration
@@ -471,6 +471,7 @@
   "cobryan05/ha-color-notify",
   "CoderAS-ru/hass-neatsvor",
   "codyc1515/ha-yeelock",
+  "coffeerunhobby/ha-digi-rds-rcs",
   "colings/synology_virtual_album",
   "CoMPaTech/stromer",
   "CompitHomeAssistant/HomeAssistant",


### PR DESCRIPTION
Adds **Digi (RCS & RDS)** — an unofficial Home Assistant integration for Digi România (formerly RCS & RDS) customer services: invoices, amounts due, due dates, overdue status, active services, and an opt-in public-IP sensor.

- Repository: https://github.com/coffeerunhobby/ha-digi-rds-rcs
- Domain: `digi`
- Latest release: `v0.3.1`
- Brand images bundled in `custom_components/digi/brand/` (HA 2026.3 mechanism).

The repository passes HACS validation (`hacs/action`) and `hassfest` in CI, has a description and topics, and contains a single integration under `custom_components/digi/`.