### PR TITLE
Add openlamp/openlamp-beat-card

### DIFF
--- a/plugin
+++ b/plugin
@@ -449,6 +449,7 @@
   "Nyaran/myjdownloader-card",
   "ofekashery/vertical-stack-in-card",
   "omachala/ha-treemap-card",
+  "openlamp/openlamp-beat-card",
   "othorg/rv-level-ha-lovelace-card",
   "OtisPresley/snmp-switch-manager-card",
   "ownbee/bootstrap-grid-card",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) hassfest action — N/A, this is a **plugin** (Lovelace card), not an integration.

### Repository links

- Repository: https://github.com/openlamp/openlamp-beat-card
- Latest release: https://github.com/openlamp/openlamp-beat-card/releases/tag/v0.2.1
- CI action runs: https://github.com/openlamp/openlamp-beat-card/actions

A Lovelace control panel for the OpenLamp Beat add-on (flash WLED lamps on the Ableton Link tempo). HACS validation is green (plugin, 8/8), MIT licensed.