### PR TITLE
Add Smart-Home-Assistant-UK/lovelace-trading212-card

### DIFF
--- a/integration
+++ b/integration
@@ -2231,6 +2231,7 @@
   "slx612/WOL-Home-Assistant-And-Alexa",
   "SlyBase/homeassistant-openmediavault",
   "slydiman/sscpoe",
+  "Smart-Home-Assistant-UK/homeassistant-trading212",
   "smart-ishhome/temperature_alarm",
   "smarthomeblack/npc",
   "smarthomeblack/zalo_bot",

--- a/plugin
+++ b/plugin
@@ -542,6 +542,7 @@
   "skeefee/android-tv-remote-card",
   "skydarc/Venus-OS-Dashboard",
   "slipx06/sunsynk-power-flow-card",
+  "Smart-Home-Assistant-UK/lovelace-trading212-card",
   "snootched/cb-lcars",
   "soestin/hass_periodic_card_reload",
   "sonite/particle-cloud-card",


### PR DESCRIPTION
## Checklist

- [x] I have read [the requirements](https://hacs.xyz/docs/publish/frontend/) for submitting a frontend plugin to HACS
- [x] This repository complies with all requirements
- [x] The repository contains a `hacs.json` file
- [x] There is at least one GitHub release with the built JS file attached
- [x] `hacs.json` specifies `filename: investment-card.js`

## About

Lovelace card for the Trading212 Home Assistant integration. Displays a portfolio overview, positions, and pies in a single card with expandable sections and multiple theme support.

## Links

- Repository: https://github.com/Smart-Home-Assistant-UK/lovelace-trading212-card
- Latest release: https://github.com/Smart-Home-Assistant-UK/lovelace-trading212-card/releases/tag/v1.0.0
- CI action runs: https://github.com/Smart-Home-Assistant-UK/lovelace-trading212-card/actions