### PR TITLE
Adds new integration pickerin/hass-busybar

### DIFF
--- a/integration
+++ b/integration
@@ -1948,6 +1948,7 @@
   "Pho3niX90/solis_modbus",
   "phoinixgrr/sigma_connect_ha",
   "physje/waterinfo",
+  "pickerin/hass-busybar",
   "Pigotka/ha-cc-jablotron-cloud",
   "piitaya/home-assistant-qubino-wire-pilot",
   "pikipixel/hass-one-pocket",


### PR DESCRIPTION
## Checklist

- [x] I am the owner of the repository
- [x] The repository is public and on GitHub
- [x] HACS Action and Hassfest pass ([latest run](https://github.com/pickerin/hass-busybar/actions))
- [x] The repository has releases (latest: v0.5.2)
- [x] Brand icons included in-repo (`custom_components/busybar/brand/`, HA 2026.3+ mechanism)

## About

Home Assistant integration for the [BUSY Bar](https://busy.app/) productivity device by Flipper Devices, using its local HTTP API and WebSocket state stream (no cloud). Provides busy/custom card switches, screen (theme) selection, timers, a mode selector mirroring the physical 5-way slider, entities and events for all physical controls, display drawing, and audio services. Hardware-tested on firmware 1.0.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)