### PR TITLE
Add yufeikang/hass-aiphone

### DIFF
--- a/integration
+++ b/integration
@@ -2671,6 +2671,7 @@
   "youdroid/home-assistant-gogs",
   "youdroid/home-assistant-sickchill",
   "youngaileaderslinz/HA-RAGent",
+  "yufeikang/hass-aiphone",
   "YukariChiba/hass_companieshouse",
   "yunusp01/auto_utility_meter",
   "ZacheryThomas/homeassistant-smartrent",


### PR DESCRIPTION
Adds the `aiphone` integration to the default store.

- **Repository:** https://github.com/yufeikang/hass-aiphone
- **Domain:** `aiphone`
- **Category:** integration
- Native Home Assistant integration for Aiphone WP-2MED / VKZ-R video intercoms — connects directly to the device's AWS IoT MQTT, no cloud relay. Provides ring events, monitor button, camera snapshots and automatic call recording.

Checklist:
- [x] Public GitHub repo, not archived, issues enabled, description + topics set
- [x] Latest **stable** release `v0.1.1`
- [x] Valid `hacs.json` (name) and `manifest.json` (domain, name, version, documentation, issue_tracker, codeowners)
- [x] Local brand assets at `custom_components/aiphone/brand/` (icon + logo)
- [x] HACS Action + hassfest passing
- [x] Submitted by the repository owner (@yufeikang)