### PR TITLE
Adds new integration [jerzik/robzone_xclean]

### DIFF
--- a/integration
+++ b/integration
@@ -1294,6 +1294,7 @@
   "jeroenterheerdt/HADailySensor",
   "jeroenterheerdt/HAsmartirrigation",
   "jerrit/ha-base-power",
+  "jerzik/robzone_xclean",
   "jesserockz/ha-leafspy",
   "jestempablo/home-assistant-tcl-intelligent-ac",
   "Jezza34000/homeassistant_petkit",


### PR DESCRIPTION
Adding new integration **Robzone Xclean** by @jerzik

- Repository: https://github.com/jerzik/robzone_xclean
- HACS + Hassfest validation: green
- Version: 2.0.2

**Checklist:**
- [x] The code is original and authored by the repository owner (not forked)
- [x] Has a README and LICENSE
- [x] Has brand assets (brand/icon.png)
- [x] Manifest is sorted and valid

> I understand that this PR does not automatically grant the right to be part of the HACS default repository, and the HACS team can remove my repository at any time.