### PR TITLE
Add dsackr/fraimic-homeassistant

### DIFF
--- a/integration
+++ b/integration
@@ -706,6 +706,7 @@
   "droans/mass_queue",
   "droidgren/smhi_season",
   "droso-hass/idfm",
+  "dsackr/fraimic-homeassistant",
   "dscao/ikuai",
   "DSorlov/http_agent",
   "DSorlov/snmp_printer",


### PR DESCRIPTION
## Repository
https://github.com/dsackr/fraimic-homeassistant

Home Assistant integration for Fraimic e-ink photo frames — battery/WiFi sensors, restart/sleep/refresh controls, and a shared image library for pushing artwork to one or more frames.

## Checklist
- [x] Public repository
- [x] Issues enabled
- [x] Repository has a description
- [x] Repository has topics
- [x] Passes hassfest
- [x] Passes HACS validation action
- [x] Brand icon included (custom_components/fraimic/brand/icon.png + icon@2x.png)
- [x] Has a GitHub release (latest: v0.4.2)