### PR TITLE
Adds new integration [C3H3-AI/ha-voice-fab]

### DIFF
--- a/integration
+++ b/integration
@@ -387,6 +387,7 @@
   "c1pher-cn/heweather",
   "c1pher-cn/homeassistan-ezviz",
   "C2gl/tududi_integration",
+  "C3H3-AI/ha-voice-fab",
   "cabberley/HA_AemoNemData",
   "cabberley/HA_RedbackTech",
   "cabberley/utility_meter_evolved",


### PR DESCRIPTION
## Checklist

I have verified the following for this new integration submission:

- [x] The repository is public
- [x] The repository contains a valid `hacs.json` file
- [x] The repository contains an `info.md` file
- [x] The repository contains a valid `manifest.json`
- [x] The integration passes hassfest validation (Hassfest run is green on the repo)
- [x] The repository has a published release

## Links

- Repository: https://github.com/C3H3-AI/ha-voice-fab
- Documentation: https://github.com/C3H3-AI/ha-voice-fab
- Issues: https://github.com/C3H3-AI/ha-voice-fab/issues

## Notes

Voice FAB adds a floating voice-control button to Home Assistant. This PR adds the repository to the `integration` list. The manifest key order has been corrected (domain, name first then alphabetical) and hassfest passes on the default branch.