### PR TITLE
Adds new integration [Booyaka101/hass-breakage-radar]

### DIFF
--- a/integration
+++ b/integration
@@ -389,6 +389,7 @@
   "bodyscape/cielo_home",
   "BoilerController/boiler-controller-ha",
   "boot-nyxpoint/prana-wifi",
+  "Booyaka101/hass-breakage-radar",
   "boralyl/kodi-recently-added",
   "boralyl/steam-wishlist",
   "borski/ha-lucidmotors",


### PR DESCRIPTION
## Checklist

- [x] I have read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I have added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I have added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I have added a link to the action run on my repository below in the links section.
- [x] I have created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/Booyaka101/hass-breakage-radar/releases/tag/v1.0.1>
Link to successful HACS action (without the `ignore` key): <https://github.com/Booyaka101/hass-breakage-radar/actions/runs/31243129706/job/93067238468>
Link to successful hassfest action (if integration): <https://github.com/Booyaka101/hass-breakage-radar/actions/runs/31243129706/job/93067238448>

---

**Breakage Radar** answers one question for a Home Assistant user: which of my installed custom integrations stop working, and in which future release.

Home Assistant marks API removals a year ahead with `breaks_in_ha_version=`, but the `custom_integration_behavior` argument of `report_usage` defaults to `LOG` — so a custom integration using a doomed API produces one line in `home-assistant.log` and nothing else, until upgrade day.

The integration downloads a public index (rebuilt daily by a crawler in the same repo that AST-scans the HACS catalogue for these APIs), matches it against `custom_components/`, and exposes `sensor.breakage_radar_affected` plus a repairs issue. It declares `"requirements": []` — no third-party runtime dependencies.

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->