### PR TITLE
Adds new integration [grzgrzgrz3/pingwa-hass]

### DIFF
--- a/integration
+++ b/integration
@@ -976,6 +976,7 @@
   "Griswoldlabs/span-panel-ha",
   "gritaro/gigachain",
   "grotan1/denon-avr-3805",
+  "grzgrzgrz3/pingwa-hass",
   "gstrike/ha-xlights_scheduler",
   "gtjadsonsantos/consul",
   "gtjadsonsantos/controlid",


### PR DESCRIPTION
## The repository

https://github.com/grzgrzgrz3/pingwa-hass

**pingwa** — send WhatsApp notifications from Home Assistant and receive two-way replies (text and button taps) over the official WhatsApp Cloud API.

## Checklist

- [x] I know that the wait time for a new integration is long, and I have read and understood https://hacs.xyz/docs/publish/include
- [x] The repository is public and its default branch has a release (`v0.2.0`).
- [x] The repository has a `hacs.json`, a `README.md`, and `custom_components/pingwa/manifest.json` with `domain`, `documentation`, `issue_tracker`, `codeowners`, and `version`.
- [x] The integration uses a UI config flow (`config_flow: true`), is single-instance, and ships brand icons under `custom_components/pingwa/brand/`.
- [x] hassfest and HACS validation run in CI and pass on the default branch.
- [x] Zero runtime dependencies; minimum Home Assistant version 2024.12.0.

## Notes

- iot_class: `cloud_push` (inbound replies arrive via an HMAC-signed webhook).
- Onboarding is UI-only (WhatsApp code registration, with an API-key fallback).