### PR TITLE
Add diRk262/ha-unitree-go2

### DIFF
--- a/integration
+++ b/integration
@@ -671,6 +671,7 @@
   "dingo35/ha-SmartEVSEv3",
   "dinki/view_assist_integration",
   "dirkgroenen/hass-evse-load-balancer",
+  "diRk262/ha-unitree-go2",
   "DisplacedForest/ha-hevy-tracker",
   "DiUS/homeassistant-powersensor",
   "Dixet/homeassistant_hetzner",


### PR DESCRIPTION
## New integration

**Repository:** https://github.com/diRk262/ha-unitree-go2

**What does the integration do?**
Home Assistant integration for the Unitree Go2 robot dog. Connects via WebRTC on the local network and exposes sensors, controls, camera and LiDAR map as native HA entities.

**Features:**
- 17 sensors (battery, temperature, position, IMU, LiDAR status)
- 2 switches (obstacle avoidance, LiDAR)
- 2 number sliders (volume, head light brightness)
- Front camera live stream
- Real-time 2D LiDAR point cloud visualization
- Auto-discovery via multicast
- Auto-reconnect
- English and German translations

**Checklist:**
- [x] HACS Action validation passes
- [x] Hassfest validation passes
- [x] Repository has topics set
- [x] Repository has a description
- [x] Brand assets included
- [x] `issue_tracker` in manifest