### PR TITLE
Add Fochest/ha-bee-am

### DIFF
--- a/integration
+++ b/integration
@@ -868,6 +868,7 @@
   "flexopus/flexopus-hass-sensor",
   "Flo-Schilli/ha-grohe_smarthome",
   "florianbaethge/simple_irrigation",
+  "Fochest/ha-bee-am",
   "fondberg/spotcast",
   "foureight84/CallAttendantNext_Monitor",
   "Foxi352/pollen_lu",


### PR DESCRIPTION
Adds the BEAAM API integration for Home Assistant.

- **Repository:** https://github.com/Fochest/ha-bee-am
- **Category:** Integration
- **Description:** Home Assistant integration for Neoom's Beaam local API (energy flow, battery, PV, wallbox sensors + charging-mode select).

Checklist:
- [x] Repository is public and not archived
- [x] Has a description and topics
- [x] Contains a valid `hacs.json`
- [x] Integration lives in `custom_components/beaam/` with a valid `manifest.json`
- [x] Passes the HACS Action validation (incl. brands via local `custom_components/beaam/brand/` assets)
- [x] Has published releases (latest `v.0.4.1`)