### PR TITLE
Add tomereli/mahlkoenig_sync_hacs

### DIFF
--- a/integration
+++ b/integration
@@ -2870,6 +2870,7 @@
   "TomBrien/cardiffwaste-ha",
   "tomer-w/ha-nmea2000",
   "tomer-w/ha-victron-mqtt",
+  "tomereli/mahlkoenig_sync_hacs",
   "TomTuTHub/mitsubishi-outlander-phev-eu",
   "tonyroberts/hawundasmart",
   "toreamun/amshan-homeassistant",


### PR DESCRIPTION
Adds the Mahlkönig Sync integration.

Home Assistant integration for the Mahlkönig E64 WS grinder and paired Sync Scale, reading grind/brew data from the Mahlkönig Sync cloud. First integration for the Sync-ecosystem grinders.

- Repo: https://github.com/tomereli/mahlkoenig_sync_hacs
- Release: v0.1.0
- HACS Action + hassfest: passing
- Brand icon bundled under custom_components/mahlkoenig_sync/brand/
