### PR TITLE
Remove archived repository [mbillow/ha-redpocket]

### DIFF
--- a/integration
+++ b/integration
@@ -1631,7 +1631,6 @@
   "mayerwin/HA-Real-Last-Changed-Reported-Seen-Sensors",
   "mb-software/homeassistant-powerbrain",
   "mbillow/ha-chargepoint",
-  "mbillow/ha-redpocket",
   "mbuchber/ha_heliotherm",
   "mcapmari/ha-djv_meter",
   "mchwalisz/home-assistant-senec",


### PR DESCRIPTION
## Summary

Removing mbillow/ha-redpocket from the integration list -- the repository has been archived and is no longer maintained.

Repository: https://github.com/mbillow/ha-redpocket
Latest release: https://github.com/mbillow/ha-redpocket/releases/tag/v2.3.3

This is a removal-only PR (no addition), split out from #9109 per hacs-bot's single-entry-diff requirement.