### PR TITLE
Add amithbalan/lg-ac-ir

### DIFF
--- a/integration
+++ b/integration
@@ -134,6 +134,7 @@
   "amitfin/oref_alert",
   "amitfin/pima_force",
   "amitfin/retry",
+  "amithbalan/lg-ac-ir",
   "amoisis/volkswagen_goconnect",
   "amosyuen/ha-epson-projector-link",
   "amosyuen/ha-tplink-deco",


### PR DESCRIPTION
Adds `amithbalan/lg-ac-ir` to the integration list.

**What it is:** a custom integration that exposes an **LG air conditioner as a native `climate` entity**, transmitting through Home Assistant''s `infrared` platform (e.g. an ESPHome `ir_rf_proxy` emitter). It is the AC counterpart to the built-in `lg_infrared` / `samsung_infrared` consumers, which are TV-only — there is currently no AC consumer for the infrared platform.

**Requirements checklist:**
- Public GitHub repo, addable as a HACS custom repository
- Passes the HACS Action with no ignores and Hassfest (green CI on `main`)
- Release published after a clean action run: `v0.1.2`
- Brand assets present: `custom_components/lg_ac_ir/brand/icon.png` (+ `icon@2x.png`)
- Repo has a description, enabled issues, and topics
- Submitter is the repository owner

Repo: https://github.com/amithbalan/lg-ac-ir