### PR TITLE
Adds new integration [woddi81-beep/ha-anycubic-cloud-connect]

### DIFF
--- a/integration
+++ b/integration
@@ -2634,6 +2634,7 @@
   "WJDDesigns/ultra-card-connect",
   "WLANThermo-nano/homeassistant",
   "wlcrs/huawei_solar",
+  "woddi81-beep/ha-anycubic-cloud-connect",
   "wolffshots/hass-audiobookshelf",
   "Woulve/phonetrack",
   "Wouter0100/homeassistant-nanokvm",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/woddi81-beep/ha-anycubic-cloud-connect/releases/tag/v0.2.5>
Link to successful HACS action (without the `ignore` key): <https://github.com/woddi81-beep/ha-anycubic-cloud-connect/actions/runs/29007873741>
Link to successful hassfest action (if integration): <https://github.com/woddi81-beep/ha-anycubic-cloud-connect/actions/runs/29007873828>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->
