### PR TITLE
Adds new integration [kn8v7bf65h-art/homeassistant-p2000-companion]

### DIFF
--- a/integration
+++ b/integration
@@ -1373,6 +1373,7 @@
   "Kleinrotti/hass-senertec",
   "klejejs/ha-thermia-heat-pump-integration",
   "klokku/klokku-home-assistant-integration",
+  "kn8v7bf65h-art/homeassistant-p2000-companion",
   "kneave/climate-scheduler",
   "Knifa/led-matrix-zmq-hass",
   "knirzinger/hargassner-ha",


### PR DESCRIPTION
Adds kn8v7bf65h-art/homeassistant-p2000-companion to the default HACS integration repository list.

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/kn8v7bf65h-art/homeassistant-p2000-companion/releases/tag/v3.0.0>
Link to successful HACS action (without the `ignore` key): <https://github.com/kn8v7bf65h-art/homeassistant-p2000-companion/actions/runs/29963572289/job/89069992806>
Link to successful hassfest action (if integration): <https://github.com/kn8v7bf65h-art/homeassistant-p2000-companion/actions/runs/29963572289/job/89069992719>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->