### PR TITLE
Add LayerTM/unifi-ucg-fiber-ha

### DIFF
--- a/integration
+++ b/integration
@@ -1442,6 +1442,7 @@
   "lavalex2003/profimaktab",
   "LavermanJJ/home-assistant-solarfocus",
   "LawPaul/HA_Solar_Shade",
+  "LayerTM/unifi-ucg-fiber-ha",
   "lbbrhzn/ocpp",
   "ledimestari/homeassistant-precious-metals",
   "ledimestari/homeassistant-storj-integration",


### PR DESCRIPTION
Adds [`LayerTM/unifi-ucg-fiber-ha`](https://github.com/LayerTM/unifi-ucg-fiber-ha) — a non-invasive, read-only-by-default Home Assistant integration for Ubiquiti UniFi OS gateways (UCG-Fiber / UCG / UDM / UXG): WAN, ISP, speedtest, failover, console health and SFP status over the local UniFi Network API.

- Platinum quality scale; all CI green (tests, hassfest, hacs, lint, secret-scan)
- Releases published (latest v0.1.3); brand icons shipped in-repo
- Bundled zero-dependency client; read-only by default with opt-in controls