### PR TITLE
Add Bru Living NuVo NV-T2FAM integration

### DIFF
--- a/integration
+++ b/integration
@@ -427,6 +427,7 @@
   "brmccrary/nuvo_tuner",
   "brott8/ha-crowdsec",
   "Brunas/meteo_lt_by_brunas",
+  "bru-living/ha-nuvo-t2fam",
   "bscholer/home-assistant-comma-ai",
   "buchuman/hisense_vrf",
   "buggedcom/Enion-hass",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [X ] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [ X] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ]X (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [ X] The actions are passing without any disabled checks in my repository.
- [ X] I've added a link to the action run on my repository below in the links section.
- [ X] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: https://github.com/bru-living/ha-nuvo-t2fam/releases/tag/v1.8.2
Link to successful HACS action (without the `ignore` key): https://github.com/bru-living/ha-nuvo-t2fam/actions/runs/31193142302/job/92914731036
Link to successful hassfest action (if integration): https://github.com/bru-living/ha-nuvo-t2fam/actions/runs/31193142302/job/92914731034

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->