### PR TITLE
Add eeve mower willow map card to plugin

### DIFF
--- a/plugin
+++ b/plugin
@@ -182,6 +182,7 @@
   "finity69x2/light-brightness-preset-row",
   "finity69x2/toggle-control-button-row",
   "fixtse/o365-card",
+  "flame4ever/eeve_mower_willow_map_card",
   "flect41/lovelace-blind-card-enhanced",
   "flixlix/energy-flow-card-plus",
   "flixlix/energy-gauge-bundle-card",


### PR DESCRIPTION
## Checklist

[x] I've read the publishing documentation (hacs.xyz/docs/publish/start).

[x] I've added the HACS action (hacs.xyz/docs/publish/action) to my repository.

[x] (For integrations only) Not applicable, this is a Lovelace plugin, not an integration, so the hassfest action does not apply.

[x] The actions are passing without any disabled checks in my repository.

[x] I've added a link to the action run on my repository below in the links section.

[x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: https://github.com/flame4ever/eeve_mower_willow_map_card/releases/tag/v0.1.0

Link to successful HACS action (without the ignore key): https://github.com/flame4ever/eeve_mower_willow_map_card/actions/runs/30473303383

Link to successful hassfest action: not applicable, this repository is a Lovelace plugin (category: plugin), not an integration.