### PR TITLE
Adds new integration [javaDevJT/ha-xsense-home]

### DIFF
--- a/integration
+++ b/integration
@@ -1157,6 +1157,7 @@
   "jasonwragg/home-assistant-readynaslocal",
   "jasperslits/haithowifi",
   "javaDevJT/DTE-Rates-for-Home-Assistant",
+  "javaDevJT/ha-xsense-home",
   "Javisen/proxmox_sensors",
   "JayBlackedOut/hass-nhlapi",
   "jaycollett/OpenIRBlaster",


### PR DESCRIPTION
Adds X-Sense Home Security as a default HACS integration.\n\nSource repository: https://github.com/javaDevJT/ha-xsense-home\nRelease: https://github.com/javaDevJT/ha-xsense-home/releases/tag/v0.1.4\n\nPre-submission validation on the source repository:\n- HACS: https://github.com/javaDevJT/ha-xsense-home/actions/runs/28338163794\n- Hassfest: https://github.com/javaDevJT/ha-xsense-home/actions/runs/28338163798\n\nLocal validation in hacs/default:\n- jq parses repository lists\n- python3 scripts/is_sorted.py\n- integration contains javaDevJT/ha-xsense-home once in sorted order