### PR TITLE
Add PrayerZone Home Assistant integration

### DIFF
--- a/integration
+++ b/integration
@@ -2116,6 +2116,7 @@
   "ppaglier/voltalis-homeassistant",
   "prairiesnpr/hass-tdameritrade",
   "pranjal-joshi/moodlights",
+  "PrayerZone/prayer-times-home-assistant",
   "prestomation/resmed_myair_sensors",
   "PrimeAutomation/petnovations",
   "princekama/home-assistant-rako",


### PR DESCRIPTION
Adds PrayerZone/prayer-times-home-assistant, a public HACS integration for pray.zone prayer sensors, next prayer, and Qibla bearing. The repository includes HACS metadata, config flow, release v0.1.0, documentation, attribution, and passing CI. The entry is alphabetically sorted.