### PR TITLE
Adds new integration [C3H3-AI/ha-voice-fab]

### DIFF
--- a/integration
+++ b/integration
@@ -387,6 +387,7 @@
   "c1pher-cn/heweather",
   "c1pher-cn/homeassistan-ezviz",
   "C2gl/tududi_integration",
+  "C3H3-AI/ha-voice-fab",
   "cabberley/HA_AemoNemData",
   "cabberley/HA_RedbackTech",
   "cabberley/utility_meter_evolved",


### PR DESCRIPTION
## Description
Adds the [C3H3-AI/ha-voice-fab](https://github.com/C3H3-AI/ha-voice-fab) integration to the HACS default repository list.

**Voice FAB** is a custom voice assistant frontend panel for Home Assistant, providing an enhanced voice interaction UI.

### Repository links
- Repository: https://github.com/C3H3-AI/ha-voice-fab
- Latest release: https://github.com/C3H3-AI/ha-voice-fab/releases/tag/v1.1.0
- Validation run: https://github.com/C3H3-AI/ha-voice-fab/actions/runs/29096684570

### Pre-submission checks
- [x] Integration repo is public and ready
- [x] `manifest.json` keys sorted alphabetically (hassfest compliant)
- [x] HACS Validation + hassfest workflows pass
- [x] `info.md`, `hacs.json`, `LICENSE`, `README*` present
- [x] `custom_components/voice_fab/manifest.json` validates
- [x] Entry inserted in correct alphabetical position in `integration`