### PR TITLE
Add new integration [lerebel103/pool-lab-ha-plugin]

### DIFF
--- a/integration
+++ b/integration
@@ -1453,6 +1453,7 @@
   "leonardlcl/mhtzn",
   "leorbs/airco2ntrol",
   "leranp/HomeAssistant-galatz-news",
+  "lerebel103/pool-lab-ha-plugin",
   "LeszekWroblowski/ffes_sauna__modbus_home_assistant",
   "Lewa-Reka/ha-rce-pse",
   "lewei50/ha_iammeter",


### PR DESCRIPTION
Adds Pool Lab integration for Poolpower Australia PL MAX series pool controllers (local TCP protocol).