### PR TITLE
Add smarthomebutbetter/navroom-card

### DIFF
--- a/plugin
+++ b/plugin
@@ -547,6 +547,7 @@
   "skeefee/android-tv-remote-card",
   "skydarc/Venus-OS-Dashboard",
   "slipx06/sunsynk-power-flow-card",
+  "smarthomebutbetter/navroom-card",
   "snootched/cb-lcars",
   "soestin/hass_periodic_card_reload",
   "sonite/particle-cloud-card",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/smarthomebutbetter/navroom-card/releases/tag/v2.1.2>
Link to successful HACS action (without the `ignore` key): <https://github.com/smarthomebutbetter/navroom-card/actions/runs/28648822695>
Link to successful hassfest action (if integration): <N/A>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->
