### PR TITLE
Add kahombur/ha-mopeka-standard-check

### DIFF
--- a/integration
+++ b/integration
@@ -1507,6 +1507,7 @@
   "Ka3seBr0t/HA_Philips_Air_Plus",
   "kaechele/napoleon-efire",
   "Kahera/HA_pollen_forecast",
+  "kahombur/ha-mopeka-standard-check",
   "Kajkac/ZTE-MC-Home-assistant-repo",
   "kalanda/homeassistant-aemet-sensor",
   "Kaluzaburza/Hoymiles_HIT_xxL_G3_ModBus",


### PR DESCRIPTION
Adds [ha-mopeka-standard-check](https://github.com/kahombur/ha-mopeka-standard-check) — a Home Assistant integration for Mopeka **Standard** "Check" Bluetooth propane sensors.

Home Assistant's built-in `mopeka` integration only supports the Pro family; the Standard sensor is a different protocol (service `0xADA0`, raw ultrasonic echo data). This integration decodes it over HA's existing Bluetooth (no ESP32), with a tank-size selector and level/temperature/battery entities.

- Passes HACS validation + hassfest (see repo Actions)
- Ships self-hosted brand icons in `custom_components/mopeka_std/brand/` (per the 2026.3 brands-proxy change)
- Released: `v1.0.0`