### PR TITLE
Add bangboomben/ha-nasa-firms

### DIFF
--- a/integration
+++ b/integration
@@ -249,6 +249,7 @@
   "bacco007/sensor.waternsw",
   "bairnhard/fishing_assistant",
   "bairnhard/home-assistant-google-aqi",
+  "bangboomben/ha-nasa-firms",
   "banter240/hdg_bavaria_homeassistant",
   "banter240/tado_hijack",
   "baracudaz/fenix_tft",


### PR DESCRIPTION
Adds [bangboomben/ha-nasa-firms](https://github.com/bangboomben/ha-nasa-firms) — **NASA FIRMS Wildfire Monitor**.

Near-real-time satellite wildfire detections (VIIRS NOAA-20 / NOAA-21 / Suomi NPP, MODIS) as native Home Assistant entities: fires on the map card, aggregate sensors (hotspot count, nearest distance, max fire radiative power), and per-fire attributes for proximity alerting.

Distinguishing features over consuming the FIRMS feed with the core `geo_json_events` integration:

- Cross-satellite deduplication (~1 km clustering) — the same fire seen by three satellites becomes one entity instead of three markers
- Confidence and fire-radiative-power filters in the config and options flow
- Location + radius picked on a map instead of a hand-computed bounding box
- FIRMS attributes (FRP, confidence, satellites, acquisition time) preserved per fire

Checklist:

- [x] Public GitHub repository, addable as a custom HACS repository
- [x] HACS Action and hassfest both pass
- [x] Published release (v0.1.1)
- [x] Repository description, topics and issues enabled
- [x] Brand icon shipped in `custom_components/nasa_firms/brand/` (HA 2026.3+ mechanism)
- [x] Submitted by the repository owner from a personal account