### PR TITLE
Adds new integration [kahombur/ha-mopeka-standard-check]

### DIFF
--- a/integration
+++ b/integration
@@ -1507,6 +1507,7 @@
   "Ka3seBr0t/HA_Philips_Air_Plus",
   "kaechele/napoleon-efire",
   "Kahera/HA_pollen_forecast",
+  "kahombur/ha-mopeka-standard-check",
   "Kajkac/ZTE-MC-Home-assistant-repo",
   "kalanda/homeassistant-aemet-sensor",
   "Kaluzaburza/Hoymiles_HIT_xxL_G3_ModBus",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: https://github.com/kahombur/ha-mopeka-standard-check/releases/tag/v1.0.1
Link to successful HACS action (without the `ignore` key): https://github.com/kahombur/ha-mopeka-standard-check/actions/runs/31201679696/job/92942910405
Link to successful hassfest action (if integration): https://github.com/kahombur/ha-mopeka-standard-check/actions/runs/31201679696/job/92942910391