### PR TITLE
Adds new integration [xIceTea/HeatNexus]

### DIFF
--- a/integration
+++ b/integration
@@ -3041,6 +3041,7 @@
   "Xerolux/idm-heatpump-hass",
   "xiaodong-lx/tplink-ipc-control",
   "XiaoMi/ha_xiaomi_home",
+  "xIceTea/HeatNexus",
   "xilense/aimp_custom_component",
   "xirixiz/homeassistant-afvalwijzer",
   "xkain/ESPSomfy-RTS-enhanced",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/xIceTea/HeatNexus/releases/tag/v1.4.0>
Link to successful HACS action (without the `ignore` key): <https://github.com/xIceTea/HeatNexus/actions/runs/30944352907/job/92110472825>
Link to successful hassfest action (if integration): <https://github.com/xIceTea/HeatNexus/actions/runs/30944352907/job/92110472622>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->
