### PR TITLE
Adds new integration [outagedeck/home-assistant]

### DIFF
--- a/integration
+++ b/integration
@@ -2156,6 +2156,7 @@
   "OStrama/weishaupt_modbus",
   "OtisPresley/control4-mediaplayer",
   "OtisPresley/snmp-switch-manager",
+  "outagedeck/home-assistant",
   "oven-lab/tuya_cloud_map_extractor",
   "owanvik/ha-nodvarsel",
   "owenashurst/Antminer-HomeAssistant-Integration",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/outagedeck/home-assistant/releases/tag/v0.1.0>
Link to successful HACS action (without the `ignore` key): <https://github.com/outagedeck/home-assistant/actions/runs/30971232117/job/92195780938>
Link to successful hassfest action (if integration): <https://github.com/outagedeck/home-assistant/actions/runs/30971232117/job/92195781026>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->
