### PR TITLE
Adds new integration [karl-petter/protimeter-ble-humidity-sensor-for-ha]

### DIFF
--- a/integration
+++ b/integration
@@ -1519,6 +1519,7 @@
   "Kannix2005/homeassistant-selve",
   "Kaptensanders/skolmat",
   "Kaptensanders/vklass",
+  "karl-petter/protimeter-ble-humidity-sensor-for-ha",
   "Karmaus/myko_plus",
   "Kartax/home-assistant-binance",
   "KartoffelToby/better_thermostat",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
Re-submission of https://github.com/hacs/default/pull/7299 since it was closed due to inactivity. Found time to fix the issue now.

## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: https://github.com/karl-petter/protimeter-ble-humidity-sensor-for-ha/releases/tag/v1.0.2
Link to successful HACS action (without the `ignore` key): https://github.com/karl-petter/protimeter-ble-humidity-sensor-for-ha/actions/runs/30980309489
Link to successful hassfest action (if integration): https://github.com/karl-petter/protimeter-ble-humidity-sensor-for-ha/actions/runs/30980309530

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->