### PR TITLE
Add distante/ha-xplora-watch

### DIFF
--- a/integration
+++ b/integration
@@ -665,6 +665,7 @@
   "dinki/view_assist_integration",
   "dirkgroenen/hass-evse-load-balancer",
   "DisplacedForest/ha-hevy-tracker",
+  "distante/ha-xplora-watch",
   "DiUS/homeassistant-powersensor",
   "Dixet/homeassistant_hetzner",
   "djansen1987/SAJeSolar",


### PR DESCRIPTION
Adds the Xplora® Watch integration to the default store.

- Repository: https://github.com/distante/ha-xplora-watch
- Category: `integration`
- Brand: already present in home-assistant/brands (`custom_integrations/xplora_watch`)
- CI runs hassfest + `hacs/action` (category: integration) and is passing; latest release `v1.2.2`.
