### PR TITLE
Add dasimon135/ha-bluetooth-mesh

### DIFF
--- a/integration
+++ b/integration
@@ -598,6 +598,7 @@
   "Darkdragon14/ha-guest-mode",
   "DarwinsBuddy/WienerNetzeSmartmeter",
   "DasBasti/SmartHashtag",
+  "dasimon135/ha-bluetooth-mesh",
   "dasshubham762/atomberg-integration",
   "dave-code-ruiz/elkbledom",
   "dave-code-ruiz/uhomeuponor",


### PR DESCRIPTION
Adds the **Bluetooth Mesh** integration.

Control Bluetooth SIG Mesh lighting (Häfele Connect Mesh / ThingOS) from Home Assistant with a pure-Python mesh stack — no vendor gateway, using existing ESPHome Bluetooth proxies (or a local adapter). One `light` entity per node (on/off, brightness, colour temperature).

- Repo: https://github.com/dasimon135/ha-bluetooth-mesh
- Category: integration
- Release: v0.1.0
- CI: tests + hassfest + HACS validation all green
- Validated end-to-end on real hardware (Häfele tunable-white lamp via an ESPHome proxy).