### PR TITLE
Adds new plugin [yosef-chai/ha-checklist-card]

### DIFF
--- a/plugin
+++ b/plugin
@@ -659,6 +659,7 @@
   "xBourner/status-card",
   "xplanes/ha-plant-diary-card",
   "yohaybn/lovelace-aliexpress-package-card",
+  "yosef-chai/ha-checklist-card",
   "yshaish1/ha-google-fonts",
   "ytilis/hass-progress-bar-feature",
   "yuri-val/th-sensor-card",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: https://github.com/yosef-chai/ha-checklist-card/releases/tag/v2.2.2
Link to successful HACS action (without the `ignore` key): https://github.com/yosef-chai/ha-checklist-card/actions/runs/28740134133
Link to successful hassfest action (if integration): N/A — this is a plugin (Lovelace dashboard card), not an integration.

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->
