### PR TITLE
Adds new integration [Ilumen-MAdomotique/ha-newtron]

### DIFF
--- a/integration
+++ b/integration
@@ -1268,6 +1268,7 @@
   "ILoveMyProjects/StarlingBankEnhanced",
   "ilpianista/meteoeuregio",
   "iluebbe/maintenance_supporter",
+  "Ilumen-MAdomotique/ha-newtron",
   "iluvdata/august_access_codes",
   "iluvdata/liebherr",
   "iluvdata/pdf_scrape",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/Ilumen-MAdomotique/ha-newtron/releases/tag/v1.0.1>
Link to successful HACS action (without the `ignore` key): <https://github.com/Ilumen-MAdomotique/ha-newtron/actions/runs/30736147101>
Link to successful hassfest action (if integration): <https://github.com/Ilumen-MAdomotique/ha-newtron/actions/runs/30736147118>

---

Resubmission of #9648, with both blockers from the previous review resolved:

1. **Owner check** — the initial commits carried an incorrect author identity, so my account did not appear in the repository's contributor list. Authorship has been corrected; `younes-212` is now the sole contributor.
2. **Brands check** — the brand assets were present on `master` but the `v1.0.0` tag predated the commit that added them, so the release being validated did not contain them. Release `v1.0.1` includes `custom_components/newtron/brand/` (`icon.png`, `icon@2x.png`, `logo.png`, `logo@2x.png`). The stray `brands_submission/` folder has also been removed.

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->
