### PR TITLE
Adds new integration [GeneralFuturics/ha-flappyboard]

### DIFF
--- a/integration
+++ b/integration
@@ -931,6 +931,7 @@
   "geertmeersman/youfone",
   "GeiserX/cashpilot-ha",
   "GeiserX/genieacs-ha",
+  "GeneralFuturics/ha-flappyboard",
   "gensyn/ssh_command",
   "gensyn/ssh_docker",
   "gensyn/task_tracker",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/GeneralFuturics/ha-flappyboard/releases/tag/v1.0.1>
Link to successful HACS action (without the `ignore` key): <https://github.com/GeneralFuturics/ha-flappyboard/actions/runs/29295742239/job/86968716091>
Link to successful hassfest action (if integration): <https://github.com/GeneralFuturics/ha-flappyboard/actions/runs/29295742239/job/86968716097>