### PR TITLE
Adds new integration [pickerin/hass-busybar]

### DIFF
--- a/integration
+++ b/integration
@@ -1948,6 +1948,7 @@
   "Pho3niX90/solis_modbus",
   "phoinixgrr/sigma_connect_ha",
   "physje/waterinfo",
+  "pickerin/hass-busybar",
   "Pigotka/ha-cc-jablotron-cloud",
   "piitaya/home-assistant-qubino-wire-pilot",
   "pikipixel/hass-one-pocket",


### PR DESCRIPTION
Home Assistant integration for the BUSY Bar productivity device by Flipper Devices, using its local HTTP API and WebSocket state stream (no cloud). Busy/custom card switches, screen selection, timers, mode control mirroring the physical slider, entities and events for all physical controls, display drawing and audio services, plus a bundled Lovelace card with a live display mirror. Hardware-tested on firmware 1.0.2.

- [x] I am the owner of the repository
- [x] HACS action and hassfest pass
- [x] Latest release: v0.6.7
- [x] Brand icons in-repo (custom_components/busybar/brand/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)