### PR TITLE
Adds new integration [Seidel76/noopy-tv-homeassistant]

### DIFF
--- a/integration
+++ b/integration
@@ -2541,6 +2541,7 @@
   "sebr/inception-home-assistant",
   "SecKatie/ha-wyzeapi",
   "sedward5/nws_spc_outlook",
+  "Seidel76/noopy-tv-homeassistant",
   "Selectra-Dev/selectra-ha",
   "senalse/ha-alphaess-modbus",
   "SenMorgan/EX-HABridge",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: https://github.com/Seidel76/noopy-tv-homeassistant/releases/tag/v4.8.1
Link to successful HACS action (without the `ignore` key): https://github.com/Seidel76/noopy-tv-homeassistant/actions/runs/31134736041/job/92731476422
Link to successful hassfest action (if integration): https://github.com/Seidel76/noopy-tv-homeassistant/actions/runs/31134736041/job/92731476383