### PR TITLE
Add yufeikang/hass-aiphone

### DIFF
--- a/integration
+++ b/integration
@@ -2671,6 +2671,7 @@
   "youdroid/home-assistant-gogs",
   "youdroid/home-assistant-sickchill",
   "youngaileaderslinz/HA-RAGent",
+  "yufeikang/hass-aiphone",
   "YukariChiba/hass_companieshouse",
   "yunusp01/auto_utility_meter",
   "ZacheryThomas/homeassistant-smartrent",


### PR DESCRIPTION
Adds the `aiphone` integration to the default HACS store.

Repository: https://github.com/yufeikang/hass-aiphone
Latest release: https://github.com/yufeikang/hass-aiphone/releases/tag/v0.1.1
CI action runs: https://github.com/yufeikang/hass-aiphone/actions/workflows/validate.yml

Domain: `aiphone` — a native Home Assistant integration for Aiphone WP-2MED / VKZ-R video intercoms (connects directly to the device's AWS IoT MQTT, no cloud relay). Provides ring events, monitor button, camera snapshots and automatic call recording. Local brand assets ship under `custom_components/aiphone/brand/`. Submitted by the repository owner (@yufeikang).