### PR TITLE
Add Universal Modbus integration

### DIFF
--- a/integration
+++ b/integration
@@ -1100,6 +1100,7 @@
   "IATkachenko/HA-YandexWeather",
   "Ibepower/Ibepower-Homeassistant-Integration",
   "ideaalab/gui-recorder",
+  "Idelmaeaen/HA-Universal-Modbus",
   "ifMike/homeyHASS",
   "IgnacioHR/de-dietrich-c230-ha",
   "iioel/magiline-imagix-homeassistant",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/Idelmaeaen/HA-Universal-Modbus/releases/tag/v0.5.8>
Link to successful HACS action (without the \ignore\ key): <https://github.com/Idelmaeaen/HA-Universal-Modbus/actions/runs/29620909077>
Link to successful hassfest action (if integration): <https://github.com/Idelmaeaen/HA-Universal-Modbus/actions/runs/29620909091>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->