### PR TITLE
Add vlioscz/is3-export

### DIFF
--- a/integration
+++ b/integration
@@ -2587,6 +2587,7 @@
   "vithurshanselvarajah/ha-glinet",
   "VitisEK/nibe_energy_conversion",
   "vivo/ha_vivohomebridge",
+  "vlioscz/is3-export",
   "vlumikero/home-assistant-securitas",
   "vmakeev/huawei_mesh_router",
   "vmarkovtsev/sistena_onix_ha",


### PR DESCRIPTION
Adds `vlioscz/is3-export` to the integration store.

**Home Assistant integration for iNELS (ELKO EP) CU3 central units** over their plain-TCP ASCII interface — zero-config discovery from the unit's own export, live state via pushed events, no Connection Server required.

- Repository: https://github.com/vlioscz/is3-export
- Owner/author: @vlioscz (I own the repository)
- Latest release: `0.1.1`

Requirements:
- [x] Public, not archived; Issues enabled; description and topics set
- [x] At least one published release (`0.1.1`)
- [x] `hassfest` and HACS Action pass in CI
- [x] Brand icon shipped in-repo (`custom_components/is3_export/brand/icon.png`, 256×256)
- [x] Single integration under `custom_components/is3_export/` with a valid `manifest.json` and `hacs.json`
