### PR TITLE
Adds new integration [Karo-X/obi_energy]

### DIFF
--- a/integration
+++ b/integration
@@ -1303,6 +1303,7 @@
   "Kannix2005/homeassistant-selve",
   "Kaptensanders/skolmat",
   "Kaptensanders/vklass",
+  "Karo-X/obi_energy",
   "Kartax/home-assistant-binance",
   "KartoffelToby/better_thermostat",
   "kasztp/hass_databricks",


### PR DESCRIPTION
Add OBI Energy integration by Karo-X to the default HACS repository list.

Repository:
https://github.com/Karo-X/obi_energy

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [X] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [X] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [X] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [X] The actions are passing without any disabled checks in my repository.
- [X] I've added a link to the action run on my repository below in the links section.
- [X] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/Karo-X/obi_energy/releases/tag/v0.1.0>
Link to successful HACS action (without the `ignore` key): <https://github.com/Karo-X/obi_energy/actions/runs/28549782407>
Link to successful hassfest action (if integration): <https://github.com/Karo-X/obi_energy/actions/runs/28549782388>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->