### PR TITLE
Add Tobhs/flights_above

### DIFF
--- a/integration
+++ b/integration
@@ -2484,6 +2484,7 @@
   "tlskinneriv/awnet_local",
   "tmenguy/ha-hydropolis-valbonne",
   "tmonck/clean_up_snapshots",
+  "Tobhs/flights_above",
   "tobias-terhaar/e3dc_rscp_connect",
   "tofuSCHNITZEL/home-assistant-wienerlinien",
   "toggm/askoheat",


### PR DESCRIPTION
Adds [Tobhs/flights_above](https://github.com/Tobhs/flights_above) as a default integration.

Flights Above shows aircraft passing over a chosen location, with departure/arrival airports, a progress track (hours flown/remaining/total), estimated CO2 and people on board, and a bundled Lovelace card. Uses free ADS-B data (adsb.lol / airplanes.live) and adsbdb.com routes - no API key.

- Passes hassfest and HACS validation
- Local brand icon in `custom_components/flights_above/brand/`
- Release: v1.0.1