### PR TITLE
Remove home-assistant-wienerlinien integration

### DIFF
--- a/integration
+++ b/integration
@@ -2485,7 +2485,6 @@
   "tmenguy/ha-hydropolis-valbonne",
   "tmonck/clean_up_snapshots",
   "tobias-terhaar/e3dc_rscp_connect",
-  "tofuSCHNITZEL/home-assistant-wienerlinien",
   "toggm/askoheat",
   "Tom-Bom-badil/home-assistant_helios-vallox",
   "Tom-Bom-badil/home-assistant_ugreen-nas",


### PR DESCRIPTION
I have archived https://github.com/tofuSCHNITZEL/home-assistant-wienerlinien since there is a better working, more feature complete version now published in hacs: https://github.com/rolandzeiner/wiener-linien-austria

Please remove 'tofuSCHNITZEL/home-assistant-wienerlinien' from the integration list.

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/tofuSCHNITZEL/home-assistant-wienerlinien>
Link to successful HACS action (without the `ignore` key): <https://github.com/tofuSCHNITZEL/home-assistant-wienerlinien>
Link to successful hassfest action (if integration): <https://github.com/tofuSCHNITZEL/home-assistant-wienerlinien>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->