### PR TITLE
Add jarvis2k1/ha-appletv-mgmt

### DIFF
--- a/integration
+++ b/integration
@@ -1175,6 +1175,7 @@
   "jarcovlieger/brink-hrv-modbus",
   "jaroschek/home-assistant-myuplink",
   "jaruba/ha-samsungtv-tizen",
+  "jarvis2k1/ha-appletv-mgmt",
   "jason0x43/hacs-hubitat",
   "jasonmx/philips-hue-smooth-dimmer",
   "jasonwragg/home-assistant-readynaslocal",


### PR DESCRIPTION
Adds the **appletv_mgmt** integration — kids' screen-time management for Apple TV + game consoles on Home Assistant (daily/per-category budgets, enforcement, voice warnings, parent approval, REST API).

- Repository: https://github.com/jarvis2k1/ha-appletv-mgmt
- Category: integration
- Public ✓, description ✓, topics ✓, GitHub release ✓ (v0.20.2), README ✓
- hassfest + HACS action pass except the **brands** check, which is pending in home-assistant/brands#10690 (adds `custom_integrations/appletv_mgmt` icons). This PR will go green once that merges.