### PR TITLE
Add Alshekhi/xbloom-studio

### DIFF
--- a/integration
+++ b/integration
@@ -113,6 +113,7 @@
   "alryaz/hass-pik-intercom",
   "alryaz/hass-tns-energo",
   "alryaz/hass-turkov",
+  "Alshekhi/xbloom-studio",
   "altfoxie/ha-sberdevices",
   "Altrec/remko_mqtt-ha",
   "alves-dev/stackspot-homeassistant",


### PR DESCRIPTION
Adds the `xbloom` custom integration — a local (BLE) Home Assistant integration for the xBloom Studio coffee machine.

- Repository: https://github.com/Alshekhi/xbloom-studio
- Category: integration
- Passes hassfest + HACS Action (no ignores)
- Ships an inline brand icon (`custom_components/xbloom/brand/`)
- Released: v3.0.0