### PR TITLE
Adds new integration [D4nte85/Solakon-One-Nulleinspeisung-integration]

### DIFF
--- a/integration
+++ b/integration
@@ -557,6 +557,7 @@
   "cyr-ius/hass-reolink-thumbs",
   "D-N91/home-assistant-global-health-score",
   "d03n3rfr1tz3/hass-divoom",
+  "D4nte85/Solakon-One-Nulleinspeisung-integration",
   "DaanVervacke/hass-engie-be",
   "Dacid99/artsauna_ble",
   "daernsinstantfortress/cupra_we_connect",

--- a/integration
+++ b/integration
@@ -665,6 +665,7 @@
   "czechbol/hass-mcp",
   "D-N91/home-assistant-global-health-score",
   "d03n3rfr1tz3/hass-divoom",
+  "D4nte85/Solakon-One-Nulleinspeisung-integration",
   "da-sa-li/HA-smartenergy-Tarif",
   "DaanVervacke/hass-engie-be",
   "DAB-LABS/HAIR",


### PR DESCRIPTION
## Repository

https://github.com/D4nte85/Solakon-One-Nulleinspeisung-integration

Home Assistant custom integration for the Solakon ONE inverter: zero-export (Nulleinspeisung) control via a PI controller, SOC-based zone logic, surplus feed-in, tariff-based charging arbitrage, and a sidebar panel for configuration and live monitoring.

## Latest release

https://github.com/D4nte85/Solakon-One-Nulleinspeisung-integration/releases/tag/v2.1.3

## CI action run

https://github.com/D4nte85/Solakon-One-Nulleinspeisung-integration/actions/runs/29334788264

## Checklist

- [x] `hacs.json` present
- [x] `hassfest` validation passing
- [x] HACS validation action passing
- [x] GitHub topic `hacs` set
- [x] Repository description set
- [x] Tagged releases with changelog notes (latest: v2.1.3)