### PR TITLE
Adds new custom card [thlucas1/homeassistantcomponent_soundtouchplus_card]

### DIFF
--- a/plugin
+++ b/plugin
@@ -643,6 +643,7 @@
   "TheRealEiskaffee/brightness-overlay",
   "TheScubadiver/camera-gallery-card",
   "TheWillMiller/radar-wise",
+  "thlucas1/homeassistantcomponent_soundtouchplus_card",
   "tholgir/TodoIst-Task-List",
   "thomasloven/lovelace-auto-entities",
   "thomasloven/lovelace-badge-card",


### PR DESCRIPTION
## Checklist

- [X] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [X] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [X] The actions are passing without any disabled checks in my repository.
- [X] I've added a link to the action run on my repository below in the links section.
- [X] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/thlucas1/homeassistantcomponent_soundtouchplus_card/releases/tag/v1.0.36>
Link to successful HACS action (without the `ignore` key): <https://github.com/thlucas1/homeassistantcomponent_soundtouchplus_card/actions/runs/30834197862/job/91755263201>
Link to successful hassfest action (if integration): <n/a>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->