### PR TITLE
Add dasimon135/daikin_madoka

### DIFF
--- a/integration
+++ b/integration
@@ -598,6 +598,7 @@
   "Darkdragon14/ha-guest-mode",
   "DarwinsBuddy/WienerNetzeSmartmeter",
   "DasBasti/SmartHashtag",
+  "dasimon135/daikin_madoka",
   "dasshubham762/atomberg-integration",
   "dave-code-ruiz/elkbledom",
   "dave-code-ruiz/uhomeuponor",


### PR DESCRIPTION
Adds the **Daikin Madoka** integration — control Daikin BRC1H (Madoka) Bluetooth thermostats, directly from HA's Bluetooth stack or through an ESPHome Bluetooth proxy.

Category: **integration**

Repository: https://github.com/dasimon135/daikin_madoka

Checklist:
- [x] Repository is public, not archived, has a description and topics
- [x] Issues are enabled
- [x] MIT license
- [x] `hacs.json` + valid `manifest.json` (domain, version, documentation, issue_tracker, codeowners)
- [x] hassfest + hacs/action validation pass in CI
- [x] Published release (v2.4.0)
- [x] Brand images shipped locally (HA 2026.3 `brand/` folder)
- [x] Requirement published on PyPI (`pymadoka-ng==0.3.4`)