### PR TITLE
Add Media Frame integration (GripSoftApps/home-assistant-media-frame)

### DIFF
--- a/integration
+++ b/integration
@@ -953,7 +953,7 @@
   "gregoryduckworth/GoogleGeocode-HASS",
   "grid-coordination/openadr3-ven-hass",
   "grimmpp/home-assistant-eltako",
-  "GripSoftApps/Media-Frame-HACS",
+  "GripSoftApps/home-assistant-media-frame",
   "Griswoldlabs/span-panel-ha",
   "gritaro/gigachain",
   "grotan1/denon-avr-3805",

--- a/integration
+++ b/integration
@@ -953,6 +953,7 @@
   "gregoryduckworth/GoogleGeocode-HASS",
   "grid-coordination/openadr3-ven-hass",
   "grimmpp/home-assistant-eltako",
+  "GripSoftApps/Media-Frame-HACS",
   "Griswoldlabs/span-panel-ha",
   "gritaro/gigachain",
   "grotan1/denon-avr-3805",


### PR DESCRIPTION
## Summary
Adds [GripSoftApps/home-assistant-media-frame](https://github.com/GripSoftApps/home-assistant-media-frame) to the default integration list.

Home Assistant integration for Media Frame Android tablets (LAN REST on port 8787).

## Links (required)
- Repository: https://github.com/GripSoftApps/home-assistant-media-frame
- Latest release: https://github.com/GripSoftApps/home-assistant-media-frame/releases/latest
- CI action runs: https://github.com/GripSoftApps/home-assistant-media-frame/actions/workflows/validate.yaml

## Checklist
- [x] I am submitting only **one** repository
- [x] Repository is public and compliant with https://hacs.xyz/docs/publish/start
- [x] Tested as a custom repository in HACS before this PR
- [x] Only **one** line added to the `integration` file
- [x] List remains alphabetically sorted
- [x] Repository name does **not** contain HACS (renamed from Media-Frame-HACS)
- [x] GitHub release published (v2.0.4)
- [x] hassfest + HACS validation passing on main

## Integration
- Domain: `media_frame`
- Config flow, device integration, local polling
- MIT licensed
