### PR TITLE
Add saihgupr/frigate-events-card

### DIFF
--- a/plugin
+++ b/plugin
@@ -571,6 +571,7 @@
   "rusty4444/recently-added-media-card",
   "ryanbuiltthat/prism",
   "s5zone/weasley-clock-card",
+  "saihgupr/frigate-events-card",
   "SalvatoreITA/domhouse-weather-card",
   "samuelgoodell/clock-weather-card-hui-icons",
   "Savjee/button-text-card",


### PR DESCRIPTION
Adding saihgupr/frigate-events-card custom Lovelace card to HACS default store.