### PR TITLE
Add livetennisapi/ha-livetennis

### DIFF
--- a/integration
+++ b/integration
@@ -1480,6 +1480,7 @@
   "Lint-Free-Technology/uix",
   "lipelix/home-assistant-chmu-weather",
   "littleyoda/ha-pysmaplus",
+  "livetennisapi/ha-livetennis",
   "lizardsystems/hass-mygas",
   "lizardsystems/hass-taipit",
   "lizardsystems/hass-tnse",


### PR DESCRIPTION
Adds the Live Tennis integration.

**Repository:** https://github.com/livetennisapi/ha-livetennis

Live tennis scores as Home Assistant sensors — ATP, WTA, Challenger and ITF. A `live matches` count sensor plus an optional sensor per live match, with a config flow for the user's own API key, tour selection and poll interval.

### Requirements checklist
- [x] Single integration under `custom_components/` (`livetennis`)
- [x] `manifest.json` with `version`, `iot_class` (`cloud_polling`), `config_flow`, `documentation` and `issue_tracker`
- [x] `hacs.json` with name and `homeassistant` minimum (2024.8.0)
- [x] Published release: [v1.0.0](https://github.com/livetennisapi/ha-livetennis/releases/tag/v1.0.0)
- [x] Repository description and topics set
- [x] README and MIT LICENSE
- [x] CI running hassfest + HACS Action

### Notes
Tested against a real Home Assistant 2026.7.3: the config entry reaches `LOADED`, sensors populate from live data, and a rejected key keeps the entry out of `LOADED` for reauth. The coordinator passes `config_entry` explicitly, since that becomes mandatory in 2026.8.

Polling defaults to 120s with a 60s floor, so a single key stays well inside the upstream free tier's rate limit. Users supply their own key; a free tier is available without a card.

Brand icons will be submitted separately to home-assistant/brands.