### PR TITLE
Adds new integration [pickerin/hass-busybar]

### DIFF
--- a/integration
+++ b/integration
@@ -2235,6 +2235,7 @@
   "phoinixgrr/sigma_connect_ha",
   "physje/waterinfo",
   "pickeld/nuki_integration",
+  "pickerin/hass-busybar",
   "Pigotka/ha-cc-jablotron-cloud",
   "piitaya/home-assistant-qubino-wire-pilot",
   "pikipixel/hass-one-pocket",

--- a/integration
+++ b/integration
@@ -2352,6 +2352,7 @@
   "phoinixgrr/sigma_connect_ha",
   "physje/waterinfo",
   "pickeld/nuki_integration",
+  "pickerin/hass-busybar",
   "Pigotka/ha-cc-jablotron-cloud",
   "piitaya/home-assistant-qubino-wire-pilot",
   "pikipixel/hass-one-pocket",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Repository: <https://github.com/pickerin/hass-busybar>
Link to current release: <https://github.com/pickerin/hass-busybar/releases/tag/v0.6.8>
Link to successful HACS action (without the `ignore` key): <https://github.com/pickerin/hass-busybar/actions/runs/30351538482/job/90249927006>
Link to successful hassfest action (if integration): <https://github.com/pickerin/hass-busybar/actions/runs/30351538482/job/90249931241>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->

Home Assistant integration for the BUSY Bar productivity device by Flipper Devices, using its local HTTP API and WebSocket state stream (no cloud). Provides busy/custom card switches, screen (theme) selection, timers, a mode selector mirroring the physical 5-way slider, entities and events for all physical controls, display drawing and audio services, and a bundled Lovelace card with a live mirror of the device's LED display. Hardware-tested against firmware 1.0.2.

I am the owner of the repository and submitting it myself.
