### PR TITLE
Adds new plugin [iret33/confirm-tap-card]

### DIFF
--- a/plugin
+++ b/plugin
@@ -282,6 +282,7 @@
   "Inter-Raptor/raptor-youtube-feed-card",
   "iot7m/septic-card",
   "ipod86/lovelace-agentdvr-card",
+  "iret33/confirm-tap-card",
   "ironsheep/lovelace-lightning-detector-card",
   "ironsheep/lovelace-rpi-monitor-card",
   "isabellaalstrom/lovelace-grocy-chores-card",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: https://github.com/iret33/confirm-tap-card/releases/tag/v1.0.0
Link to successful HACS action (without the `ignore` key): https://github.com/iret33/confirm-tap-card/actions/runs/31128098262
Link to successful hassfest action (if integration): N/A (plugin, not integration)