### PR TITLE
Add Ofloo/growatt_meter_emulator to default integrations

### DIFF
--- a/integration
+++ b/integration
@@ -335,6 +335,7 @@
   "bndtblds/homeassistant-vorwerk",
   "bobbesnl/growatt_thor",
   "bobsilesia/oblamatik",
+  "Ofloo/growatt_meter_emulator",
   "BobTheShoplifter/HomeAssistant-Posten",
   "bodyscape/cielo_home",
   "BoilerController/boiler-controller-ha",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
- Title: Add Ofloo/growatt_meter_emulator to default integrations
- Description: 
This PR adds the growatt_meter_emulator integration to HACS defaults.

The integration emulates a CHINT DDSU666 energy meter via Modbus TCP for Home Assistant.
It meets all HACS requirements:
- Public repository with MIT license
- manifest.json with correct version (0.3.0)
- README with installation instructions
<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->