### PR TITLE
Add nizaga/ferroli-egea

### DIFF
--- a/integration
+++ b/integration
@@ -1829,6 +1829,7 @@
   "NirBY/ha-mashov",
   "nitaybz/ha-pima",
   "nitaybz/optimistic_feedback",
+  "nizaga/ferroli-egea",
   "njobrien1006/hass_traeger",
   "nkvoll/home-assistant-qsys-qrc",
   "nnnlog/homeassistant-cvnet-smarthome",


### PR DESCRIPTION
Adds the **Ferroli Egea** integration: https://github.com/nizaga/ferroli-egea

- Category: `integration`
- Description and topics set on the repository
- Passes `hassfest` + HACS validation (CI green)
- Brand assets included in the repository (`custom_components/ferroli_egea/brand/`)
- Released: `v0.2.0`

Unofficial cloud integration for **Ferroli Egea** heat-pump water heaters (the ones using the *Ferroli Home* app / Four Solid API). Provides a water_heater entity (temperature, on/off, operation modes), an operation-mode select (incl. Off/Standby/Fan), sensors and binary sensors, all set up through a UI config flow with device auto-discovery.