### PR TITLE
Adds new integration [breed007/ha-fleetdm]

### DIFF
--- a/integration
+++ b/integration
@@ -408,6 +408,7 @@
   "bramstroker/homeassistant-powercalc",
   "bramstroker/homeassistant-state-webhook",
   "braytonstafford/grok_conversation",
+  "breed007/ha-fleetdm",
   "Breina/idrac_power_monitor",
   "Breina/nad_controller",
   "Breina/PowerTagGateway",


### PR DESCRIPTION
Adds [breed007/ha-fleetdm](https://github.com/breed007/ha-fleetdm), a Home Assistant integration for [Fleet](https://fleetdm.com) — the open-source osquery-based device management platform. It surfaces fleet-wide host counts, per-policy compliance, and compliance drift events. Read-only: `GET` requests only, and a Fleet Observer token is sufficient.

## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/breed007/ha-fleetdm/releases/tag/v0.1.0>
Link to successful HACS action (without the `ignore` key): <https://github.com/breed007/ha-fleetdm/actions/runs/31220260825/job/93003055724>
Link to successful hassfest action (if integration): <https://github.com/breed007/ha-fleetdm/actions/runs/31220260825/job/93003055775>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->