### PR TITLE
Add MakerWorld Stats integration

### DIFF
--- a/integration
+++ b/integration
@@ -2866,6 +2866,7 @@
   "tomaae/homeassistant-truenas",
   "tomasbedrich/home-assistant-hikconnect",
   "tomasbedrich/home-assistant-skydance",
+  "tomaspacner-lgtm/HomeAssistant-MakerWorld-Stats",
   "tomasmcguinness/homeassistant-mixergy",
   "TomBrien/cardiffwaste-ha",
   "tomer-w/ha-nmea2000",


### PR DESCRIPTION
Adds the MakerWorld Stats Home Assistant integration to the default HACS repository list.\n\nRepository: https://github.com/tomaspacner-lgtm/HomeAssistant-MakerWorld-Stats\n\nValidation: HACS action and Hassfest are passing; a GitHub release is published.