### PR TITLE
Add cbetz/ratebook-homeassistant

### DIFF
--- a/integration
+++ b/integration
@@ -406,6 +406,7 @@
   "cavefire/hass-openid",
   "caveman2024/sossen-ha",
   "cazeaux/ha-iracing",
+  "cbetz/ratebook-homeassistant",
   "cdnninja/yoto_ha",
   "cedricziel/ha-matter-binding-helper",
   "cedricziel/ha-sunlit",


### PR DESCRIPTION
Adds **Ratebook**, a Home Assistant integration exposing live US electricity-price and cheapest-charge-window sensors from real utility tariffs.

- Repo: https://github.com/cbetz/ratebook-homeassistant
- Passes HACS validation + hassfest (scheduled and on push), has a v0.1.0 release, and ships brand icons in its `brand/` folder.
- No cloud account or API key; the rate engine and data are bundled.