### PR TITLE
Add Media Frame integration (GripSoftApps/Media-Frame-HACS)

### DIFF
--- a/integration
+++ b/integration
@@ -953,6 +953,7 @@
   "gregoryduckworth/GoogleGeocode-HASS",
   "grid-coordination/openadr3-ven-hass",
   "grimmpp/home-assistant-eltako",
+  "GripSoftApps/Media-Frame-HACS",
   "Griswoldlabs/span-panel-ha",
   "gritaro/gigachain",
   "grotan1/denon-avr-3805",


### PR DESCRIPTION
## Summary
Adds [GripSoftApps/Media-Frame-HACS](https://github.com/GripSoftApps/Media-Frame-HACS) to the default integration list.

Home Assistant integration for Media Frame Android tablets (LAN REST, port 8787).

## Repository
- Public repo with README, topics, LICENSE, MIT
- Latest release: **v2.0.3**
- CI: hassfest + HACS validation passing
- Brand: \custom_components/media_frame/brand/icon.png\
- Tested as custom repository before this PR

## Integration
- Domain: \media_frame\
- Config flow, device integration, local polling
- No secrets in repository

## Note
Replaces closed PR #8846 (same addition, repository now at v2.0.3 with passing validation).

Made with [Cursor](https://cursor.com)