### PR TITLE
Adds new plugin [maxfok/nimbus-climate-card]

### DIFF
--- a/plugin
+++ b/plugin
@@ -390,6 +390,7 @@
   "mathoudebine/homeassistant-browser-control-card",
   "mattieha/select-list-card",
   "mawinkler/astroweather-card",
+  "maxfok/nimbus-climate-card",
   "maxfok/nimbus-weather-card",
   "maxwroc/battery-state-card",
   "maxwroc/github-flexi-card",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: https://github.com/maxfok/nimbus-climate-card/releases/tag/v1.3.2.2
Link to successful HACS action (without the `ignore` key): https://github.com/maxfok/nimbus-climate-card/actions/runs/28676900145/job/85052116898
Link to successful hassfest action (if integration): N/A — this is a plugin/card repository.
