### PR TITLE
Add new integration for ford-triplog

### DIFF
--- a/integration
+++ b/integration
@@ -2608,6 +2608,7 @@
   "WeaveHubHQ/ha-u-by-moen",
   "WeaveHubHQ/robinhood_crypto",
   "webbson/homeassistant-message-queue",
+  "weberdomi-ctrl/ford-triplog",
   "weiangongsi/ddns",
   "Weissnix4711/hass-listenbrainz",
   "weltenwort/home-assistant-rct-power-integration",


### PR DESCRIPTION
## Summary

Add Ford Triplog to the HACS default repository.

Repository:
https://github.com/weberdomi-ctrl/ford-triplog

### Validation

- [x] HACS validation passes
- [x] Hassfest passes
- [x] HACS compatible
- [x] GitHub release available