### PR TITLE
Update Nino6689/hass-anycubic_cloud to Nino6689/hass-anycubic

### DIFF
--- a/integration
+++ b/integration
@@ -2091,7 +2091,7 @@
   "nimroddolev/chime_tts",
   "NinDTendo/homeassistant_gradual_volume_control",
   "NinDTendo/tobi",
-  "Nino6689/hass-anycubic_cloud",
+  "Nino6689/hass-anycubic",
   "NirBY/ha-mashov",
   "nitaybz/ha-pima",
   "nitaybz/optimistic_feedback",


### PR DESCRIPTION
The repository has been renamed from `hass-anycubic_cloud` to `hass-anycubic`.

The integration now talks to the printer either through Anycubic's cloud or directly over its LAN Mode broker, so "cloud" in the name had stopped being accurate. The integration's `domain` is unchanged (`anycubic_cloud`) — only the repository path and the display name have moved, so no existing installation is affected.

GitHub redirects the old path, and the numeric repository id is unchanged, so this is housekeeping to keep the stored path accurate rather than a fix for anything broken.