### PR TITLE
Adds new plugin [Rsoul2634/ha-network-ping-card]

### DIFF
--- a/plugin
+++ b/plugin
@@ -516,6 +516,7 @@
   "RomRider/apexcharts-card",
   "rosenrot00/home-flow-card",
   "royto/logbook-card",
+  "Rsoul2634/ha-network-ping-card",
   "rusty4444/coming-soon-card",
   "rusty4444/recently-added-media-card",
   "s5zone/weasley-clock-card",


### PR DESCRIPTION
## Repository

https://github.com/Rsoul2634/ha-network-ping-card

## Description

A Lovelace card that pings a host from the Home Assistant server. Lets you
pick a host from a dropdown of known entities (any entity with an IP-like
attribute, e.g. `device_tracker`), or type one manually, with buttons to
update/clear the cached entity list.

## Links

- Latest release: [v1.0.0](https://github.com/Rsoul2634/ha-network-ping-card/releases/tag/v1.0.0)
- CI action run: [hacs/action passing](https://github.com/Rsoul2634/ha-network-ping-card/actions/runs/29573236695)

## Checklist

- [x] `hacs.json` present
- [x] README with installation/usage instructions
- [x] LICENSE (MIT)
- [x] GitHub topics set (hacs, home-assistant, lovelace, plugin, frontend)
- [x] `hacs/action` validation workflow passing