### PR TITLE
Add openlamp/openlamp-beat-card

### DIFF
--- a/plugin
+++ b/plugin
@@ -449,6 +449,7 @@
   "Nyaran/myjdownloader-card",
   "ofekashery/vertical-stack-in-card",
   "omachala/ha-treemap-card",
+  "openlamp/openlamp-beat-card",
   "othorg/rv-level-ha-lovelace-card",
   "OtisPresley/snmp-switch-manager-card",
   "ownbee/bootstrap-grid-card",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the hassfest action — N/A, this is a **plugin** (Lovelace card).

Adds [openlamp/openlamp-beat-card](https://github.com/openlamp/openlamp-beat-card) — a Lovelace control panel for the OpenLamp Beat add-on (flash WLED lamps on the Ableton Link tempo). HACS validation is green (plugin, 8/8), release v0.2.1 published, MIT licensed.