### PR TITLE
Adds new integration [yodax/ha-scaleway]

### DIFF
--- a/integration
+++ b/integration
@@ -2663,6 +2663,7 @@
   "yieldhog/usgs_streamflow",
   "yinyang17/pvpc_energy",
   "yo-han/Home-Assistant-Carelink",
+  "yodax/ha-scaleway",
   "yohaybn/HA_aliexpress_package_tracker_sensor",
   "yohaybn/HomeAssistant-EPG",
   "yomonpet/ha-sofabaton-hub",


### PR DESCRIPTION
Adds [yodax/ha-scaleway](https://github.com/yodax/ha-scaleway), a Home Assistant integration for [Scaleway](https://www.scaleway.com/).

It exposes read-only sensors for account spend (total and per billing category), Instance state, Kubernetes (Kapsule) cluster status, and Object Storage bucket size/object count. A Scaleway bucket can also be registered as a Home Assistant backup location.

The integration has no Python dependencies — it talks to Scaleway's REST and S3-compatible APIs directly using Home Assistant's own aiohttp session.

### Checklist

- [x] Repository is public, has a description, topics, and issues enabled
- [x] [Release v1.0.0](https://github.com/yodax/ha-scaleway/releases/tag/v1.0.0) published
- [x] [HACS action](https://github.com/yodax/ha-scaleway/actions/workflows/validate.yml) passes with no ignored checks — *All (9) checks passed*
- [x] Hassfest passes
- [x] `hacs.json` present with `name`, and a minimum Home Assistant version
- [x] Valid `custom_components/scaleway/manifest.json`
- [x] Brand images included at `custom_components/scaleway/brand/`
- [x] Entry added in alphabetical order
- [x] Submitted by the repository owner

🤖 Generated with [Claude Code](https://claude.com/claude-code)