### PR TITLE
Adds new plugin [ADNPolymerase/ha-ecoflow-powerstream-flow-card]

### DIFF
--- a/plugin
+++ b/plugin
@@ -14,6 +14,7 @@
   "adamjthompson/Gaming-Status-Cards",
   "adaxi/ha-teamtracker-badge",
   "adizanni/floor3d-card",
+  "ADNPolymerase/ha-ecoflow-powerstream-flow-card",
   "ADNPolymerase/ha-pluviometer-card",
   "ADNPolymerase/oklyn-card",
   "aex351/home-assistant-neerslag-card",


### PR DESCRIPTION
https://github.com/ADNPolymerase/ha-ecoflow-powerstream-flow-card

An animated power-flow card for an EcoFlow PowerStream + battery chain, drawn the way that chain is actually wired: PV strings into the inverter's MPPT, then out to both the battery and the house. It needs neither a house-consumption sensor nor a bidirectional grid meter, which a behind-the-meter plug-in setup does not have.

Multilingual (EN, FR, DE, ES, IT, NL), visual editor with sensor auto-detection, and an icon-only mode for people who would rather not have the devices drawn.