### PR TITLE
Add Anycubic HA Integration

### DIFF
--- a/integration
+++ b/integration
@@ -1458,6 +1458,7 @@
   "lizardsystems/hass-tnse",
   "ljbotero/hvac-vent-optimizer",
   "ljmerza/orbit-bhyve-ble",
+  "ljschmitt/hass-anycubic_cloud_v3",
   "lloydw/hass-spanet",
   "lmt-lv/lmt-iot-ha-integration",
   "lnagel/hass-eaton-ups-mqtt",


### PR DESCRIPTION
## Proposed change

Add `ljschmitt/hass-anycubic_cloud_v3` as a default HACS integration repository.

The repository provides a Home Assistant custom integration for Anycubic cloud printers, including status sensors, MQTT updates, print/file functions, ACE/material handling, and an optional camera panel.

## Checklist

- [x] Repository is public
- [x] Repository has stable GitHub releases
- [x] Latest stable release is `v0.3.1`
- [x] HACS validation passes in the integration repository
- [x] Hassfest passes in the integration repository
- [x] Repository includes local brand assets under `custom_components/anycubic_ha_integration/brand/`