### PR TITLE
Add glinet4/glinet4-ha

### DIFF
--- a/integration
+++ b/integration
@@ -956,6 +956,7 @@
   "gjohansson-ST/response_as_sensor",
   "gjohansson-ST/sector",
   "gleanlux/alertsys",
+  "glinet4/glinet4-ha",
   "glyndavidson/MACS",
   "gndean/home-assistant-hypervolt-charger",
   "godely/ha-dremel-3d-printer",


### PR DESCRIPTION
Adds the **glinet4** integration ([glinet4/glinet4-ha](https://github.com/glinet4/glinet4-ha)) — a Home Assistant integration for GL.iNet routers (firmware 4.x) via the local JSON-RPC API.

- Category: integration
- Domain: `glinet4`
- HACS validation: passes all checks (brands provided via the self-hosted `custom_components/glinet4/brand/` folder)
- Released: v0.2.0