### PR TITLE
Add elad-sudo/domiara-ha

### DIFF
--- a/integration
+++ b/integration
@@ -765,6 +765,7 @@
   "elad-bar/ha-edgeos",
   "elad-bar/ha-hpprinter",
   "elad-bar/ha-shinobi",
+  "elad-sudo/domiara-ha",
   "eladnahum5/ha-vouchervault",
   "elahd/ha-cyclepay",
   "elahd/ha-nyc311",


### PR DESCRIPTION
Adds `elad-sudo/domiara-ha` to the integration list.

**Domiara (TouchWand)** is a Home Assistant integration for TouchWand smart-home controllers. The vendor's own consumer app was discontinued, leaving these controllers without mobile or hub control; this integration talks to them directly over the local network.

- Local push (`iot_class: local_push`) — state arrives from the controller rather than being polled
- Platforms: light, cover, climate, switch, sensor, binary_sensor, scene
- Devices are assigned to HA areas named after the controller's own rooms
- Config flow, translations in English and Hebrew, diagnostics support
- Local-only by design: rejects non-private controller addresses unless explicitly overridden

Repository: https://github.com/elad-sudo/domiara-ha
Release: https://github.com/elad-sudo/domiara-ha/releases/tag/v1.0.0

HACS action and hassfest both pass on `main`. Brand assets are bundled in the repository, and a PR adding them to the brands repository is open at home-assistant/brands#10839.

License MIT. Independent third-party project, not affiliated with TouchWand.