### PR TITLE
Add portbusy/ha-input-boolean-group

### DIFF
--- a/integration
+++ b/integration
@@ -1949,6 +1949,7 @@
   "popeen/Home-Assistant-Custom-Component-TCL-Remote",
   "popeen/Home-Assistant-Custom-Component-Temperatur-Nu",
   "PorlyBe/glance_clock_ha",
+  "portbusy/ha-input-boolean-group",
   "portbusy/smart-presence-notify",
   "Poshy163/HomeAssistant-Sharesight",
   "postlund/dlink_hnap",


### PR DESCRIPTION
## Checklist

- [x] I have read the [requirements](https://hacs.xyz/docs/publish/include)
- [x] The repository is public
- [x] I am the owner of the repository

## Information

| Field | Value |
|-------|-------|
| Repository | https://github.com/portbusy/ha-input-boolean-group |
| Category | Integration |
| Latest release | https://github.com/portbusy/ha-input-boolean-group/releases/tag/v1.0.0 |
| HACS Validation (run 1) | https://github.com/portbusy/ha-input-boolean-group/actions/runs/28231361762 |
| HACS Validation (run 2) | https://github.com/portbusy/ha-input-boolean-group/actions/runs/28231295880 |

## Description

Groups `input_boolean` entities into a single helper with four evaluation modes: **any**, **all**, **union** (explicit ON/OFF constraints), and **conditions** (full OR/AND/NOT logic using the same condition editor as automations). Configurable entirely from the UI, no YAML required.

Home Assistant's built-in Group helper does not support `input_boolean`. This integration fills that gap.