### PR TITLE
Adds new integration [fmastrella/ha-dohome-rgb-using-mac-addr]

### DIFF
--- a/integration
+++ b/integration
@@ -998,6 +998,7 @@
   "flexopus/flexopus-hass-sensor",
   "Flo-Schilli/ha-grohe_smarthome",
   "florianbaethge/simple_irrigation",
+  "fmastrella/ha-dohome-rgb-using-mac-addr",
   "Folkman/ha-fcast",
   "fondberg/spotcast",
   "foureight84/CallAttendantNext_Monitor",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/fmastrella/ha-dohome-rgb-using-mac-addr/releases/tag/v0.2.1>

Link to successful HACS action (without the `ignore` key): <https://github.com/fmastrella/ha-dohome-rgb-using-mac-addr/actions/runs/30919277623>

Link to successful hassfest action (if integration): <https://github.com/fmastrella/ha-dohome-rgb-using-mac-addr/actions/runs/30919278488>