### PR TITLE
Adds new integration [DemiVis/ha-checkiday]

### DIFF
--- a/integration
+++ b/integration
@@ -640,6 +640,7 @@
   "delphiki/hass-pronote",
   "delphiki/hass-tarif-edf",
   "DeLuca21/ynab-ha",
+  "DemiVis/ha-checkiday",
   "demoklion/home-assistant-globaltrack",
   "Dennis90BW/ha-power-helper",
   "denov/home-assistant-apex-neptune",


### PR DESCRIPTION
Add new repo, DemiVis/ha-checkiday, to default integrations

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: [https://github.com/DemiVis/ha-checkiday/releases/tag/v1.0.0](https://github.com/DemiVis/ha-checkiday/releases/tag/v1.0.0)
Link to successful HACS action (without the `ignore` key): [https://github.com/DemiVis/ha-checkiday/actions/runs/28693101419/job/85097893515](https://github.com/DemiVis/ha-checkiday/actions/runs/28693101419/job/85097893515)
Link to successful hassfest action (if integration): [https://github.com/DemiVis/ha-checkiday/actions/runs/28693101435/job/85097893744](https://github.com/DemiVis/ha-checkiday/actions/runs/28693101435/job/85097893744)

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->