### PR TITLE
Add Sarnog/ha-marktplaats

### DIFF
--- a/integration
+++ b/integration
@@ -2186,6 +2186,7 @@
   "Sanji78/telegram_voip",
   "Sanji78/vitesy_shelfy",
   "sanjoyg/dirigera_platform",
+  "Sarnog/ha-marktplaats",
   "sasiela/siepomaga",
   "SasPes/lpubelts_ha",
   "sathia-musso/enelgrid",


### PR DESCRIPTION
Adds [Sarnog/ha-marktplaats](https://github.com/Sarnog/ha-marktplaats) to the default integration list.

A HACS custom integration that watches marktplaats.nl for new listings matching a saved search (keyword + radius/location, with optional price/condition/category filters), and notifies via a Home Assistant event so users can build their own notification automations.

- [x] Public GitHub repository
- [x] Repository has a description and topics
- [x] README with usage instructions (NL/EN)
- [x] `hacs.json` present
- [x] Valid `manifest.json` (domain, name, codeowners, config_flow, documentation, integration_type, iot_class, issue_tracker, version)
- [x] hassfest and HACS validation workflows added and passing
- [x] A full GitHub Release published (v0.1.0), not just a tag
- [x] Brand assets submitted: home-assistant/brands#10801
