### PR TITLE
Adds new integration [florianbaethge/bedtime_stories]

### DIFF
--- a/integration
+++ b/integration
@@ -997,6 +997,7 @@
   "flcdrg/flipped_energy_ha",
   "flexopus/flexopus-hass-sensor",
   "Flo-Schilli/ha-grohe_smarthome",
+  "florianbaethge/bedtime_stories",
   "florianbaethge/simple_irrigation",
   "Folkman/ha-fcast",
   "fondberg/spotcast",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/florianbaethge/bedtime_stories/releases/tag/v0.3.1>
Link to successful HACS action (without the `ignore` key): <https://github.com/florianbaethge/bedtime_stories/actions/runs/30717953916/job/91416730514>
Link to successful hassfest action (if integration): <https://github.com/florianbaethge/bedtime_stories/actions/runs/30717953916/job/91416730461>

---

Adds `florianbaethge/bedtime_stories`, a kid-friendly bedtime-story library: a custom integration plus a Lovelace card (`bedtime-stories-card`) with big, tappable cover tiles grouped by category, one-tap casting to a speaker, play statistics and a switchable playback target.

Brand images are bundled in `custom_components/bedtime_stories/brand/`, per the [brands proxy API](https://developers.home-assistant.io/blog/2026/02/24/brands-proxy-api).

The entry is inserted case-insensitively, matching the existing ordering of the file.
