### PR TITLE
Adds new integration [nhazdun/HA-Upright-Go-2-BLE]

### DIFF
--- a/integration
+++ b/integration
@@ -2061,6 +2061,7 @@
   "nfeuerhelm/ha-proj-viewsonic",
   "ngoc-minh-do/ha-nescafe-ble",
   "ngocjohn/lunar-phase",
+  "nhazdun/HA-Upright-Go-2-BLE",
   "NiaoBlush/impc_energy",
   "nick2525/broadlink_s1c_s2c",
   "nickknissen/hass-monta",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/nhazdun/HA-Upright-Go-2-BLE/releases/tag/v2.4.3>
Link to successful HACS action (without the `ignore` key): <https://github.com/nhazdun/HA-Upright-Go-2-BLE/actions/runs/30915623746/job/92012888346>
Link to successful hassfest action (if integration): <https://github.com/nhazdun/HA-Upright-Go-2-BLE/actions/runs/30915623746/job/92012888453>

---

Bluetooth LE integration for the Upright GO 2 posture trainer, working through ESPHome Bluetooth proxies. Local push, config flow, no cloud account involved.

The brand images ship in `custom_components/upright_go2/brand/`.
