### PR TITLE
Adds new integration [gabrielcolceriu/hyundai-broadlink-ac]

### DIFF
--- a/integration
+++ b/integration
@@ -905,6 +905,7 @@
   "g470258/hass-esplus",
   "g4bri3lDev/munich_public_transport",
   "gabest11/homeassistant-brother_scanner",
+  "gabrielcolceriu/hyundai-broadlink-ac",
   "gadgetchnnel/entities_calendar",
   "GaillardTom/SherbrookePoubelle-HA",
   "GamingonTour1/ha-groupalarm-api",


### PR DESCRIPTION
Add [gabrielcolceriu/hyundai-broadlink-ac](https://github.com/gabrielcolceriu/hyundai-broadlink-ac) — local Home Assistant integration for Hyundai HTAC air conditioners (BroadLink/DNA 0x507A module), controlled fully over the LAN with the device AES key. Passes HACS + hassfest validation.