### PR TITLE
Add colopisalvatore/glasshopper

### DIFF
--- a/integration
+++ b/integration
@@ -482,6 +482,7 @@
   "CoderAS-ru/hass-neatsvor",
   "codyc1515/ha-yeelock",
   "colings/synology_virtual_album",
+  "colopisalvatore/glasshopper",
   "CoMPaTech/stromer",
   "CompitHomeAssistant/HomeAssistant",
   "Connectlife-LLC/HomeAssistantPlugin",


### PR DESCRIPTION
Adds `colopisalvatore/glasshopper` — **Glasshopper**, React dashboards for Home Assistant as native sidebar panels (five hooks, zero-auth via the frontend WebSocket, HACS-installable).

- Repo: https://github.com/colopisalvatore/glasshopper (public, Apache-2.0)
- `hacs.json` present; `manifest.json` valid (domain `glasshopper`, config_flow, codeowners `@colopisalvatore`, documentation + issue_tracker).
- Passes `hacs/action` (category integration) with **brands enforced** — the integration ships its brand icons in-repo via the Brands Proxy API (HA 2026.3+), so no `home-assistant/brands` entry is required.
- Published releases (latest v0.4.2). hassfest + HACS validation green in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)