### PR TITLE
Adds new integration [zzdota/ha-owon]

### DIFF
--- a/integration
+++ b/integration
@@ -2415,5 +2415,6 @@
   "zubir2k/homeassistant-esolattakwim",
   "zulufoxtrot/ha-zyxel",
   "zupancicmarko/JellyHA",
-  "Zwer2k/ha-pca301"
+  "Zwer2k/ha-pca301",
+  "zzdota/ha-owon"
 ]


### PR DESCRIPTION
## Checklist

- I've read the publishing documentation.
- I've added the HACS action to my repository.
- I've added the hassfest action to my repository.
- The actions are passing without any disabled checks in my repository.
- I've added a link to the action run on my repository below in the links section.
- I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: https://github.com/zzdota/ha-owon/releases/tag/v0.0.5

Link to successful HACS action: https://github.com/zzdota/ha-owon/actions/runs/28838195765/job/85526331005

Link to successful hassfest action: https://github.com/zzdota/ha-owon/actions/runs/28838195765/job/85526331022

## Summary

OWON Home Assistant integration for OWON smart meters via MQTT.

## Notes

- Public GitHub repository
- Single integration under custom_components/owon
- Brand assets are included in custom_components/owon/brand
- README and hacs.json are present in the repository root
- Supports OWON PC321 and PC341 devices