### PR TITLE
Add sdotter/OtterIR to integration

### DIFF
--- a/integration
+++ b/integration
@@ -2209,6 +2209,7 @@
   "script0803/BituoPMD",
   "sdague/cenhud-rates",
   "Sdahl1234/Sunseeker-lawn-mower",
+  "sdotter/OtterIR",
   "SDR3078/ps3-home-assistant",
   "sdrapha/home-assistant-custom-components-pfsense-gateways",
   "seanharsh/HA-DelOH-Refuse-Schedule",


### PR DESCRIPTION
## Description\nAdd sdotter/OtterIR to the HACS default integration list in alphabetical order.\n\n## Checklist\n- [x] Repository is public and hosted on GitHub\n- [x] HACS Action and Hassfest are configured in the repository\n- [x] GitHub release created\n- [x] Entry added alphabetically