### PR TITLE
Adds new integration [dsackr/ha-digital-frames]

### DIFF
--- a/integration
+++ b/integration
@@ -722,7 +722,7 @@
   "droans/mass_queue",
   "droidgren/smhi_season",
   "droso-hass/idfm",
-  "dsackr/fraimic-homeassistant",
+  "dsackr/ha-digital-frames",
   "dscao/ikuai",
   "DSorlov/http_agent",
   "DSorlov/snmp_printer",

--- a/integration
+++ b/integration
@@ -722,6 +722,7 @@
   "droans/mass_queue",
   "droidgren/smhi_season",
   "droso-hass/idfm",
+  "dsackr/fraimic-homeassistant",
   "dscao/ikuai",
   "DSorlov/http_agent",
   "DSorlov/snmp_printer",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: https://github.com/dsackr/ha-digital-frames/releases/tag/v0.12.123
Link to successful HACS action (without the `ignore` key): https://github.com/dsackr/ha-digital-frames/actions/runs/29707719502
Link to successful hassfest action (if integration): https://github.com/dsackr/ha-digital-frames/actions/runs/29707719526

Repository was renamed from `dsackr/fraimic-homeassistant` → `dsackr/ha-digital-frames` (product: Digital Frames, domain: `digital_frames`).

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->