### PR TITLE
Add Rhaiderr/homeassistant-cloudflare-ip-sync (integration)

### DIFF
--- a/integration
+++ b/integration
@@ -2070,6 +2070,7 @@
   "ReZ-TI/rezti_matter_knoblink",
   "rgc99/irrigation_unlimited",
   "rgerbranda/rbfa",
+  "Rhaiderr/homeassistant-cloudflare-ip-sync",
   "rhanekom/hass-qwikswitch-api",
   "rhizomatics/autoarm",
   "rhizomatics/remote_logger",


### PR DESCRIPTION
## Repository
https://github.com/Rhaiderr/homeassistant-cloudflare-ip-sync

## What it does
Home Assistant integration that keeps a Cloudflare Rule List updated with the user's current public IP address, for use in WAF custom rules, Zero Trust policies and Tunnel access control. Config-flow only (no YAML), `DataUpdateCoordinator`-based, with a verified write path (replace items → poll bulk operation → re-read and verify → exponential backoff), sync-status sensor, diagnostics with token redaction, repairs, and `force_sync`/`reload` services.

## Checklist
- [x] `hacs.json` present (`name`, `homeassistant: 2026.6.0`, `render_readme`)
- [x] `manifest.json` with `version`, `documentation`, `issue_tracker`, `codeowners`
- [x] GitHub release published (v1.0.0)
- [x] Repository description and topics set
- [x] HACS action + hassfest running on every PR/push — both green
- [x] Test suite (41 tests) — validated end-to-end on a real installation
- [ ] Brands: pending review at home-assistant/brands#10691

🤖 Generated with [Claude Code](https://claude.com/claude-code)