### PR TITLE
Add pgress/hass-nuernberg-umweltdaten

### DIFF
--- a/integration
+++ b/integration
@@ -1940,6 +1940,7 @@
   "Petro31/ha-integration-multizone-controller",
   "peyton/homeassistant-anona-holo",
   "pfalzcraft/notion-garden-care",
+  "pgress/hass-nuernberg-umweltdaten",
   "PhantomPhoton/S3-Compatible",
   "Phil-Barker/hass-bosch-ebike",
   "Phil7989/advanced_snapshot",


### PR DESCRIPTION
## Submission

- **Repository:** `pgress/hass-nuernberg-umweltdaten`
- **Category:** integration
- **Owner:** @pgress

## Checklist

- [x] The repository is public and hosted on GitHub.
- [x] The repository can be added to HACS as a custom repository.
- [x] The [HACS Action](https://github.com/hacs/action) passes without errors or ignores.
- [x] The [Hassfest](https://github.com/home-assistant/actions#hassfest) action passes (integrations only).
- [x] A new GitHub release (not just a tag) has been published after the actions ran successfully.
- [x] I am the owner of the repository.
- [x] The entry is added in alphabetical order.
- [x] The PR is submitted from a personal account and is editable.

## Description

Custom integration for Home Assistant that reads the public environmental
data (air quality, weather, water) published by the City of Nuremberg
(Stadtentwässerung und Umweltanalytik Nürnberg) via its JSON microservice.
Offers a station picker and dynamically creates sensors only for the
values each station actually reports.

Latest release: v1.1.0