### PR TITLE
Add dneprojects/ebus_bridge

### DIFF
--- a/integration
+++ b/integration
@@ -696,6 +696,7 @@
   "dmoralesdev/zha_lock_manager",
   "dmoranf/home-assistant-wattio",
   "dn5qMDW3/tzevaadom",
+  "dneprojects/ebus_bridge",
   "dneprojects/mypv",
   "dolezsa/thermal_comfort",
   "dominikamann/oekofen-pellematic-compact",


### PR DESCRIPTION
Adds the custom integration **eBUS Bridge** (`ebus_bridge`).

- Repository: https://github.com/dneprojects/ebus_bridge
- Category: integration
- Local eBUS/ebusd integration for Home Assistant (Vaillant and other eBUS heating devices), no cloud, no MQTT.
- Public, has description + topics + issues, MIT license, full release `v1.0.0`.
- CI green: hassfest + HACS action + ruff + pytest.
- Brand icon bundled in `custom_components/ebus_bridge/brand/`.
- Submitted by the repository owner (@dneprojects).