### PR TITLE
Adds new integration [thlucas1/homeassistantcomponent_spotifyplus]

### DIFF
--- a/integration
+++ b/integration
@@ -2806,6 +2806,7 @@
   "thevoltagesource/LennoxiComfort",
   "thisisthetechie/home-assistant-sickgear",
   "thizanchettin/home-assistant-epson-snmp",
+  "thlucas1/homeassistantcomponent_spotifyplus",
   "thokaro/solarwatt-manager-homeassistant",
   "thomas-svrts/blossom_be",
   "thomasgregg/oralb-ha",


### PR DESCRIPTION
## Checklist

- [X] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [X] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [X] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [X] The actions are passing without any disabled checks in my repository.
- [X] I've added a link to the action run on my repository below in the links section.
- [X] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/thlucas1/homeassistantcomponent_spotifyplus/releases/tag/v1.0.212>
Link to successful HACS action (without the `ignore` key): <https://github.com/thlucas1/homeassistantcomponent_spotifyplus/actions/runs/30677908340/job/91308799661>
Link to successful hassfest action (if integration): <https://github.com/thlucas1/homeassistantcomponent_spotifyplus/actions/runs/30677908340/job/91308799636>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->