### PR TITLE
Add lektrico-charger-card to plugin list

### DIFF
--- a/plugin
+++ b/plugin
@@ -415,6 +415,7 @@
   "mtheli/gardena-smart-system-card",
   "mtheli/toothbrush-card",
   "mutilator/homeassistant-solar-panel-preview",
+  "naked-head/lektrico-charger-card"
   "nathan-gs/ha-map-card",
   "nathanmarlor/foxess_modbus_charge_period_card",
   "nathkrill/lovelace-google-fonts-header-card",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [X] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [X] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [X] The actions are passing without any disabled checks in my repository.
- [X] I've added a link to the action run on my repository below in the links section.
- [X] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: https://github.com/naked-head/lektrico-charger-card
Link to successful HACS action (without the `ignore` key): https://github.com/naked-head/lektrico-charger-card/actions/runs/28737323537/job/85213749580
Link to successful hassfest action (if integration): <>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->