### PR TITLE
Adds Safe SomaFM as a default HACS integration.

### DIFF
--- a/integration
+++ b/integration
@@ -2696,5 +2696,6 @@
   "zubir2k/homeassistant-esolattakwim",
   "zulufoxtrot/ha-zyxel",
   "zupancicmarko/JellyHA",
-  "Zwer2k/ha-pca301"
+  "Zwer2k/ha-pca301",
+  "kalykulam/Safe-SomaFM"
 ]


### PR DESCRIPTION
Adds Safe SomaFM as a default HACS integration.

Repository:
https://github.com/kalykulam/Safe-SomaFM

Safe SomaFM is a Home Assistant custom integration for listening to SomaFM streams through a local Home Assistant player.

Features:
- local browser player;
- compact Lovelace card;
- sidebar launcher;
- station artwork and metadata;
- quality selection;
- automatic reconnect.

Validation:
- HACS validation: passing
- Hassfest validation: passing
- Tested through HACS as a custom repository

The repository includes:
- brand assets;
- English and French documentation;
- security review;
- GitHub release.