### PR TITLE
Adds new integration [pickerin/maytag_laundry_homeassistant]

### DIFF
--- a/integration
+++ b/integration
@@ -1948,6 +1948,7 @@
   "Pho3niX90/solis_modbus",
   "phoinixgrr/sigma_connect_ha",
   "physje/waterinfo",
+  "pickerin/maytag_laundry_homeassistant",
   "Pigotka/ha-cc-jablotron-cloud",
   "piitaya/home-assistant-qubino-wire-pilot",
   "pikipixel/hass-one-pocket",


### PR DESCRIPTION
Home Assistant integration for Maytag, Whirlpool, and KitchenAid laundry appliances (washers and dryers) via the Whirlpool cloud API over AWS IoT MQTT. Real-time push updates with polling fallback, capability-driven per-model sensor discovery, comprehensive washer and dryer sensors, config flow with reauth.

- [x] I am the owner of the repository
- [x] HACS action and hassfest pass
- [x] Latest release: v1.1.7
- [x] Brand icons in-repo (custom_components/maytag_laundry/brand/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)