### PR TITLE
Add prusuino/ha_referenzmarktpreis_solar_schweiz

### DIFF
--- a/integration
+++ b/integration
@@ -2006,6 +2006,7 @@
   "princekama/home-assistant-rako",
   "Prosono/SMARTi_BaseComponent",
   "ProudElm/solaredgeoptimizers",
+  "prusuino/ha_referenzmarktpreis_solar_schweiz",
   "ptimatth/GeorideHA",
   "ptrkoz/ha-smogtok",
   "PTST/LibreView-HomeAssistant",


### PR DESCRIPTION
## Repository

https://github.com/prusuino/ha_referenzmarktpreis_solar_schweiz

Home Assistant custom integration that tracks the Swiss quarterly PV reference market price (published by the BFE per Art. 15 EnFV) and computes a feed-in price from it (configurable minimum price + guarantee-of-origin surcharge).

## Checklist

- [x] I have read the [publish documentation](https://hacs.xyz/docs/publish/start).
- [x] I have added the HACS action to the repository.
- [x] I have added the hassfest action to the repository.
- [x] All validation actions pass, no checks have been disabled.
- [x] The repository has a release.

## Links

- Current release: https://github.com/prusuino/ha_referenzmarktpreis_solar_schweiz/releases/tag/v1.0.0
- Successful HACS action run: https://github.com/prusuino/ha_referenzmarktpreis_solar_schweiz/actions/runs/29434376233
- Successful hassfest action run: https://github.com/prusuino/ha_referenzmarktpreis_solar_schweiz/actions/runs/29434376233
