### PR TITLE
Add sikelo83/lovelace-wordclock-card (plugin)

### DIFF
--- a/plugin
+++ b/plugin
@@ -540,6 +540,7 @@
   "Sian-Lee-SA/honeycomb-menu",
   "sierramike/lovelace-advanced-digital-clock",
   "sierramike/lovelace-simple-navbar",
+  "sikelo83/lovelace-wordclock-card",
   "silasmariusz/fork_u-house_card",
   "silentbil/silent-bus",
   "silentbil/silent-image-slider",


### PR DESCRIPTION
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: https://github.com/sikelo83/lovelace-wordclock-card/releases/tag/v0.1.1
Link to successful HACS action (without the `ignore` key): https://github.com/sikelo83/lovelace-wordclock-card/actions/runs/29318379170
Link to successful hassfest action (if integration): <>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->