### PR TITLE
Add Playcolors-co/ha-binhass (integration)

### DIFF
--- a/integration
+++ b/integration
@@ -2268,6 +2268,7 @@
   "PlanetCitizen1829381/ha-nsw-beachwatch",
   "plantlab-ai/home-assistant-plantlab",
   "Platzii/homeassistant-evcnet",
+  "Playcolors-co/ha-binhass",
   "plmilord/Hass.io-custom-component-ikamand",
   "plmilord/Hass.io-custom-component-spaclient",
   "plmilord/Hass.io-custom-component-superior-propane",


### PR DESCRIPTION
## Add integration: `Playcolors-co/ha-binhass`

**Waltham Forest Bin Collection** — a config-flow integration exposing London
Borough of Waltham Forest bin collection dates as per-service `date` sensors and
a calendar, over plain HTTPS (no Selenium, no container).

- Repository: https://github.com/Playcolors-co/ha-binhass
- Domain: `binhass`
- Category: integration

### Checklist
- [x] Added to the `integration` file, inserted alphabetically (not at the end).
- [x] Repository is public, not a fork, not archived.
- [x] Repository has a description, topics, and Issues enabled.
- [x] There is at least one release.
- [x] Valid `hacs.json` (with `name`) and `manifest.json` (domain, documentation, issue_tracker, codeowners, version).
- [x] HACS Action and Hassfest validation pass on the repository.
- [x] Brand icon bundled in-repo at `custom_components/binhass/brand/` (per the HA 2026.3 custom brand-images mechanism; brands repo no longer accepts custom-integration icons).
- [x] PR opened from a personal account (`TheBoxCoder`) with maintainer edits allowed.