### PR TITLE
Add olzeug/ha-vacation-mode

### DIFF
--- a/integration
+++ b/integration
@@ -1949,6 +1949,7 @@
   "olivierplante/thermostat-slider-card",
   "ollo69/ha-samsungtv-smart",
   "ollo69/ha-smartthinq-sensors",
+  "olzeug/ha-vacation-mode",
   "oMtQB4/HomeAssistant-Pracht-Alpha-Wallbox-Custom-Component",
   "onpremcloudguy/HelloSmart_HomeAssistant",
   "oooohhoo/tokit_cooker",


### PR DESCRIPTION
## Repository

https://github.com/olzeug/ha-vacation-mode

## Description

Home Assistant integration that turns a person's current location into travel context: weather, air quality, sea conditions, public holidays, exchange rate, travel advisory, earthquakes and country facts. All data sources are free and need no API key.

## Checklist

- [x] I am the owner of this repository.
- [x] The repository is public and active.
- [x] The repository has releases.
- [x] The repository has a description and topics set.
- [x] Issues are enabled.
- [x] `hacs.json` and `manifest.json` are present and valid.
- [x] The integration ships its own brand assets (`brand/icon.png`, `brand/icon@2x.png`).
- [x] The HACS action and hassfest pass without errors or ignores.