### PR TITLE
Removes pjordanandrsn/ha-generac (reconverged with upstream)

### DIFF
--- a/blacklist
+++ b/blacklist
@@ -350,6 +350,7 @@
   "PiotrMachowski/Home-Assistant-custom-components-Google-Keep",
   "pippyn/Home-Assistant-Sensor-Groningen-Afvalwijzer",
   "pippyn/Home-Assistant-Sensor-Ophaalkalender",
+  "pjordanandrsn/ha-generac",
   "ppanagiotis/pymusiccast",
   "PTST/O365-HomeAssistant",
   "PTST/O365Calendar-HomeAssistant",

--- a/integration
+++ b/integration
@@ -1974,7 +1974,6 @@
   "pippyn/Home-Assistant-Sensor-Afvalbeheer",
   "Pirate-Weather/pirate-weather-ha",
   "Pjarbit/home-assistant-combined-notification-integration",
-  "pjordanandrsn/ha-generac",
   "pkarimov/jukeaudio_ha",
   "plamish/xcomfort",
   "PlanetCitizen1829381/ha-nsw-beachwatch",

--- a/removed
+++ b/removed
@@ -2559,5 +2559,10 @@
     "reason": "Repository is archived",
     "removal_type": "remove",
     "link": "https://github.com/hacs/default/pull/7183"
+  },
+  {
+    "repository": "pjordanandrsn/ha-generac",
+    "reason": "Reconverged with upstream binarydev/ha-generac, which is in the default store",
+    "removal_type": "remove"
   }
 ]


### PR DESCRIPTION
Owner-requested removal of `pjordanandrsn/ha-generac` (I'm the owner).

The fork existed to ship the Auth0/DPoP auth rework + MFA while `binarydev/ha-generac` was dormant; upstream absorbed all of it in v0.5.2 (2026-07-26) and is already in the default store, so the duplicate entry is no longer needed. The fork's README now points users upstream with migration steps; the repo will be archived once its last open PR resolves.

Added to `removed` with a reason so existing installs get the notice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
