### PR TITLE
Add HybridRCG/sprinkler-dash-card

### DIFF
--- a/plugin
+++ b/plugin
@@ -238,6 +238,7 @@
   "hulkhaugen/hass-bha-icons",
   "hyperb1iss/hyper-light-card",
   "Hypfer/lovelace-valetudo-map-card",
+  "HybridRCG/sprinkler-dash-card",
   "iablon/HomeAssistant-Touchpad-Card",
   "iantrich/config-template-card",
   "iantrich/radial-menu",


### PR DESCRIPTION
A fully self-contained smart irrigation dashboard card for Home Assistant. Zero YAML required beyond the card type declaration.
https://github.com/HybridRCG/sprinkler-dash-card/releases/tag/v2.6.0
https://github.com/HybridRCG/sprinkler-dash-card/actions

- [x]  I've read the [publishing documentation](https://hacs.xyz/docs/publish/include).
- [x]  I've added the HACS action to my repository.
- [x]  The actions are passing.