### PR TITLE
Add allusv/atomberg-local

### DIFF
--- a/integration
+++ b/integration
@@ -102,6 +102,7 @@
   "alfwro13/ghostfolio_ha_integration",
   "algirdasc/hass-floureon",
   "AllonGit/energy_hub_poland",
+  "allusv/atomberg-local",
   "alpenfun/fems-diagnostics",
   "alray31/RAV311-Remote",
   "alryaz/hass-energosbyt-plus",


### PR DESCRIPTION
Adds [allusv/atomberg-local](https://github.com/allusv/atomberg-local) — local Wi-Fi + Bluetooth control for Atomberg smart fans in Home Assistant (no cloud).

- Category: integration (domain `atomberg_local`)
- Release: `v0.1.0`
- Brand images bundled locally (`custom_components/atomberg_local/brand/`) per HA 2026.3 brands-proxy
- Passes hassfest + HACS validation