### PR TITLE
Add BrainDeLook/ha-fatsecret-dashboard

### DIFF
--- a/plugin
+++ b/plugin
@@ -59,6 +59,7 @@
   "Bobsilvio/calcio-live-card",
   "bokub/rgb-light-card",
   "bolkedebruin/erhv-lovelace",
+  "BrainDeLook/ha-fatsecret-dashboard",
   "bramkragten/swipe-card",
   "bramkragten/weather-card",
   "Brianfit/calvin-card-ha",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the hassfest action. Not applicable: this repository is a plugin/dashboard card.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/BrainDeLook/ha-fatsecret-dashboard/releases/tag/v1.0.0>
Link to successful HACS action (without the `ignore` key): <https://github.com/BrainDeLook/ha-fatsecret-dashboard/actions/runs/30698300503>
Link to successful hassfest action (if integration): Not applicable — plugin/dashboard card.

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->
