### PR TITLE
Remove home-assistant-wienerlinien integration

### DIFF
--- a/integration
+++ b/integration
@@ -2485,7 +2485,6 @@
   "tmenguy/ha-hydropolis-valbonne",
   "tmonck/clean_up_snapshots",
   "tobias-terhaar/e3dc_rscp_connect",
-  "tofuSCHNITZEL/home-assistant-wienerlinien",
   "toggm/askoheat",
   "Tom-Bom-badil/home-assistant_helios-vallox",
   "Tom-Bom-badil/home-assistant_ugreen-nas",


### PR DESCRIPTION
I have archived https://github.com/tofuSCHNITZEL/home-assistant-wienerlinien since there is a better working, more feature complete version now published in hacs: https://github.com/rolandzeiner/wiener-linien-austria

Please remove 'tofuSCHNITZEL/home-assistant-wienerlinien' from the integration list.

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->