### PR TITLE
Add LayerTM/unifi-unas-ha

### DIFF
--- a/integration
+++ b/integration
@@ -1422,6 +1422,7 @@
   "lavalex2003/profimaktab",
   "LavermanJJ/home-assistant-solarfocus",
   "LawPaul/HA_Solar_Shade",
+  "LayerTM/unifi-unas-ha",
   "lbbrhzn/ocpp",
   "ledimestari/homeassistant-precious-metals",
   "ledimestari/homeassistant-storj-integration",


### PR DESCRIPTION
Adds **LayerTM/unifi-unas-ha** to the default integration list.

A non-invasive (agentless, read-only by default) Home Assistant integration for the Ubiquiti **UniFi UNAS**, via the local UniFi OS / UniFi Drive REST API — no SSH, nothing installed on the NAS.

- Repository: https://github.com/LayerTM/unifi-unas-ha
- Category: integration · HACS-compliant (`hacs.json`, releases v1.0.0–v1.7.0, `hacs/action` passing)
- Home Assistant quality scale: **platinum** (self-reported)

**Depends on** home-assistant/brands#10666 (adds the `unifi_unas_rest` brand) — the brand check will pass once that merges.
