### PR TITLE
Add sikelo83/lovelace-wordclock-card (plugin)

### DIFF
--- a/plugin
+++ b/plugin
@@ -540,6 +540,7 @@
   "Sian-Lee-SA/honeycomb-menu",
   "sierramike/lovelace-advanced-digital-clock",
   "sierramike/lovelace-simple-navbar",
+  "sikelo83/lovelace-wordclock-card",
   "silasmariusz/fork_u-house_card",
   "silentbil/silent-bus",
   "silentbil/silent-image-slider",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://github.com/hacs/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://github.com/home-assistant/actions) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: https://github.com/sikelo83/lovelace-wordclock-card/releases/tag/v0.1.1

Link to successful HACS action (without the `ignore` key): https://github.com/sikelo83/lovelace-wordclock-card/actions/runs/29318379170

Link to successful hassfest action: N/A (plugin)
