### PR TITLE
Add CUKTECH Charger integration

### DIFF
--- a/integration
+++ b/integration
@@ -2698,3 +2698,4 @@
   "zupancicmarko/JellyHA",
   "Zwer2k/ha-pca301"
 ]
+kairui1108/cuktech-ble-ha-integration


### PR DESCRIPTION
Add `kairui1108/cuktech-ble-ha-integration` to default repositories.

- Domain: `cuktech_charger`
- BLE charger monitoring and control for Home Assistant
- Real-time power monitoring, port control, Web UI