### PR TITLE
Add dougle03/trading-212

### DIFF
--- a/integration
+++ b/integration
@@ -695,6 +695,7 @@
   "dotelpenguin/ha-integration-jirafilters",
   "doubleukay/godaikin-ha",
   "doudz/homeassistant-myjdownloader",
+  "dougle03/trading-212",
   "dougrathbone/2n-doorman",
   "dphae/bsh",
   "drake69/NeverDry",


### PR DESCRIPTION
## Checklist

- [x] The repository is not archived.
- [x] The repository has a description.
- [x] The repository has topics.
- [x] The repository has issues enabled.
- [x] The repository is installable as a custom repository in HACS.
- [x] The repository has a GitHub release after HACS and Hassfest validation passed.
- [x] (For integrations only) I've added the hassfest action to my repository.

Repository: https://github.com/dougle03/trading-212

Successful Hassfest action:
https://github.com/dougle03/trading-212/actions/runs/28233360427

Successful HACS validation action:
https://github.com/dougle03/trading-212/actions/runs/28233360423

Latest release:
https://github.com/dougle03/trading-212/releases/tag/v2026.06.7

This is a strictly read-only Trading 212 Home Assistant integration. It exposes portfolio/account summary sensors and does not place trades, cancel orders, edit pies, or expose account-changing Home Assistant services, buttons, switches, or selects.