### PR TITLE
Adds new integration [grzgrzgrz3/pingwa-hass]

### DIFF
--- a/integration
+++ b/integration
@@ -976,6 +976,7 @@
   "Griswoldlabs/span-panel-ha",
   "gritaro/gigachain",
   "grotan1/denon-avr-3805",
+  "grzgrzgrz3/pingwa-hass",
   "gstrike/ha-xlights_scheduler",
   "gtjadsonsantos/consul",
   "gtjadsonsantos/controlid",


### PR DESCRIPTION
## Repository

- Repository: https://github.com/grzgrzgrz3/pingwa-hass
- Latest release: https://github.com/grzgrzgrz3/pingwa-hass/releases/latest
- CI action runs: https://github.com/grzgrzgrz3/pingwa-hass/actions

**pingwa** — send WhatsApp notifications from Home Assistant and receive two-way replies (text and button taps) over the official WhatsApp Cloud API.

## Checklist

- [x] I have read and understood https://hacs.xyz/docs/publish/include
- [x] The repository is public and its default branch has a published release.
- [x] `hacs.json`, `README.md`, and `custom_components/pingwa/manifest.json` (domain, documentation, issue_tracker, codeowners, version) are present.
- [x] UI config flow, single-instance, brand icons under `custom_components/pingwa/brand/`.
- [x] hassfest and HACS validation run in CI and pass on the default branch.
- [x] Zero runtime dependencies; minimum Home Assistant 2024.12.0.