### PR TITLE
Adds new integration [derekclapham/ha-mempool]

### DIFF
--- a/integration
+++ b/integration
@@ -740,6 +740,7 @@
   "denysdovhan/ha-check-weather",
   "denysdovhan/ha-lun-misto-air",
   "denysdovhan/ha-yasno-outages",
+  "derekclapham/ha-mempool",
   "derliebemarcus/homeassistant_teltonika_rms",
   "dermotduffy/hass-web-proxy-integration",
   "derolli1976/enpal",


### PR DESCRIPTION
Adds **Bitcoin Mempool** (`derekclapham/ha-mempool`) — a Home Assistant integration for the [mempool](https://github.com/mempool/mempool) Bitcoin blockchain/mempool explorer. Works with the public mempool.space or a self-hosted instance; provides native Bitcoin sensors (price, blocks, fees, mempool, mining, difficulty, halving countdown) and can backfill long-term price statistics.

## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/derekclapham/ha-mempool/releases/tag/v0.3.0>
Link to successful HACS action (without the `ignore` key): <https://github.com/derekclapham/ha-mempool/actions/runs/30889632170/job/91928452095>
Link to successful hassfest action (if integration): <https://github.com/derekclapham/ha-mempool/actions/runs/30889632170/job/91928452186>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->
