### PR TITLE
Add JJack640/ha-hydro-monitor

### DIFF
--- a/integration
+++ b/integration
@@ -1401,6 +1401,7 @@
   "jippi/hass-nordnet",
   "jirutka/hass-goliash",
   "jirutka/hass-smarwi",
+  "JJack640/ha-hydro-monitor",
   "jjjonesjr33/petlibro",
   "jjlawren/sonos_cloud",
   "jjsmackay/hass-yolo-updater",


### PR DESCRIPTION
## Repository

https://github.com/JJack640/ha-hydro-monitor

## Description

Hydro Monitor is a Home Assistant integration for hydrological monitoring
using public groundwater, river discharge, water level and spring
discharge data. It currently supports NIWIS, a nationwide German public
hydrological data service (station coverage spans nearly every German
federal state, confirmed via the station catalogue's `landcode` field,
plus federal waterway gauges).

## Checklist

- [x] Repository is public, not a fork, not archived
- [x] `hacs.json` present
- [x] `manifest.json` valid, with `codeowners` set
- [x] HACS Action passes: https://github.com/JJack640/ha-hydro-monitor/actions/workflows/hacs.yml
- [x] Hassfest passes: https://github.com/JJack640/ha-hydro-monitor/actions/workflows/hassfest.yml
- [x] Repository description, topics, and issues are set/enabled
- [x] A full GitHub release exists (not just a tag): https://github.com/JJack640/ha-hydro-monitor/releases/tag/v0.3.0-beta1
- [x] I am the owner of this repository
- [x] Brand icon is bundled locally under `custom_components/hydro_monitor/brand/` (per the [Brands Proxy API](https://developers.home-assistant.io/blog/2026/02/24/brands-proxy-api), `hacs.json` requires Home Assistant 2026.7.0+, well above the 2026.3.0 threshold where this is supported)
