### PR TITLE
Adds new integration: droomurray/hass-intesishome-local

### DIFF
--- a/integration
+++ b/integration
@@ -721,6 +721,7 @@
   "drlaplace/KVV_Departure_Monitor",
   "droans/mass_queue",
   "droidgren/smhi_season",
+  "droomurray/hass-intesishome-local",
   "droso-hass/idfm",
   "dscao/ikuai",
   "DSorlov/http_agent",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/droomurray/hass-intesishome-local/releases/tag/v1.0.1>
Link to successful HACS action (without the `ignore` key): <https://github.com/droomurray/hass-intesishome-local/actions/runs/28971852495/job/85969248183>
Link to successful hassfest action (if integration): <https://github.com/droomurray/hass-intesishome-local/actions/runs/28971852495/job/85969248211>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->

Brands PR: home-assistant/brands#10715