### PR TITLE
Add abpei/hacs_horizontal-bidirectional-gauge

### DIFF
--- a/plugin
+++ b/plugin
@@ -6,6 +6,7 @@
   "a-p-z/datetime-card",
   "Aasikki/comic-card",
   "abmantis/ozw-network-visualization-card",
+  "abpei/hacs_horizontal-bidirectional-gauge",
   "abualy/philips-tv-remote-card",
   "adamf83/lovelace-my-rail-commute-card",
   "adaxi/ha-teamtracker-badge",


### PR DESCRIPTION
## Add Horizontal Bidirectional Gauge to HACS Default Store

**Repository:** https://github.com/abpei/hacs_horizontal-bidirectional-gauge

### Description
Custom Lovelace card: horizontal bar gauge with zero divider, bidirectional fill, and diagonal stripe flow animation for Home Assistant dashboards.

### Features
- Bidirectional fill from configurable zero divider
- Asymmetric range support with correct zero positioning
- Diagonal stripe flow animation (direction-aware)
- Scale row with optional unit display
- Visual editor (getConfigForm) with expandable sections
- tap_action interaction (more-info, toggle, navigate, none)
- 21 configurable options
- Theme-aware CSS variables, dark/light mode support
- Graceful unavailable/unknown entity handling

### Checklist
- [x] Public GitHub repository
- [x] HACS Action passes
- [x] GitHub release with artifact
- [x] README with screenshots
- [x] hacs.json in root
- [x] hacs-custom-card topic
- [x] Issues enabled