### PR TITLE
Add V-Plum/evse_energy_star

### DIFF
--- a/integration
+++ b/integration
@@ -2556,6 +2556,7 @@
   "usersaynoso/ha-cudy-router",
   "usersaynoso/Meter-MACS-Portal-for-Home-Assistant",
   "usersaynoso/victron-vebus-mk3-control",
+  "V-Plum/evse_energy_star",
   "v1ack/lelight",
   "V4n1X/ha_stromgedacht",
   "vakio-ru/vakio_atmosphere",


### PR DESCRIPTION
Adds the custom integration **V-Plum/evse_energy_star** (EVSE Energy Star / Eveus Pro EV charger — local control).

- Repository: https://github.com/V-Plum/evse_energy_star
- Category: integration
- License: MIT · has releases (latest v1.3.3) · description · topics
- Brand icons included in-repo · `hassfest` + HACS validation workflow passing

Inserted in alphabetical order in `integration`.