### PR TITLE
Add Seblin01/wolta-homeassistant

### DIFF
--- a/integration
+++ b/integration
@@ -2216,6 +2216,7 @@
   "Seba101288/home-assistant-ever-ups",
   "sebakerckhof/aritech-ha",
   "sebcaps/atmofrance",
+  "Seblin01/wolta-homeassistant",
   "sebr/bhyve-home-assistant",
   "sebr/inception-home-assistant",
   "SecKatie/ha-wyzeapi",


### PR DESCRIPTION
Adds the [Wolta](https://github.com/Seblin01/wolta-homeassistant) integration (domain `wolta`) to the HACS default store.

Wolta grades how well a home battery is optimised against Nord Pool / ENTSO-E day-ahead electricity prices, and calculates battery economics for Swedish price zones.

Checklist:
- Public repo, works as a HACS custom repository
- HACS Action + Hassfest passing on the latest commit
- Full GitHub releases published (latest v0.5.0)
- Local brand assets present (custom_components/wolta/brand/icon.png + icon@2x.png)
- Repository has description, topics, and issues enabled
- I am the repository owner / code owner (@Seblin01)