### PR TITLE
Add mrtian2016/yunkan-hass-integration

### DIFF
--- a/integration
+++ b/integration
@@ -1721,6 +1721,7 @@
   "MrSjodin/HomeAssistant_Trafiklab_Integration",
   "MrSleeps/Juwel-HeliaLux-Home-Assistant-Custom-Component",
   "Mrtenz/hass-free-sleep",
+  "mrtian2016/yunkan-hass-integration",
   "mrverrall/philips-heater-coap",
   "msp1974/ViewAssist_Companion_App",
   "msvinth/ha-vinorage",


### PR DESCRIPTION
Adds the **Yunkan** custom integration to the HACS default store.

- Repository: https://github.com/mrtian2016/yunkan-hass-integration
- Category: integration
- Domain: `yunkan`

A thin-client Home Assistant integration for the self-hosted Yunkan camera
server (native WebRTC cameras, detection sensors, PTZ, media browser, device
actions; no MQTT required). Passes the HACS validation and hassfest workflows.
A brand-assets PR to home-assistant/brands has been submitted
(home-assistant/brands#10823).
