### PR TITLE
Adds new integration [C3H3-AI/hacs-vision]

### DIFF
--- a/integration
+++ b/integration
@@ -387,6 +387,7 @@
   "c1pher-cn/heweather",
   "c1pher-cn/homeassistan-ezviz",
   "C2gl/tududi_integration",
+  "C3H3-AI/hacs-vision",
   "cabberley/HA_AemoNemData",
   "cabberley/HA_RedbackTech",
   "cabberley/utility_meter_evolved",


### PR DESCRIPTION
## Description
Adds the [C3H3-AI/hacs-vision](https://github.com/C3H3-AI/hacs-vision) integration to the HACS default repository list.

**HACS Vision** is a visual enhancement panel for the HACS store, providing a richer browsing/storefront experience inside Home Assistant.

### Integration details
- Domain: `hacs_vision`
- Version: 6.4.1
- Config flow: yes
- Dependencies: `hacs`
- IoT class: calculated
- Translations: en / de / zh-Hans
- Branding: `brand/icon.png`, `brand/icon@2x.png`, `brand/logo.png`

### Pre-submission checks (all green)
- [x] Integration repo is public and ready
- [x] `manifest.json` keys sorted alphabetically (hassfest compliant)
- [x] HACS Validation workflow passes (`validate.yml`)
- [x] `info.md`, `hacs.json`, `LICENSE`, `README*` present
- [x] `custom_components/hacs_vision/manifest.json` validates
- [x] Entry inserted in correct alphabetical position in `integration`

Co-Authored-By: Claude <noreply@anthropic.com>