### PR TITLE
Adds new integration [igraph100/ha-restart-guard]

### DIFF
--- a/integration
+++ b/integration
@@ -1261,6 +1261,7 @@
   "Identity-labs/ha-maison-protegee2",
   "ifMike/homeyHASS",
   "IgnacioHR/de-dietrich-c230-ha",
+  "igraph100/ha-restart-guard",
   "iioel/magiline-imagix-homeassistant",
   "iKaew/hass-lifesmart-addon",
   "ikb42/homeassistant-lightwave2",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/igraph100/ha-restart-guard/releases/tag/v0.0.3>
Link to successful HACS action (without the `ignore` key): <https://github.com/igraph100/ha-restart-guard/actions/runs/30733894482/job/91458915635>
Link to successful hassfest action (if integration): <https://github.com/igraph100/ha-restart-guard/actions/runs/30733894482/job/91458915611>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->
