### PR TITLE
Add Nino6689/VisonicAlarm-for-Hassio

### DIFF
--- a/integration
+++ b/integration
@@ -2092,6 +2092,7 @@
   "NinDTendo/homeassistant_gradual_volume_control",
   "NinDTendo/tobi",
   "Nino6689/hass-anycubic_cloud",
+  "Nino6689/VisonicAlarm-for-Hassio",
   "NirBY/ha-mashov",
   "nitaybz/ha-pima",
   "nitaybz/optimistic_feedback",


### PR DESCRIPTION
https://github.com/Nino6689/VisonicAlarm-for-Hassio

Visonic / Bentel / Tyco alarm integration, talking to the PowerManage cloud.

The maintained continuation of `And3rsL/VisonicAlarm-for-Hassio` (already in this list), which was **archived in December 2025** — along with the library it depended on, `And3rsL/VisonicAlarm2`. That client is vendored here so it could be fixed.

**What this adds over the archived original**

- UI config flow, with reauth, reconfigure and an options flow — the original was YAML-only. Existing YAML configuration is imported automatically and entity IDs are preserved.
- Stale cloud sessions now self-heal. Upstream's `is_token_valid` was a property returning the *bound method* `is_logged_in` without calling it, so the reconnect branch was dead code and recovery needed a full Home Assistant restart.
- Dropped a hard `python-dateutil==2.7.3` pin that was downgrading dateutil for every other integration in the container. There are now **no external requirements at all**.
- Stopped publishing the live session token as an entity attribute.
- Zone bypass switches, siren actions, and panel-health entities including cloud connectivity.

**Checks**

- HACS Action and hassfest both green on `master`
- Releases published (currently `v4.0.3`)
- Brand icons ship in `custom_components/visonicalarm/brand/` per the [2026.3 brands proxy API](https://developers.home-assistant.io/blog/2026/02/24/brands-proxy-api)
- 60 tests, 97.6% coverage, `mypy --strict` clean, all gated in CI
- Quality scale self-assessed to platinum

Submitted by the repository owner.