### PR TITLE
Add ReikanYsora/Helios-Forecast

### DIFF
--- a/integration
+++ b/integration
@@ -2005,6 +2005,7 @@
   "redstone99/hass-alert2",
   "Refoss/refoss-homeassistant",
   "Refoss/refoss_rpc",
+  "ReikanYsora/Helios-Forecast",
   "reinos/solar-daytopper-ha",
   "remialban/ipx800v3",
   "remimikalsen/ollama_vision",


### PR DESCRIPTION
Hi HACS team, and thank you for everything you do for this community.

I would love to add Helios Forecast to the default store.

Helios Forecast is an accurate, self-learning solar production forecast for Home Assistant. It computes the PV forecast on the server from Open-Meteo irradiance and the installation geometry, then learns a correction from the home's own recorded production, so the prediction keeps getting closer to what the panels really do: shading, soiling, orientation error, inverter clipping, even battery curtailment.

It gives back three things people actually use day to day:
- A native provider for the official Energy dashboard, so the forecast sits right next to real production.
- A clean set of sensors (power now and next hour, per-day energy and peaks over a 7 day horizon, energy left today) ready to drop into automations.
- A sub-hourly detail series for the companion Helios card.

Configuration is one entry per panel line, so every roof orientation gets its own forecast, its own device and its own entities.

Repository: https://github.com/ReikanYsora/Helios-Forecast

Thanks a lot for taking a look, and for the store that makes sharing this so easy.