### PR TITLE
Adds new integration [gsmnode/gsmnode-ha]

### DIFF
--- a/integration
+++ b/integration
@@ -976,6 +976,7 @@
   "Griswoldlabs/span-panel-ha",
   "gritaro/gigachain",
   "grotan1/denon-avr-3805",
+  "gsmnode/gsmnode-ha",
   "gstrike/ha-xlights_scheduler",
   "gtjadsonsantos/consul",
   "gtjadsonsantos/controlid",


### PR DESCRIPTION
Home Assistant integration for [gsmnode](https://github.com/gsmnode/gsmnode-ha), which turns Android phones into an SMS gateway: it sends SMS, MMS and calls from automations, exposes the gateway and each phone as connectivity sensors, and turns incoming messages and calls into Home Assistant events. Configured entirely from the UI.

## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/gsmnode/gsmnode-ha/releases/tag/v3.3.1>
Link to successful HACS action (without the `ignore` key): <https://github.com/gsmnode/gsmnode-ha/actions/runs/30357437727/job/90268805462>
Link to successful hassfest action (if integration): <https://github.com/gsmnode/gsmnode-ha/actions/runs/30357437727/job/90268805543>
