### PR TITLE
Adds new plugin [deconstructionalism/homeassistant-dashboard-sidebar]

### DIFF
--- a/plugin
+++ b/plugin
@@ -131,7 +131,7 @@
   "dcramer/lovelace-nextbus-card",
   "deblockt/aria2-card",
   "decompil3d/lovelace-hourly-weather",
-  "deconstructionalism/hacs-dashboard-sidebar",
+  "deconstructionalism/homeassistant-dashboard-sidebar",
   "denysdovhan/purifier-card",
   "denysdovhan/vacuum-card",
   "derliebemarcus/homeassistant_custom_dishwasher_card",

--- a/plugin
+++ b/plugin
@@ -131,6 +131,7 @@
   "dcramer/lovelace-nextbus-card",
   "deblockt/aria2-card",
   "decompil3d/lovelace-hourly-weather",
+  "deconstructionalism/hacs-dashboard-sidebar",
   "denysdovhan/purifier-card",
   "denysdovhan/vacuum-card",
   "derliebemarcus/homeassistant_custom_dishwasher_card",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: https://github.com/deconstructionalism/homeassistant-dashboard-sidebar/releases/tag/v1.0.0
Link to successful HACS action (without the `ignore` key): https://github.com/deconstructionalism/homeassistant-dashboard-sidebar/actions/runs/31245352451
Link to successful hassfest action (if integration): N/A (this is a plugin, not an integration)

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->
