### PR TITLE
Adds new integration [Matzaptor/ha-recorder-ext]

### DIFF
--- a/integration
+++ b/integration
@@ -1847,6 +1847,7 @@
   "MattieGit/qube_heatpump",
   "mattrayner/pod-point-home-assistant-component",
   "MattXcz/CEZ",
+  "Matzaptor/ha-recorder-ext",
   "MauroDruwel/Weathercloud-HA",
   "mawinkler/astroweather",
   "maxbeizer/homeassistant-nes",

--- a/integration
+++ b/integration
@@ -1943,6 +1943,7 @@
   "mattrayner/pod-point-home-assistant-component",
   "MattXcz/CEZ",
   "Matysh/houseplan-card",
+  "Matzaptor/ha-recorder-ext",
   "MauroDruwel/Weathercloud-HA",
   "mawinkler/astroweather",
   "Max-src/yeelight-cube-lite",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: https://github.com/Matzaptor/ha-recorder-ext/releases/tag/v2.4.1
Link to successful HACS action (without the `ignore` key): https://github.com/Matzaptor/ha-recorder-ext/actions/runs/29694091529/job/88211742071
Link to successful hassfest action (if integration): https://github.com/Matzaptor/ha-recorder-ext/actions/runs/29694091529/job/88211742049