### PR TITLE
Adds new plugin [mycrouch/origami-entity-card]

### DIFF
--- a/plugin
+++ b/plugin
@@ -455,6 +455,7 @@
   "mtheli/toothbrush-card",
   "MUbeira0/lovelace-vigobus-card",
   "mutilator/homeassistant-solar-panel-preview",
+  "mycrouch/origami-entity-card",
   "naked-head/puffer-card",
   "nathan-gs/ha-map-card",
   "nathanmarlor/foxess_modbus_charge_period_card",

--- a/plugin
+++ b/plugin
@@ -478,6 +478,7 @@
   "mtheli/toothbrush-card",
   "MUbeira0/lovelace-vigobus-card",
   "mutilator/homeassistant-solar-panel-preview",
+  "mycrouch/origami-entity-card",
   "naked-head/lektrico-charger-card",
   "naked-head/puffer-card",
   "nathan-gs/ha-map-card",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/mycrouch/origami-entity-card/releases/tag/v1.2.0>
Link to successful HACS action (without the `ignore` key): <https://github.com/mycrouch/origami-entity-card/actions/runs/29177005841>