### PR TITLE
Adds new integration [mojo17/ha-enova-power]

### DIFF
--- a/integration
+++ b/integration
@@ -1700,6 +1700,7 @@
   "moerk-o/ha-solstice_season",
   "moerk-o/WhenHub",
   "Mofeywalker/openmensa-hass-component",
+  "mojo17/ha-enova-power",
   "Monitor-My-Solar/monitormysolar",
   "monty68/uniled",
   "moox-it/hass-moox-track",


### PR DESCRIPTION
Adds the Enova Power integration: consumption, cost, and rate-plan sensors plus long-term statistics for the Enova Power (Ontario, Canada) utility customer portal.

## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/mojo17/ha-enova-power/releases/tag/v0.5.2>
Link to successful HACS action (without the `ignore` key): <https://github.com/mojo17/ha-enova-power/actions/runs/28690880728/job/85091821853>
Link to successful hassfest action (if integration): <https://github.com/mojo17/ha-enova-power/actions/runs/28690880728/job/85091821855>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->
