### PR TITLE
Add oetiker/byonk

### DIFF
--- a/integration
+++ b/integration
@@ -1852,6 +1852,7 @@
   "OddanN/etelecom_for_home_assistant",
   "OddanN/info_lan_for_home_assistant",
   "odya/hass-ina219-ups-hat",
+  "oetiker/byonk",
   "ofalvai/home-assistant-candy",
   "ogerardin/ha-cfl-commute",
   "ohheyrj/home-assistant-aws-codepipeline",


### PR DESCRIPTION
Adds [oetiker/byonk](https://github.com/oetiker/byonk) as a HACS integration.

Byonk is a self-hosted content server for TRMNL e-ink devices; the repo ships a Home Assistant custom integration (`custom_components/byonk/`) that installs and manages the Byonk add-on with zero-touch setup.

- Single integration under `custom_components/byonk/`
- `hacs.json` and `manifest.json` present (`domain`, `name`, `version`, `documentation`, `issue_tracker`, `codeowners`)
- Local brand images in `custom_components/byonk/brand/` (icon + logo, @1x/@2x)
- Published release: `v0.17.1`