### PR TITLE
Adds new integration [albertovincenzi/ha_samsung_dms]

### DIFF
--- a/integration
+++ b/integration
@@ -67,6 +67,7 @@
   "ALArvi019/moderntides",
   "albaintor/homeassistant_electrolux_status",
   "albertogeniola/meross-homeassistant",
+  "albertovincenzi/ha_samsung_dms",
   "AlbinLind/dawarich-home-assistant",
   "AlbrechtL/hass-padersprinter",
   "alceasan/ha-deepgram-tts",


### PR DESCRIPTION
## Adds a new integration

- Repository: https://github.com/albertovincenzi/ha_samsung_dms
- Category: integration

Home Assistant integration for the **Samsung DMS2.5** local DVM air-conditioning controller. Local polling only (no cloud). Exposes indoor units as `climate`, EHS units as `water_heater` + `climate`, energy-recovery ventilators as `fan`, plus per-unit remote-lock `switch` and schedule `binary_sensor`.

### Checklist
- [x] The repository passes the HACS Action validation (9/9 checks) and hassfest.
- [x] The integration lives under `custom_components/samsung_dms/` with a valid `manifest.json` (domain, name, version, documentation, issue_tracker, codeowners).
- [x] The repository has a description and topics set.
- [x] The repository has a published release (v0.4.2).
- [x] A README is present.
- [x] Brand assets are provided (local `brand/` icon, Brands Proxy API).
- [x] I am the owner/author of the repository being added.