### PR TITLE
Adds new integration [Nino6689/VisonicAlarm-for-Hassio]

### DIFF
--- a/integration
+++ b/integration
@@ -2092,6 +2092,7 @@
   "NinDTendo/homeassistant_gradual_volume_control",
   "NinDTendo/tobi",
   "Nino6689/hass-anycubic_cloud",
+  "Nino6689/VisonicAlarm-for-Hassio",
   "NirBY/ha-mashov",
   "nitaybz/ha-pima",
   "nitaybz/optimistic_feedback",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/Nino6689/VisonicAlarm-for-Hassio/releases/tag/v4.0.3>
Link to successful HACS action (without the `ignore` key): <https://github.com/Nino6689/VisonicAlarm-for-Hassio/actions/runs/30884614434/job/91912976655>
Link to successful hassfest action (if integration): <https://github.com/Nino6689/VisonicAlarm-for-Hassio/actions/runs/30884614434/job/91912976752>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->

---

Repository: <https://github.com/Nino6689/VisonicAlarm-for-Hassio>

Visonic / Bentel / Tyco alarm integration, talking to the PowerManage cloud.

This is the maintained continuation of `And3rsL/VisonicAlarm-for-Hassio`, already in this list, which was **archived in December 2025** — as was the library it depended on, `And3rsL/VisonicAlarm2`. That client is vendored here so it could be fixed.

Notable changes over the archived original:

- UI config flow with reauth, reconfigure and options. The original was YAML-only; existing YAML is imported automatically and entity IDs are preserved.
- Stale cloud sessions self-heal. Upstream's `is_token_valid` was a property returning the *bound method* `is_logged_in` without calling it, so the reconnect branch was dead code and recovery needed a full Home Assistant restart.
- Dropped a hard `python-dateutil==2.7.3` pin that downgraded dateutil for every other integration in the container. There are now no external requirements at all.
- Stopped publishing the live session token as an entity attribute.
- Adds zone bypass switches, siren actions and panel-health entities including cloud connectivity.

Brand icons ship in `custom_components/visonicalarm/brand/` per the [2026.3 brands proxy API](https://developers.home-assistant.io/blog/2026/02/24/brands-proxy-api).

60 tests at 97.6% coverage with `mypy --strict`, all gated in CI. Submitted by the repository owner.
