### PR TITLE
Add dkpnw/ha-mxz-coordinator

### DIFF
--- a/integration
+++ b/integration
@@ -686,6 +686,7 @@
   "dkarv/ha-bwt-perla",
   "dkarv/ha-komodo",
   "dknowles2/ha-pitboss",
+  "dkpnw/ha-mxz-coordinator",
   "dlarrick/hass-kumo",
   "dlashua/templatebinarysensor",
   "dm82m/hass-Deltasol-KM2",


### PR DESCRIPTION
## Add integration: MXZ Coordinator

Adds `dkpnw/ha-mxz-coordinator` to the `integration` category.

**Repository:** https://github.com/dkpnw/ha-mxz-coordinator (public, MIT)

A Home Assistant integration for **Mitsubishi MXZ multi-zone** mini-splits (multiple indoor heads on one outdoor unit). It fixes the AUTO idle-head deadlock by running both heads under one explicit shared mode with a single "Tesla-style" comfort target per room, resolves the heat-vs-cool standoff with a configurable demand threshold + hysteresis, idles a satisfied head in `fan_only` instead of starving it, and adds optional local-weather seasonal changeover and delta-proportional fan boost.

### Requirements checklist
- [x] Config-flow integration; `manifest.json` has `domain`, `name`, `documentation`, `issue_tracker`, `codeowners`, `version`
- [x] `hacs.json` present
- [x] Published GitHub **release** exists (latest `v2.8.1`)
- [x] Repository **description** and **topics** set; issues enabled
- [x] Passes `hacs/action` (integration) with **no ignores** — brand icons ship locally in `custom_components/mxz_coordinator/brand/` (HA 2026.3+ self-served brands)
- [x] hassfest passing
- [x] Entry added alphabetically, valid JSON, no duplicate