### PR TITLE
Add fschubi/shutter_pilot

### DIFF
--- a/integration
+++ b/integration
@@ -896,6 +896,7 @@
   "FrogStoneMedia/paddle-conditions",
   "fsaris/home-assistant-awox",
   "fsaris/home-assistant-zonneplan-one",
+  "fschubi/shutter_pilot",
   "FScoua/ha-ajax-uart",
   "fuatakgun/eufy_security",
   "FUjr/homeassistant-openwrt-ubus",


### PR DESCRIPTION
Adds **Shutter Pilot** as a default integration repository.

- Repository: https://github.com/fschubi/shutter_pilot
- Category: integration
- Domain: `shutter_pilot`
- Latest release: [v2.1.0](https://github.com/fschubi/shutter_pilot/releases/tag/v2.1.0)

## What it does

Automates roller shutters and blinds based on time schedules, a brightness sensor or sun position. Handles window and door contacts (ventilation position, lock protection, catching up missed movements), sun shading by elevation and compass direction, and slat control for venetian blinds. Everything is configured from a dedicated sidebar panel — no YAML.

## Checklist

- [x] The repository passes the HACS Action (9/9 checks on `master`)
- [x] hassfest passes
- [x] The repository has a description and topics
- [x] The repository has a license (MIT)
- [x] The repository has releases
- [x] `hacs.json` is present
- [x] The integration lives in `custom_components/shutter_pilot/` with a valid `manifest.json`
- [x] Brands PR submitted: home-assistant/brands#10878

Validation run: https://github.com/fschubi/shutter_pilot/actions/runs/30543719453