### PR TITLE
Add mkirsten/lydbro-hass

### DIFF
--- a/integration
+++ b/integration
@@ -1686,6 +1686,7 @@
   "MislavMandaric/home-assistant-vaillant-vsmart",
   "miyosmart/miyocube-homeassistant-custom-component",
   "mjcumming/wiim",
+  "mkirsten/lydbro-hass",
   "MKSG-MugunthKumar/ha-chameleon",
   "MKsys1337/MiWiFi-CB0401V2",
   "mkuthan/solis-cloud-control",


### PR DESCRIPTION
## Repository
https://github.com/mkirsten/lydbro-hass

Home Assistant integration for the [Lydbro One](https://lydbro.com) bridge — brings the Bang & Olufsen BeoRemote One into Home Assistant over a local push TCP connection (config flow, zeroconf discovery, event entities and device triggers for every button, battery/link sensors, services).

## Checklist

- [x] I am the owner of the repository
- [x] The repository is public and can be added as a HACS custom repository
- [x] [HACS action](https://github.com/mkirsten/lydbro-hass/actions/workflows/validate.yml) with `category: integration` passes (no `ignore`)
- [x] [Hassfest](https://github.com/mkirsten/lydbro-hass/actions/workflows/validate.yml) passes
- [x] GitHub release published: [v0.2.5](https://github.com/mkirsten/lydbro-hass/releases/tag/v0.2.5)
- [x] Brand images ship in the integration's own `brand/` directory (`icon.png` + `icon@2x.png`, HA ≥ 2026.3.0 style)
- [x] Entry added alphabetically to `integration`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C2GPvoxbEJntREHGMbByMg