### PR TITLE
Add AboveColin/HA-Liberty-Global-Gateway

### DIFF
--- a/integration
+++ b/integration
@@ -27,6 +27,7 @@
   "ablyler/home-assistant-bradford-white-connect",
   "abnvle/ha-imgw-pib-monitor",
   "abnvle/ha-matomo",
+  "AboveColin/HA-Liberty-Global-Gateway",
   "AboveColin/HA-Philips-Pet-Series",
   "absent42/Aqara-Advanced-Lighting",
   "absent42/Aqara-Camera-2-Way-Audio",


### PR DESCRIPTION
Home Assistant integration for the DOCSIS cable gateways Liberty Global operators ship — the Ziggo SmartWifi modem (NL), UPC / Unitymedia Connect Box, Virgin Media hubs and the Sunrise / Yallo equivalents. They all run the same LG-RDK firmware and expose the same local admin REST API.

- Local polling only, no cloud.
- DOCSIS diagnostics, WAN/provisioning, Wi-Fi and firewall state, per-device presence detection, UPnP/LED controls, reboot button.
- SSDP discovery, confirmed against an unauthenticated identification endpoint so unrelated UPnP routers are not offered.
- Models: Sagemcom F3896LG / F3897LG / F5685LGB / F5685LGE and Compal CH7465LG.

Built on [liberty-global-gateway](https://pypi.org/project/liberty-global-gateway/) (also mine). Brand assets are bundled under `custom_components/liberty_global_gateway/brand/`.