### PR TITLE
Adds new plugin [Vatoe/ha-weatherflow-bom-weathercard]

### DIFF
--- a/plugin
+++ b/plugin
@@ -683,6 +683,7 @@
   "usernein/tailwindcss-template-card",
   "usernein/tv-card",
   "vasqued2/ha-teamtracker-card",
+  "Vatoe/ha-weatherflow-bom-weathercard",
   "vdgced/ha-card-playground",
   "VeniVidiVici/givtcp-power-flow-card",
   "victorigualada/lovelace-solar-card",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: https://github.com/Vatoe/ha-weatherflow-bom-weathercard/releases/tag/v1.3.0
Link to successful HACS action (without the `ignore` key): https://github.com/Vatoe/ha-weatherflow-bom-weathercard/actions/runs/31238304099
Link to successful hassfest action (if integration): N/A — this is a plugin (Lovelace card), not an integration