### PR TITLE
Add Matysh/houseplan-card (integration)

### DIFF
--- a/integration
+++ b/integration
@@ -1621,6 +1621,7 @@
   "MattieGit/qube_heatpump",
   "mattrayner/pod-point-home-assistant-component",
   "MattXcz/CEZ",
+  "Matysh/houseplan-card",
   "mawinkler/astroweather",
   "maxbeizer/homeassistant-nes",
   "MaxensF/personal_weather_station",


### PR DESCRIPTION
## Repository
https://github.com/Matysh/houseplan-card

## Category
Integration (ships a Lovelace card served by the integration itself)

## Description
House Plan — interactive floor-plan for Home Assistant: draw rooms on top of your floor-plan image, bind them to HA areas, and devices appear on the plan with live states, temperature and Zigbee LQI. Drag layout, zoom/pan, device metadata with PDF manuals, virtual markers. Config is stored server-side (`.storage`) with optimistic locking and live sync between clients. Localized UI (en/ru). No YAML.

## Checklist
- [x] I am the owner of the repository
- [x] The repository has a description, topics and an English README
- [x] `hacs.json` and `manifest.json` are present and valid
- [x] GitHub release exists (latest: v1.11.1)
- [x] HACS action + hassfest run in CI — **all checks green** ([latest run](https://github.com/Matysh/houseplan-card/actions))
- [x] Brand images ship inside the integration (`custom_components/houseplan/brand/`), per the HA 2026.3 local-brands mechanism — the home-assistant/brands PR (#10700) was auto-closed as obsolete since that repo no longer accepts custom-integration icons
