### PR TITLE
Add jnctech/hinen-solar-homeassistant

### DIFF
--- a/integration
+++ b/integration
@@ -1236,6 +1236,7 @@
   "jnalepka/grenton-objects-home-assistant",
   "jnalepka/grenton-watcher-home-assistant",
   "jnbp/t-skylt",
+  "jnctech/hinen-solar-homeassistant",
   "jnxxx/homeassistant-dabblerdk_powermeterreader",
   "JoaoPedroBelo/bmw-wallbox-ha",
   "jobvk/Home-Assistant-Windcentrale",


### PR DESCRIPTION
Adds **jnctech/hinen-solar-homeassistant** — *Hinen Solar Advanced*, a monitoring **and control** integration for Hinen solar inverters, PV and battery storage.

- Category: **integration** (domain `hinen`, `custom_components/hinen/`)
- Auth via Home Assistant Application Credentials + OAuth2 framework; **no third-party Python dependency**
- 67 sensors + 7 controls (verified writes); real test suite (~90% cov)
- HACS Action + hassfest green; ships its own `brand/` icon (HA 2026.3 self-hosted brands)
- Released `v1.0.0`; distinct from the official `hinen_power`