### PR TITLE
Add Rhaiderr/homeassistant-cloudflare-ip-sync (integration)

### DIFF
--- a/integration
+++ b/integration
@@ -2070,6 +2070,7 @@
   "ReZ-TI/rezti_matter_knoblink",
   "rgc99/irrigation_unlimited",
   "rgerbranda/rbfa",
+  "Rhaiderr/homeassistant-cloudflare-ip-sync",
   "rhanekom/hass-qwikswitch-api",
   "rhizomatics/autoarm",
   "rhizomatics/remote_logger",


### PR DESCRIPTION
## Required links
- **Repository**: https://github.com/Rhaiderr/homeassistant-cloudflare-ip-sync
- **Latest release**: https://github.com/Rhaiderr/homeassistant-cloudflare-ip-sync/releases/tag/v1.0.1
- **CI action runs (HACS + hassfest validation)**: https://github.com/Rhaiderr/homeassistant-cloudflare-ip-sync/actions/workflows/validate.yaml

## What it does
Home Assistant integration that keeps a Cloudflare Rule List updated with the user's current public IP address, for use in WAF custom rules, Zero Trust policies and Tunnel access control. Config-flow only (no YAML), `DataUpdateCoordinator`-based, with a verified write path (replace items → poll bulk operation → re-read and verify → exponential backoff), sync-status sensor, diagnostics with token redaction, repairs, and `force_sync`/`reload` services.

## Notes
- Brand icons ship inside the integration (`brand/` folder, per the HA 2026.3.0 mechanism) — the previous home-assistant/brands PR was auto-closed pointing at that mechanism, as brands no longer accepts custom-integration icons.
- HACS action (category: integration) and hassfest run on every PR/push and are green.
- 41 tests; validated end-to-end on a real installation against the live Cloudflare API.
- Replaces #8969 (closed by the bot for missing required links).

🤖 Generated with [Claude Code](https://claude.com/claude-code)