### PR TITLE
Add dimgen/homeassistant-vmc-ubbink

### DIFF
--- a/integration
+++ b/integration
@@ -655,6 +655,7 @@
   "DigitallyRefined/ha-cloudflare-speed-test",
   "DigitallyRefined/ha-hwmon_temp",
   "dimagoltsman/ha-proof-dashcam-integration",
+  "dimgen/homeassistant-vmc-ubbink",
   "dingo35/ha-SmartEVSEv3",
   "dinki/view_assist_integration",
   "dirkgroenen/hass-evse-load-balancer",


### PR DESCRIPTION
Adds the **VMC Ubbink** integration (Ubbink Ubiflux Vigor W325/W400 ventilation) to the integration category.

- Repo: https://github.com/dimgen/homeassistant-vmc-ubbink
- Single integration under `custom_components/vmc_ubbink/`
- Brand icon shipped in `custom_components/vmc_ubbink/brand/`
- `hacs.json` present; public repo with description, topics and Issues enabled
- First GitHub Release published (`v1.1.0`)
- CI green: HACS Action (category integration) + Hassfest

Owner submission (I am @dimgen, the repository owner).