### PR TITLE
Add Global Water Reservoirs integration

### DIFF
--- a/integration
+++ b/integration
@@ -2410,6 +2410,7 @@
   "tcareyintx/skybellgen",
   "tcarwash/home-assistant_noaa-space-weather",
   "tdragon/reef-pi-hass-custom",
+  "tecnoyfoto/global_water_reservoirs",
   "tefinger/hass-brematic",
   "teh-hippo/ha-govee-led-ble",
   "teh-hippo/ha-porkbun",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: https://github.com/tecnoyfoto/global_water_reservoirs/releases/tag/v1.1.23
Link to successful HACS action (without the `ignore` key): https://github.com/tecnoyfoto/global_water_reservoirs/actions/runs/28739426747
Link to successful hassfest action (if integration): https://github.com/tecnoyfoto/global_water_reservoirs/actions/runs/28739426745

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->