### PR TITLE
Add HybridRCG/sprinkler-dash-card

### DIFF
--- a/plugin
+++ b/plugin
@@ -238,6 +238,7 @@
   "hulkhaugen/hass-bha-icons",
   "hyperb1iss/hyper-light-card",
   "Hypfer/lovelace-valetudo-map-card",
+  "HybridRCG/sprinkler-dash-card",
   "iablon/HomeAssistant-Touchpad-Card",
   "iantrich/config-template-card",
   "iantrich/radial-menu",


### PR DESCRIPTION
A fully self-contained smart irrigation dashboard card for Home Assistant. Zero YAML required beyond the card type declaration.
Features:

Up to 12 configurable zones with progress bar, countdown timer, and auto-stop manual timer
Auto-creates script.sprinkler and Scheduler entity on first load
Per-zone skip-next-run (self-clearing after schedule fires)
Built-in scheduler section — days, time, next-run countdown
4-slot configurable info bar with MDI icon picker and dual-sensor support
Rain auto-disable / auto-restore after configurable hours
Jojo/tank low-level zone shutoff
Zone run order indicator during active schedule
Last Run popup with per-zone details
Settings persist via websocket save (works in sections layout)
Confirmation popups on all actions (configurable)

Checklist:

 hacs.json present with name, render_readme, homeassistant
 MIT licensed
 Public repository
 README with description and screenshots
 Release with downloadable JS asset (v2.6.0)