### PR TITLE
Adds new integration [slettmayer/wiener-netze-smart-meter]

### DIFF
--- a/integration
+++ b/integration
@@ -2614,6 +2614,7 @@
   "slesinger/HomeAssistant-BMR",
   "slesinger/HomeAssistant-PREdistribuce",
   "slettmayer/ha-fermob",
+  "slettmayer/wiener-netze-smart-meter",
   "SLG/home-assistant-whatpulse",
   "sli-cka/karakeep-homeassistant",
   "slx612/WOL-Home-Assistant-And-Alexa",


### PR DESCRIPTION
Adds the custom integration [`slettmayer/wiener-netze-smart-meter`](https://github.com/slettmayer/wiener-netze-smart-meter) — imports Wiener Netze smart meter energy data as external statistics for the Home Assistant Energy Dashboard.

## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: https://github.com/slettmayer/wiener-netze-smart-meter/releases/tag/v2.6.0
Link to successful HACS action (without the `ignore` key): https://github.com/slettmayer/wiener-netze-smart-meter/actions/runs/29501232795/job/87630377109
Link to successful hassfest action (if integration): https://github.com/slettmayer/wiener-netze-smart-meter/actions/runs/29501232795/job/87630377090

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->
