### PR TITLE
Adds new integration [rdgerken/ha-timebase]

### DIFF
--- a/integration
+++ b/integration
@@ -2345,6 +2345,7 @@
   "rccoleman/channels_dvr_recently_recorded",
   "rdehuyss/homeassistant-custom_components-denkovi",
   "rdgerken/ha-i3x",
+  "rdgerken/ha-timebase",
   "recalbox/RecalboxHomeAssistant",
   "redchupa/kr_baby_kit",
   "RedFirebreak/ha-osrs-data",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/rdgerken/ha-timebase/releases/tag/v0.5.1>
Link to successful HACS action (without the `ignore` key): <https://github.com/rdgerken/ha-timebase/actions/runs/33318649606/job/99276585020>
Link to successful hassfest action (if integration): <https://github.com/rdgerken/ha-timebase/actions/runs/33318649606/job/99276584878>

## About the integration

Home Assistant integration for [Flow Software's Timebase](https://timebase.flow-software.com/) industrial time-series historian: exports entity history as event-timestamped, quality-coded samples (ordered store-and-forward, Repair issues), and surfaces historian data back into HA as native long-term statistics (measurement + meter-reset-aware counters) and live sensors. Pulse (OAuth2) authentication supported. Tested end-to-end against a live Timebase 1.3.x deployment; pytest suite + hassfest + HACS validation run on every push.

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->

