### PR TITLE
Adds new integration [florianbaethge/advanced_cover]

### DIFF
--- a/integration
+++ b/integration
@@ -997,6 +997,7 @@
   "flcdrg/flipped_energy_ha",
   "flexopus/flexopus-hass-sensor",
   "Flo-Schilli/ha-grohe_smarthome",
+  "florianbaethge/advanced_cover",
   "florianbaethge/simple_irrigation",
   "Folkman/ha-fcast",
   "fondberg/spotcast",

--- a/integration
+++ b/integration
@@ -1019,6 +1019,7 @@
   "flcdrg/flipped_energy_ha",
   "flexopus/flexopus-hass-sensor",
   "Flo-Schilli/ha-grohe_smarthome",
+  "florianbaethge/advanced_cover",
   "florianbaethge/simple_irrigation",
   "Folkman/ha-fcast",
   "fondberg/spotcast",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/florianbaethge/advanced_cover/releases/tag/v0.7.1>
Link to successful HACS action (without the `ignore` key): <https://github.com/florianbaethge/advanced_cover/actions/runs/31694650251/job/94429540614>
Link to successful hassfest action (if integration): <https://github.com/florianbaethge/advanced_cover/actions/runs/31694650251/job/94429541411>

---

Adds `florianbaethge/advanced_cover`, a rule-based, scenario-driven cover/blind automation for Home Assistant with a sidebar panel: sun-position and window-contact aware, per-cover capabilities and a graphical scenario editor (no YAML).

Brand images are bundled in `custom_components/advanced_cover/brand/`, per the [brands proxy API](https://developers.home-assistant.io/blog/2026/02/24/brands-proxy-api).

The entry is inserted case-insensitively, matching the existing ordering of the file.
