### PR TITLE
Add jonathan-gtd/scribe

### DIFF
--- a/integration
+++ b/integration
@@ -1254,6 +1254,7 @@
   "JonasJoKuJonas/homeassistant-trias",
   "JonasJoKuJonas/homeassistant-WebUntis",
   "JonasPed/homeassistant-eloverblik",
+  "jonathan-gtd/scribe",
   "jonkristian/wasteplan_trv",
   "jonnybergdahl/HomeAssistant_NewsbinPro_Integration",
   "jonnynch/ha-jemenaoutlook",


### PR DESCRIPTION
Adds [`jonathan-gtd/scribe`](https://github.com/jonathan-gtd/scribe) to the `integration` category.

**Scribe** — high-performance TimescaleDB integration for Home Assistant. Records states & events via `asyncpg`, with automatic hypertables, compression policies, and rich entity/area/device context.

Requirements checklist:
- [x] Repository is public and not archived
- [x] Repository has a description and topics
- [x] Integration lives in `custom_components/scribe/`
- [x] Valid `manifest.json` (domain, name, codeowners, documentation, issue_tracker, version)
- [x] `hacs.json` present
- [x] Published GitHub releases (latest `v3.6.2`)
- [x] Brand icons merged in `home-assistant/brands` (`custom_integrations/scribe`)
- [x] HACS + hassfest validation workflow added