### PR TITLE
Adds new integration [WeAreSmart-home/wesmart-garbage]

### DIFF
--- a/integration
+++ b/integration
@@ -2604,6 +2604,7 @@
   "wbyoung/movement",
   "wbyoung/smartcar",
   "wbyoung/watersmart",
+  "WeAreSmart-home/wesmart-garbage",
   "WeaveHubHQ/ha-tovala",
   "WeaveHubHQ/ha-u-by-moen",
   "WeaveHubHQ/robinhood_crypto",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: https://github.com/WeAreSmart-home/wesmart-garbage/releases/tag/v1.3.1
Link to successful HACS action (without the `ignore` key): https://github.com/WeAreSmart-home/wesmart-garbage/actions/runs/28847164131/job/85553637845
Link to successful hassfest action (if integration): https://github.com/WeAreSmart-home/wesmart-garbage/actions/runs/28847164131/job/85553637879