### PR TITLE
Adds new integration [guiguihao/ureal_home]

### DIFF
--- a/integration
+++ b/integration
@@ -983,6 +983,7 @@
   "gtxaspec/leviton-load-center",
   "guerrerotook/securitas-direct-new-api",
   "GuidoJeuken-6512/lambda_heat_pumps",
+  "guiguihao/ureal_home", 
   "GuilleGF/hassio-ovh",
   "gunnjr/ha-logger-manager",
   "gurrier/localvolts",


### PR DESCRIPTION
add ureal_home

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: https://github.com/guiguihao/ureal_home/releases/tag/v1.0.5
Link to successful HACS action: https://github.com/guiguihao/ureal_home/actions/runs/27389948891
Link to successful hassfest action: https://github.com/guiguihao/ureal_home/actions/runs/27389948893

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->