### PR TITLE
Adds new integration [asco88/siterelay]

### DIFF
--- a/integration
+++ b/integration
@@ -241,7 +241,7 @@
   "arypien/ha_thesslagreen_airpack_usb",
   "asantaga/lightwaverf_HA_EnergySensor",
   "asantaga/wiserHomeAssistantPlatform",
-  "asco88/omni-state",
+  "asco88/siterelay",
   "asev/homeassistant-helios",
   "Ashus/hass-openwrt-wakeonlan",
   "aspenrt78/button-builder",

--- a/integration
+++ b/integration
@@ -241,6 +241,7 @@
   "arypien/ha_thesslagreen_airpack_usb",
   "asantaga/lightwaverf_HA_EnergySensor",
   "asantaga/wiserHomeAssistantPlatform",
+  "asco88/omni-state",
   "asev/homeassistant-helios",
   "Ashus/hass-openwrt-wakeonlan",
   "aspenrt78/button-builder",


### PR DESCRIPTION
## Integration information

- GitHub repository: https://github.com/asco88/siterelay
- Category: Integration
- Name: SiteRelay

## Required links

- Repository: https://github.com/asco88/siterelay
- Latest release: https://github.com/asco88/siterelay/releases/tag/v1.0.0
- CI action run: https://github.com/asco88/siterelay/actions/runs/26395969926

## Checklist

- [x] I'm a collaborator of the integration repository
- [x] Integration has a `hacs.json` file
- [x] Integration has a `manifest.json` file with required fields
- [x] Integration has a branded icon at `custom_components/siterelay/brand/icon.png`
- [x] GitHub Actions with `hacs/action` and `home-assistant/actions/hassfest` pass
- [x] Integration has a versioned release (v1.0.0)

---

Replaces #7986, which was closed for staleness. Branch rebased onto current `master` (no conflicts) to pick up schema/list changes since May.