### PR TITLE
Add eeve mower willow map card to plugin

### DIFF
--- a/plugin
+++ b/plugin
@@ -182,6 +182,7 @@
   "finity69x2/light-brightness-preset-row",
   "finity69x2/toggle-control-button-row",
   "fixtse/o365-card",
+  "flame4ever/eeve_mower_willow_map_card",
   "flect41/lovelace-blind-card-enhanced",
   "flixlix/energy-flow-card-plus",
   "flixlix/energy-gauge-bundle-card",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: https://github.com/flame4ever/eeve_mower_willow_map_card/releases/tag/v0.1.0
Link to successful HACS action (without the `ignore` key): https://github.com/flame4ever/eeve_mower_willow_map_card/actions/runs/30473303383
Link to successful hassfest action (if integration): N/A, this repository is a Lovelace plugin (category: plugin), not an integration.

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->