### PR TITLE
Add fboundy/miser

### DIFF
--- a/integration
+++ b/integration
@@ -843,6 +843,7 @@
   "FaserF/ha-openwrt",
   "FaserF/ha-whatsapp",
   "Favio25/Kronoterm-homeassistant",
+  "fboundy/miser",
   "FeatherKing/ha-matriocontrol",
   "FehTeh/ha-custom-component-growappy",
   "feihuasimeng1993/linkedgo_bridge",


### PR DESCRIPTION
Adds the Miser PV System Optimiser custom integration to the default HACS integration repositories.\n\nRepository: https://github.com/fboundy/miser\nRelease: https://github.com/fboundy/miser/releases/tag/v0.0.1