### PR TITLE
Add free9d9/ha-audiobookshelf

### DIFF
--- a/integration
+++ b/integration
@@ -882,6 +882,7 @@
   "FredM67/ha-emon-config",
   "fredrik-lindseth/Stromkalkulator",
   "FredrikM97/hass-surepetcare",
+  "free9d9/ha-audiobookshelf",
   "FReichelt/ha-vorwerk-kobold",
   "frenck/home-assistant-doom",
   "frenck/spook",


### PR DESCRIPTION
Adds `free9d9/ha-audiobookshelf`, a Home Assistant integration for Audiobookshelf (domain `audiobookshelf_plus`).

- Public repository with releases (latest `v0.10.0`).
- Passes the HACS action validation (integration category).
- Ships its own brand icon at `custom_components/audiobookshelf_plus/brand/`.
- Home Assistant quality scale: Platinum.

Repo: https://github.com/free9d9/ha-audiobookshelf