### PR TITLE
Add lucasgiovanny/pool-maintenance-tracker

### DIFF
--- a/integration
+++ b/integration
@@ -1507,6 +1507,7 @@
   "louispires/Oura-Home-Assistant-Integration",
   "lovelylain/hass_ingress",
   "lsellens/thesimple-thermostat",
+  "lucasgiovanny/pool-maintenance-tracker",
   "ludodefgh/montreal-snow-removal",
   "ludvikroed/homely-integration",
   "Ludy87/ecotrend-ista",


### PR DESCRIPTION
https://github.com/lucasgiovanny/pool-maintenance-tracker

Tracks swimming pool maintenance through a public, self-contained web page opened from a QR code or NFC tag in the machine room — no Home Assistant login needed, so an external technician can log what they did from their own phone. Submissions become native HA entities (manual readings, equipment state, last-done timestamps, overdue binary sensors, an event for automations), with reminders, a wall-dashboard view and a Lovelace card.

- Owner of the repository, submitting it myself.
- HACS action and hassfest both pass with no ignores; the integration ships its own `brand/icon.png`.
- Full release created after those actions passed: v0.20.1.