### PR TITLE
Adds new integration [Eales/tauron-dystrybucja]

### DIFF
--- a/integration
+++ b/integration
@@ -738,6 +738,7 @@
   "dvd-dev/hilo",
   "dwainscheeren/dwains-lovelace-dashboard",
   "dylandoamaral/trakt-integration",
+  "Eales/tauron-dystrybucja",
   "earendil06/Windy-Webcams",
   "EarthGoodness/egi",
   "ebertek/ssm",


### PR DESCRIPTION
Adds `Eales/tauron-dystrybucja` — a Home Assistant integration reporting planned and unplanned power outages from the public Tauron Dystrybucja API (Poland).

The integration exposes outages as a calendar entity, an event entity that fires when a new outage is announced, and dedicated sensors for status, start, end, duration and description.

- Repository: https://github.com/Eales/tauron-dystrybucja
- Release: https://github.com/Eales/tauron-dystrybucja/releases/tag/v0.3.0
- HACS Action and hassfest both pass with no ignores: https://github.com/Eales/tauron-dystrybucja/actions/runs/29650432477

Brand assets are shipped with the integration in `custom_components/tauron_dystrybucja/brand/`.
