### PR TITLE
Adds new integration [andrewtryder/ha-ecowater-cloud]

### DIFF
--- a/integration
+++ b/integration
@@ -183,6 +183,7 @@
   "andrew-codechimp/HA-Wasp-In-A-Box",
   "andrew-codechimp/tsmart_ha",
   "andrewjswan/SwatchTime",
+  "andrewtryder/ha-ecowater-cloud",
   "andrewtryder/ha-iguardstove",
   "andrewtryder/ha-smart-oil-gauge",
   "andriensis/ha-1control",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: https://github.com/andrewtryder/ha-ecowater-cloud/releases/tag/v0.6.0
Link to successful HACS action (without the `ignore` key): https://github.com/andrewtryder/ha-ecowater-cloud/actions/runs/31141284512
Link to successful hassfest action (if integration): https://github.com/andrewtryder/ha-ecowater-cloud/actions/runs/31141284512

Note:
A maintained, standalone rewrite for EcoWater Ayla-connected devices. It uses the distinct ecowater_cloud domain and does not replace or override a Home Assistant Core integration. It does not depend on the legacy ecowater-softener Python library. The existing barleybobs/homeassistant-ecowater-softener repository remains a separate legacy integration.
