### PR TITLE
Fix sort order of culiplan/home-assistant-culiplan in integration catalog

### DIFF
--- a/integration
+++ b/integration
@@ -2819,3 +2819,4 @@
   "zupancicmarko/JellyHA",
   "Zwer2k/ha-pca301"
 ]
+

--- a/integration
+++ b/integration
@@ -526,9 +526,9 @@
   "CtznSniiips/virtual_lymow",
   "CubicPill/china_southern_power_grid_stat",
   "cubinet-code/ha-parqet-companion",
+  "culiplan/home-assistant-culiplan",
   "CumpsD/home-assistant-leo-ntp",
   "Currency-One/walutomat-ha",
-  "culiplan/home-assistant-culiplan",
   "custom-components/ble_monitor",
   "custom-components/brewdog",
   "custom-components/climate.e_thermostaat",
@@ -2819,4 +2819,3 @@
   "zupancicmarko/JellyHA",
   "Zwer2k/ha-pca301"
 ]
-


### PR DESCRIPTION
The `culiplan/home-assistant-culiplan` entry in the `integration` catalog is one step out of case-folded sort order: it currently sits after `Currency-One/walutomat-ha`, but `culiplan` sorts before both `CumpsD/home-assistant-leo-ntp` and `Currency-One/walutomat-ha`, so it belongs just above `CumpsD/home-assistant-leo-ntp`. This trips the `is_sorted` lint on master.

This moves that single line to its correct sorted position. No entries are added or removed.

../Frenck  
<p>
  <a href="https://www.linkedin.com/in/frenck/"><img src="https://github.com/frenck/frenck/raw/main/images/linkedin.svg" width="18" height="18"></a>
  &nbsp;&nbsp;
  <a href="https://youtube.com/@frenck"><img src="https://github.com/frenck/frenck/raw/main/images/youtube.svg" width="18" height="18"></a>
  &nbsp;&nbsp;
  <a href="https://bsky.app/profile/frenck.social"><img src="https://github.com/frenck/frenck/raw/main/images/bluesky.svg" width="18" height="18"></a>
  &nbsp;&nbsp;
  <a href="https://fosstodon.org/@frenck"><img src="https://github.com/frenck/frenck/raw/main/images/mastodon.svg" width="18" height="18"></a>
  &nbsp;&nbsp;
  <a href="https://www.instagram.com/frenck/"><img src="https://github.com/frenck/frenck/raw/main/images/instagram.svg" width="18" height="18"></a>
  &nbsp;&nbsp;
  <a href="https://www.threads.net/@frenck"><img src="https://github.com/frenck/frenck/raw/main/images/threads.svg" width="18" height="18"></a>
  &nbsp;&nbsp;
  <a href="https://www.facebook.com/frenck.dev/"><img src="https://github.com/frenck/frenck/raw/main/images/facebook.svg" width="18" height="18"></a>
  &nbsp;&nbsp;
  <a href="https://x.com/frenck"><img src="https://github.com/frenck/frenck/raw/main/images/x.svg" width="18" height="18"></a>
  &nbsp;&nbsp;
  <a href="https://www.tiktok.com/@frenck.nl"><img src="https://github.com/frenck/frenck/raw/main/images/tiktok.svg" width="18" height="18"></a>
</p>
Blogging my personal ramblings at <a href="https://frenck.dev">frenck.dev</a>
