### PR TITLE
Add cyrilcolinet/enki-integration-hass

### DIFF
--- a/integration
+++ b/integration
@@ -555,6 +555,7 @@
   "Cyr-ius/hass-heatzy",
   "Cyr-ius/hass-livebox-component",
   "cyr-ius/hass-reolink-thumbs",
+  "cyrilcolinet/enki-integration-hass",
   "D-N91/home-assistant-global-health-score",
   "d03n3rfr1tz3/hass-divoom",
   "DaanVervacke/hass-engie-be",


### PR DESCRIPTION
## Summary
- Adds `cyrilcolinet/enki-integration-hass` to the default integration list.
- Custom integration for the Enki / Leroy Merlin smart home ecosystem (lights, covers, climate, scenarios, electrical consumption, etc.).
- Brand assets are bundled locally per the [Brands Proxy API](https://developers.home-assistant.io/blog/2026/02/24/brands-proxy-api/) (`custom_components/enki/brand/icon.png` + `icon@2x.png`).

## Repository
https://github.com/cyrilcolinet/enki-integration-hass

## Test plan
- [x] Repository meets HACS requirements (manifest, hacs.json, CI with HACS action)
- [x] Brand icons present at required paths and sizes (256×256, 512×512)
- [x] Integration domain matches manifest (`enki`)