### PR TITLE
Add rohanpatil1794/ha-vehicle-android-auto-card

### DIFF
--- a/plugin
+++ b/plugin
@@ -505,6 +505,7 @@
   "RJArmitage/rfxtrx-stateful-blinds-icons",
   "rkotulan/ha-wall-clock-card",
   "RodBr/miflora-card",
+  "rohanpatil1794/ha-vehicle-android-auto-card",
   "roman-16/better-miflora-card",
   "RomRider/apexcharts-card",
   "rosenrot00/home-flow-card",


### PR DESCRIPTION
## Description

Add [Vehicle Android Auto Card](https://github.com/rohanpatil1794/ha-vehicle-android-auto-card) to the HACS default plugin repository.

This card displays real-time vehicle data from the Home Assistant Companion App's Android Auto integration, including odometer, range, speed, fuel level, fuel type, and connection status.

## Checklist
- [x] Repository is public
- [x] Repository has a description
- [x] Repository has the `hacs` and `lovelace` topics
- [x] `hacs.json` is present
- [x] `README.md` is present
- [x] GitHub release exists with a valid semantic version tag (v1.0.1)
- [x] Release asset (`vehicle-android-auto-card.js`) is attached