### PR TITLE
Add Spire Energy integration

### DIFF
--- a/repositories/integrations/spire-gas-ha.json
+++ b/repositories/integrations/spire-gas-ha.json
@@ -1,0 +1,4 @@
+{
+  "repository": "phtaf/spire-gas-ha",
+  "category": "integration"
+}


### PR DESCRIPTION
## Integration Details

**Repository:** https://github.com/phtaf/spire-gas-ha

**Category:** Integration

**Description:** Home Assistant integration for Spire Gas Usage. Fetches daily gas usage from Spire Energy and displays it in the Home Assistant Energy dashboard.

## Checklist

- [x] I am the owner of the repository
- [x] The repository is public
- [x] The repository contains a valid hacs.json file
- [x] The repository contains a valid manifest.json file
- [x] Brand assets are present
- [x] The repository has at least one release
- [x] Documentation is available