### PR TITLE
Adds new plugin [n71154plus/universal-device-card]

### DIFF
--- a/plugin
+++ b/plugin
@@ -415,6 +415,7 @@
   "mtheli/gardena-smart-system-card",
   "mtheli/toothbrush-card",
   "mutilator/homeassistant-solar-panel-preview",
+  "n71154plus/universal-device-card",
   "nathan-gs/ha-map-card",
   "nathanmarlor/foxess_modbus_charge_period_card",
   "nathkrill/lovelace-google-fonts-header-card",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/n71154plus/universal-device-card/releases/tag/v2.6.4>
Link to successful HACS action (without the `ignore` key): <https://github.com/n71154plus/universal-device-card/actions/runs/29952831895>
Link to successful hassfest action (if integration): <N/A — this is a plugin / Dashboard card>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->