### PR TITLE
Add iosmand/ha-open-meteo-custom

### DIFF
--- a/integration
+++ b/integration
@@ -1119,6 +1119,7 @@
   "Infinitte/HA-IR-Light",
   "insound/iohouse_climate",
   "InTheDaylight14/nginx-proxy-manager-switches",
+  "iosmand/ha-open-meteo-custom",
   "IoTFenster/MySmartWindow",
   "iPeel/HA-Eleven-Energy",
   "iprak/sensi",


### PR DESCRIPTION
Adding highly customizable Open-Meteo weather integration for Home Assistant, supporting FlatBuffers protocol, multiple weather models, configurable update intervals, and local timezone forecast aggregation.