### PR TITLE
Add Identity-labs/ha-maison-protegee2

### DIFF
--- a/integration
+++ b/integration
@@ -1100,6 +1100,7 @@
   "IATkachenko/HA-YandexWeather",
   "Ibepower/Ibepower-Homeassistant-Integration",
   "ideaalab/gui-recorder",
+  "Identity-labs/ha-maison-protegee2",
   "ifMike/homeyHASS",
   "IgnacioHR/de-dietrich-c230-ha",
   "iioel/magiline-imagix-homeassistant",


### PR DESCRIPTION
## Link to the repository
https://github.com/Identity-labs/ha-maison-protegee2

## Description
Home Assistant custom integration for **Orange Maison Protégée** (French Orange home alarm), using the reverse-engineered gRPC API from the official Android app.

- Alarm control panel (total / partial / disarm)
- Per-device sensors (battery, signal, temperature, connection, opening)
- Config flow

## Checklist
- [x] The owner/major contributor of the repository is opening the PR
- [x] The repository follows the [HACS publishing guidelines](https://www.hacs.xyz/docs/publish/start/)
- [x] HACS Action and hassfest pass on the repository
- [x] A GitHub release exists (`v2.2.7`)
- [x] `hacs.json` includes `name` and `country: FR`
- [x] Brand icons are present under `custom_components/maison_protegee/brand/`
- [x] Entry added alphabetically to `integration`

Made with [Cursor](https://cursor.com)