### PR TITLE
Add Budget Thuis integration

### DIFF
--- a/integration
+++ b/integration
@@ -1004,6 +1004,7 @@
   "hass-uconnect/hass-uconnect",
   "hasscc/hass-edge-tts",
   "HASwitchPlate/openHASP-custom-component",
+  "hbahadorzadeh/budget-thuis-ha",
   "hcoohb/hass-yeelightbt",
   "HCookie/Webhook-Service-home-assistant",
   "hebrru/baillclim",


### PR DESCRIPTION
Adds hbahadorzadeh/budget-thuis-ha to the default HACS integration repositories.\n\nThe repository provides a Home Assistant custom integration for Budget Thuis electricity usage and has a published GitHub release.