### PR TITLE
Add nunogbento/ha-lazarus

### DIFF
--- a/integration
+++ b/integration
@@ -1843,6 +1843,7 @@
   "nstrelow/ha_philips_android_tv",
   "nuggetz/ha-amazon-price-tracker",
   "nuggetz/ha-gaming-hub",
+  "nunogbento/ha-lazarus",
   "nussfuellung/paradigma-homeassistant",
   "nyffchanium/argoclima-integration",
   "NylonDiamond/homeassistant-wrist-assistant",


### PR DESCRIPTION
Adds [Lazarus](https://github.com/nunogbento/ha-lazarus) — a Home Assistant custom integration that revives legacy iPads/iPhones (iOS 10.3+) as always-on wall panels.

- Domain: `lazarus`
- Category: integration
- Brands PR: home-assistant/brands#10680 (icons)
- Released: v0.1.0

Note: the brands PR above needs to merge first for the icon check to pass.