### PR TITLE
Add AldenDana/ha-xiaomi-vacuum-x20pro (integration)

### DIFF
--- a/integration
+++ b/integration
@@ -70,6 +70,7 @@
   "AlbinLind/dawarich-home-assistant",
   "AlbrechtL/hass-padersprinter",
   "alceasan/ha-deepgram-tts",
+  "AldenDana/ha-xiaomi-vacuum-x20pro",
   "AldenDana/ha-zte-fibra",
   "aldweb/ha-lg-hombot",
   "aldweb/ha-openwrt-mqtt",


### PR DESCRIPTION
## Repository

https://github.com/AldenDana/ha-xiaomi-vacuum-x20pro

Room-by-room cleaning — including per-room custom settings (suction, mop water, mode, passes) — for the Xiaomi Robot Vacuum X20 Pro (`xiaomi.vacuum.d102gl`). This model has no dedicated integration (it is Xiaomi in-house firmware, not Dreame-based): dreame-vacuum closed the support request, the official ha_xiaomi_home does not expose room IDs, and the cloud map extractor cannot parse its maps. This integration fills the gap as a thin, live-verified layer over al-one/hass-xiaomi-miot, adding acceptance verification + retry for the Xiaomi cloud's silently-dropped commands, plus full protocol documentation (docs/METHOD.md).

## Checklist

- [x] I am the owner of the repository and it is not a fork
- [x] The repository has a description, topics, README and MIT license
- [x] `hacs.json` and `manifest.json` (with `version`, `documentation`, `issue_tracker`, `codeowners`) are present
- [x] A GitHub release exists (v1.0.0)
- [x] The repository has the HACS action and hassfest workflows: hassfest passes; HACS action passes 8/9 checks — the remaining one is the brands check, pending home-assistant/brands#10719
- [x] Brands PR submitted: home-assistant/brands#10719
- [x] Added to the `integration` list in alphabetical order (single-line diff)