### PR TITLE
Add florianbaethge/bedtime_stories

### DIFF
--- a/integration
+++ b/integration
@@ -997,6 +997,7 @@
   "flcdrg/flipped_energy_ha",
   "flexopus/flexopus-hass-sensor",
   "Flo-Schilli/ha-grohe_smarthome",
+  "florianbaethge/bedtime_stories",
   "florianbaethge/simple_irrigation",
   "Folkman/ha-fcast",
   "fondberg/spotcast",


### PR DESCRIPTION
Adds the **Bedtime Stories** integration to the HACS default store.

Repository: https://github.com/florianbaethge/bedtime_stories

A kid-friendly bedtime-story library for Home Assistant: a custom integration plus a Lovelace card (`bedtime-stories-card`) with big tappable cover tiles grouped by category, one-tap casting to a speaker, play statistics and a switchable playback target.

Checklist:
- Public repository, usable as a custom repo; description, issues and topics set.
- `manifest.json` valid (hassfest passes); `hacs.json` with a `name`.
- HACS Action passes with **no ignores** (brand icons ship in-repo under `custom_components/bedtime_stories/brand/`, HA 2026.3+).
- Full GitHub release published (latest: `v0.3.1`).
- I am the owner of the repository.