### PR TITLE
Add mochlast/lwz-thz (integration)

### DIFF
--- a/integration
+++ b/integration
@@ -1695,6 +1695,7 @@
   "moag1000/beurer_daylight_lamps",
   "moarph/homeassistant_berner_torantriebe",
   "Moballo-LLC/airbnk-ble",
+  "mochlast/lwz-thz",
   "Moe8383/radar_map_manager",
   "moehrem/DiveraControl",
   "moerk-o/ha-solstice_season",


### PR DESCRIPTION
## Checklist

- [x] I am the owner of the repository
- [x] The repository is compliant with the [HACS requirements](https://hacs.xyz/docs/publish/start)
- [x] GitHub Actions with `hacs/action` and `hassfest` are enabled and passing: https://github.com/mochlast/lwz-thz/actions/workflows/validate.yml
- [x] Brand assets ship inside the integration (`custom_components/lwz_thz/brand/`, HA 2026.3+ mechanism)
- [x] Releases published (latest: v0.6.1)

## Repository

https://github.com/mochlast/lwz-thz

Home Assistant integration for Stiebel Eltron LWZ / Tecalor THZ integral heat pumps via their serial service interface (USB / ser2net) — no ISG module required. Sensors, verified write access (setpoints, operating mode, fan stages), climate + water_heater, energy meters, configurable poll intervals. Protocol derived from the FHEM 00_THZ.pm module (GPL-2.0).