### PR TITLE
Add clayton-devplus/portaris-home-assistant

### DIFF
--- a/integration
+++ b/integration
@@ -453,6 +453,7 @@
   "claudegel/sinope-1",
   "claudegel/sinope-130",
   "claudegel/sinope-gt125",
+  "clayton-devplus/portaris-home-assistant",
   "claytonjn/hass-circadian_lighting",
   "cleveroom-code/ha-cleveroom-home",
   "clintongormley/everything-presence-pro-grid",


### PR DESCRIPTION
clayton-devplus/portaris-home-assistant

Integration for **Portaris**, a multi-tenant access-control platform (DevPlus). Exposes doors,
readers, access events and remote door unlock to Home Assistant via a token-authenticated API.

- Repository: https://github.com/clayton-devplus/portaris-home-assistant
- Category: integration
- Passes the HACS action (hassfest + HACS validation).
- Brand images submitted: home-assistant/brands#10859 (this PR's `brands` check will go green once that is merged).
