### PR TITLE
Add Smart-Home-Assistant-UK/homeassistant-trading212

### DIFF
--- a/integration
+++ b/integration
@@ -2231,6 +2231,7 @@
   "slx612/WOL-Home-Assistant-And-Alexa",
   "SlyBase/homeassistant-openmediavault",
   "slydiman/sscpoe",
+  "Smart-Home-Assistant-UK/homeassistant-trading212",
   "smart-ishhome/temperature_alarm",
   "smarthomeblack/npc",
   "smarthomeblack/zalo_bot",


### PR DESCRIPTION
## Checklist

- [x] I have read [the requirements](https://hacs.xyz/docs/publish/integration/) for submitting an integration to HACS
- [x] This repository complies with all requirements
- [x] The repository contains a `hacs.json` file
- [x] The repository contains a valid `manifest.json` with `version` field
- [x] The integration lives under `custom_components/trading212/`
- [x] There is at least one GitHub release

## About

Trading212 integration for Home Assistant. Exposes a Trading212 investment portfolio as sensor entities:

- Account-level sensors (portfolio value, cash, invested, return, P&L, etc.)
- Per-position sensors (current price, quantity, P&L, return %)
- Per-pie sensors (value, return, invested, etc.)
- Daily gain/loss tracking with midnight reset

## Links

- Repository: https://github.com/Smart-Home-Assistant-UK/homeassistant-trading212
- Latest release: https://github.com/Smart-Home-Assistant-UK/homeassistant-trading212/releases/tag/v1.0.0
- CI action runs: https://github.com/Smart-Home-Assistant-UK/homeassistant-trading212/actions