### PR TITLE
Scope integration discovery to custom_components

### DIFF
--- a/scripts/helpers/integration_path.py
+++ b/scripts/helpers/integration_path.py
@@ -1,11 +1,20 @@
-import json
 import os
 from glob import glob
 
 
 def get_integration_path():
+    base = "/tmp/repositories/addition"
+    # Per the publishing docs, an integration lives in
+    # ROOT/custom_components/<domain>. Scope the search there when the
+    # directory exists so repositories that also ship other manifest.json
+    # files (add-ons, test fixtures) resolve to the integration; fall back
+    # to the whole clone for content_in_root repositories.
+    search_root = os.path.join(base, "custom_components")
+    if not os.path.isdir(search_root):
+        search_root = base
+
     files = []
-    for dir, _, _ in os.walk("/tmp/repositories/addition"):
+    for dir, _, _ in os.walk(search_root):
         files.extend(glob(os.path.join(dir, "*manifest.json")))
 
     if len(files) != 1:


### PR DESCRIPTION
## Proposed change

`scripts/helpers/integration_path.py` locates a submission's integration by
walking the entire clone for `*manifest.json` and exiting with "No manifest"
unless exactly one exists. The publishing documentation scopes the structure
rule to `ROOT_OF_THE_REPO/custom_components/` ("there can only be one
subdirectory to `ROOT_OF_THE_REPO/custom_components/`"), so a repository that
satisfies the documented rule but also ships other legitimately-named
`manifest.json` files (a Supervisor add-on's inner component, test fixtures)
fails the Hassfest check before hassfest runs. Reproducer: #8966 - one
integration under `custom_components/`, plus add-on and fixture manifests
elsewhere; the HACS action itself passes on that repository.

This change scopes the search to `ROOT/custom_components/` when that
directory exists and keeps the current whole-clone behavior otherwise
(`content_in_root` repositories are unaffected). Repositories with multiple
integrations under `custom_components/` still fail exactly as today. Verified
against both shapes locally.

If the whole-clone uniqueness is intentional, happy to close this - guidance
on how monorepo-shaped repositories (integration + Supervisor add-on in one
repo) should submit would then be appreciated.
