### PR TITLE
Add cloudbr34k84/home-assistant-Open-Meteo-Marine-Weather

### DIFF
--- a/integration
+++ b/integration
@@ -458,6 +458,7 @@
   "clintongormley/everything-presence-pro-grid",
   "clintongormley/ha-fado",
   "Clooos/Bubble-Card-Tools",
+  "cloudbr34k84/home-assistant-Open-Meteo-Marine-Weather",
   "cloudbr34k84/home-assistant-pocketsmith",
   "cloudless-garden/ha-gardena-smart-local-preview",
   "ClusterM/flipper_rc",


### PR DESCRIPTION
## Repository
https://github.com/cloudbr34k84/home-assistant-Open-Meteo-Marine-Weather

## What it does
Home Assistant integration for marine weather (wave height/direction/period, swell, wind-wave, sea surface temperature, ocean current, invert barometer height) via the [Open-Meteo Marine Weather API](https://open-meteo.com/en/docs/marine-weather-api). Configured entirely through the UI (config flow), one device per location, 22 sensors with a live-value picker at setup, 7-day/24-hour forecast attributes, plus a derived "Surf rating" sensor and "Good surf" binary sensor with user-configurable thresholds. No API key required.

## Checklist
- [x] `hacs.json` present
- [x] `manifest.json` has `version`, `documentation`, `issue_tracker`, `codeowners`
- [x] Local brand images shipped at `custom_components/open_meteo_marine_weather/brand/`
- [x] Repository topics: `hacs`, `home-assistant`, `homeassistant`, `custom-integration`
- [x] CI green: hassfest + HACS validation (`.github/workflows/validate.yaml`)
- [x] Tagged release matching manifest version: [v2.1.1](https://github.com/cloudbr34k84/home-assistant-Open-Meteo-Marine-Weather/releases/tag/v2.1.1)

## Note on a related existing entry
This list already includes `sh00t2kill/ha-open-meteo-marine`, which also covers the Open-Meteo Marine API. I want to flag this transparently rather than have it discovered later: it's not my repository, so I have not touched its listing. My submission differs in scope (full UI config flow, per-location sensor picker, 7-day/24-hour forecast attributes, and the added surf-quality scoring/binary-sensor feature) but reviewers should judge for themselves whether both belong in the default store.

(Supersedes #9034, which got closed by hacs-bot after a branch force-push during cleanup — this PR is opened fresh from a branch based on current master with no rewritten history.)
