### PR TITLE
Add Ofloo/growatt_meter_emulator to default integrations

### DIFF
--- a/integration
+++ b/integration
@@ -335,6 +335,7 @@
   "bndtblds/homeassistant-vorwerk",
   "bobbesnl/growatt_thor",
   "bobsilesia/oblamatik",
+  "Ofloo/growatt_meter_emulator",
   "BobTheShoplifter/HomeAssistant-Posten",
   "bodyscape/cielo_home",
   "BoilerController/boiler-controller-ha",


### PR DESCRIPTION
Title:
Add Ofloo/growatt_meter_emulator to default integrations
Description:
This PR adds the growatt_meter_emulator integration to HACS defaults.

The integration emulates a CHINT DDSU666 energy meter via Modbus TCP for Home Assistant.
It meets all HACS requirements:
- Public repository with MIT license
- manifest.json with correct version (0.3.0)
- README with installation instructions