### PR TITLE
Add Deco S1900 Local integration

### DIFF
--- a/integration
+++ b/integration
@@ -2262,6 +2262,7 @@
   "sillymoi/homeassistant-infometric",
   "silvanfischer/tuya_sensors",
   "simonjgreen/sageha",
+  "simone-losito/deco-s1900-local",
   "simplytoast1/ha-ring-smoke-detectors",
   "simplytoast1/Notify-for-HomeAssistant",
   "simplytoast1/ScentAirHABridge",


### PR DESCRIPTION
## Description

Add `deco_s1900_local` to the HACS default repository.

Repository:
https://github.com/simone-losito/deco-s1900-local

### Features

- Fully local communication
- TP-Link Cloud not required
- Config Flow
- Local polling
- HACS compliant
- Active maintenance

### Additional information

Roadmap:
https://github.com/simone-losito/deco-s1900-local/issues/1