### PR TITLE
Add HybridRCG/sprinkler-dash-card

### DIFF
--- a/plugin
+++ b/plugin
@@ -238,6 +238,7 @@
   "hulkhaugen/hass-bha-icons",
   "hyperb1iss/hyper-light-card",
   "Hypfer/lovelace-valetudo-map-card",
+  "HybridRCG/sprinkler-dash-card",
   "iablon/HomeAssistant-Touchpad-Card",
   "iantrich/config-template-card",
   "iantrich/radial-menu",


### PR DESCRIPTION
A fully self-contained smart irrigation dashboard card for Home Assistant. Zero YAML required beyond the card type declaration.
Links:

Latest release: https://github.com/HybridRCG/sprinkler-dash-card/releases/tag/v2.6.0
CI runs: https://github.com/HybridRCG/sprinkler-dash-card/actions

Features:

Up to 12 configurable zones with progress bar, countdown timer, and auto-stop manual timer
Auto-creates script.sprinkler and Scheduler entity on first load
Per-zone skip-next-run, rain auto-disable/restore, Jojo low-level shutoff
Zone run order indicator, Last Run popup, manual zone timer with auto-stop
Settings persist via websocket (works in sections layout)
- [x] The submission is for a Lovelace plugin 
- [x]  hacs.json exists with name and render_readme
- [x]  The repository is public
- [x]  The repository has a release with a downloadable asset
- [x]  The repository has a README
- [x]  The repository is licensed (MIT)