### PR TITLE
Add Media Frame integration (GripSoftApps/Media-Frame-HACS)

### DIFF
--- a/integration
+++ b/integration
@@ -953,6 +953,7 @@
   "gregoryduckworth/GoogleGeocode-HASS",
   "grid-coordination/openadr3-ven-hass",
   "grimmpp/home-assistant-eltako",
+  "GripSoftApps/Media-Frame-HACS",
   "Griswoldlabs/span-panel-ha",
   "gritaro/gigachain",
   "grotan1/denon-avr-3805",


### PR DESCRIPTION
## Summary
- Adds [GripSoftApps/Media-Frame-HACS](https://github.com/GripSoftApps/Media-Frame-HACS) to the default integration list.
- Home Assistant custom integration for Media Frame Android tablets via LAN REST (port 8787).

## Repository checks
- Public repository with README, topics, and `hacs.json`
- GitHub Actions: hassfest + HACS validation passing on `main` and release `v1.0.1`
- Brand icon at `custom_components/media_frame/brand/icon.png`
- GitHub release published: v1.0.1

## Integration
- Domain: `media_frame`
- Config flow, device integration, local polling
- MIT licensed

## Note
If HACS policy requires this PR from a personal account rather than the `GripSoftApps` org fork, I can resubmit from a personal fork on request.