### PR TITLE
Add remmob/magna3

### DIFF
--- a/integration
+++ b/integration
@@ -2360,6 +2360,7 @@
   "remimikalsen/sparebank1_pengerobot",
   "remmob/comfoair",
   "remmob/itho_amber",
+  "remmob/magna3",
   "remmob/sht20",
   "remuslazar/homeassistant-carwings",
   "renaudallard/homeassistant_be_electricity_prices",


### PR DESCRIPTION
Adds the **Grundfos MAGNA3** Modbus integration for Home Assistant.

- Repository: https://github.com/remmob/magna3
- Category: integration
- Domain: `magna3`
- Local polling Modbus integration (CIM 200 RTU / CIM 500 TCP), config flow, bilingual README (EN + NL), `hacs.json`, release `v1.0.0`.

The repository has a description, topics, a README, a valid `manifest.json` and `hacs.json`, and a tagged release.
