### PR TITLE
Adds new integration [berkansezer77/lumen-ha]

### DIFF
--- a/integration
+++ b/integration
@@ -336,6 +336,7 @@
   "benvanmierloo/ha-vitotrol",
   "benwittbrodt/Metra-Tracker",
   "Beormund/tascam-bdmp4k",
+  "berkansezer77/lumen-ha",
   "berkansezer77/presto",
   "berra200/home-assistant-rapt-cloud-link",
   "bertbert72/HomeAssistant_VirginTivo",


### PR DESCRIPTION
Adds [Lumen HA](https://github.com/berkansezer77/lumen-ha) — room lighting that
decides for itself and writes down why: one panel, one engine, no generated
automations and no helpers.

## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/berkansezer77/lumen-ha/releases/tag/v1.0.0>
Link to successful HACS action (without the `ignore` key): <https://github.com/berkansezer77/lumen-ha/actions/runs/30868158085/job/91864361162>
Link to successful hassfest action (if integration): <https://github.com/berkansezer77/lumen-ha/actions/runs/30868158085/job/91864361132>
