### PR TITLE
Re-add new integration [FaserF/ha-rewe]

### DIFF
--- a/integration
+++ b/integration
@@ -841,6 +841,7 @@
   "FaserF/ha-foodsharing",
   "FaserF/ha-kadermanager",
   "FaserF/ha-openwrt",
+  "FaserF/ha-rewe",
   "FaserF/ha-whatsapp",
   "Favio25/Kronoterm-homeassistant",
   "FeatherKing/ha-matriocontrol",

--- a/removed
+++ b/removed
@@ -1817,12 +1817,6 @@
     "link": "https://github.com/hacs/integration/issues/4254"
   },
   {
-    "repository": "FaserF/ha-rewe",
-    "reason": "Repository is archived",
-    "removal_type": "remove",
-    "link": "https://github.com/hacs/default/pull/3079"
-  },
-  {
     "repository": "isabellaalstrom/sensor.krisinformation",
     "reason": "Request from author",
     "removal_type": "remove",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [X] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [X] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [X] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [X] The actions are passing without any disabled checks in my repository.
- [X] I've added a link to the action run on my repository below in the links section.
- [X] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: https://github.com/FaserF/ha-rewe/releases/tag/v2026.7.0
Link to successful HACS action (without the `ignore` key): https://github.com/FaserF/ha-rewe/actions/runs/29496496431/job/87614888861
Link to successful hassfest action (if integration): https://github.com/FaserF/ha-rewe/actions/runs/29496496431/job/87614888818

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->

the rewe integration was already a official hacs integration (https://github.com/hacs/default/pull/1513), but the API changes broke it and it wasnt working for the last two years (https://github.com/hacs/default/pull/3079). Now I got it working again and un-archived the repo and dropped a new release. Therfore I would like to re-add it to hacs again. 