### PR TITLE
Add V-Plum/evse_energy_star

### DIFF
--- a/integration
+++ b/integration
@@ -2556,6 +2556,7 @@
   "usersaynoso/ha-cudy-router",
   "usersaynoso/Meter-MACS-Portal-for-Home-Assistant",
   "usersaynoso/victron-vebus-mk3-control",
+  "V-Plum/evse_energy_star",
   "v1ack/lelight",
   "V4n1X/ha_stromgedacht",
   "vakio-ru/vakio_atmosphere",


### PR DESCRIPTION
Adds custom integration **V-Plum/evse_energy_star** (EVSE Energy Star / Eveus Pro EV charger, local control).

- Repository: https://github.com/V-Plum/evse_energy_star
- Category: integration
- MIT, releases (v1.3.3), description, topics, in-repo brand icons, hassfest+HACS CI passing.