### PR TITLE
Add Opinet Price integration + dashboard card

### DIFF
--- a/integration
+++ b/integration
@@ -1492,6 +1492,7 @@
   "lnagel/hass-komfovent",
   "lnagel/hass-navirec",
   "lnagel/hass-ufh-controller",
+  "Loa0/ha-opinet-price",
   "lociii/homeassistant-csgo",
   "lociii/homeassistant-overwolf-status",
   "lolouk44/CurrentCost_HA_CC",

--- a/plugin
+++ b/plugin
@@ -339,6 +339,7 @@
   "ljmerza/our-groceries-card",
   "ljmerza/tracking-number-card",
   "ljmerza/travel-time-card",
+  "Loa0/ha-opinet-price-dashboard",
   "lop1505/RoomCard",
   "loryanstrant/ha-MU-TH-UR-6000-cards",
   "loryanstrant/ha-vertical-blinds-card",


### PR DESCRIPTION
## Add Opinet Price

**Integration:** `ha-opinet-price` — 한국석유공사 오피넷 API 기반 주유소 최저가 조회 통합구성요소
**Dashboard:** `ha-opinet-price-dashboard` — 주유소 랭킹 + 지도 Lovelace 카드

- ✅ hacs.json 완비
- ✅ icon.png 등록  
- ✅ zip_release 자동화
- ✅ HA 2024.1.0+ 호환

Repo: https://github.com/Loa0/ha-opinet-price