### PR TITLE
Add 'liampetti/fulloch' to integration list

### DIFF
--- a/integration
+++ b/integration
@@ -1305,6 +1305,7 @@
   "lewei50/ha_iammeter_link",
   "lewei50/ha_iammeter_modbus",
   "lhw/cloudweatherproxy",
+  "liampetti/fulloch",
   "libdyson-wg/ha-dyson",
   "lichtteil/local_luftdaten",
   "lientry/homeassistant-vivosun-growhub",


### PR DESCRIPTION
Checklist
[ x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
[ x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
[ x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
[ x] The actions are passing without any disabled checks in my repository.
[ x] I've added a link to the action run on my repository below in the links section.
[ x] I've created a new release of the repository after the validation actions were run successfully.

Links
Link to current release: https://github.com/liampetti/fulloch/releases/tag/v2.2.4
Link to successful HACS action (without the ignore key): https://github.com/liampetti/fulloch/actions/runs/29322686541
Link to successful hassfest action (if integration): https://github.com/liampetti/fulloch/actions/runs/29322686543