### PR TITLE
Adds new integration [jamarju/esp-evse-surplus-manager]

### DIFF
--- a/integration
+++ b/integration
@@ -1325,6 +1325,7 @@
   "JackJPowell/hass-unfoldedcircle",
   "jacobbjerregaard/homeassistant-growatt-modbus",
   "jaidenlabelle/tuya-vacuum-maps",
+  "jamarju/esp-evse-surplus-manager",
   "jamesshannon/thermoworks-ha",
   "jampez77/DVLA-Vehicle-Enquiry-Service",
   "jampez77/Evri",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/jamarju/esp-evse-surplus-manager/releases/tag/v0.2.0>
Link to successful HACS action (without the `ignore` key): <https://github.com/jamarju/esp-evse-surplus-manager/actions/runs/30836767899>
Link to successful hassfest action (if integration): <https://github.com/jamarju/esp-evse-surplus-manager/actions/runs/30836765694>

This replaces the earlier submission in [hacs/default#6866](https://github.com/hacs/default/pull/6866), which was closed as stale after the requested license and release updates were completed.
