### PR TITLE
Adds new integration [marl1w/reolink-stamina-ha]

### DIFF
--- a/integration
+++ b/integration
@@ -1806,6 +1806,7 @@
   "markuzzi/somfy_cul_integration",
   "markvader/ha-rpi_rf",
   "markvader/sonic",
+  "marl1w/reolink-stamina-ha",
   "marnixt/PowerClimate",
   "marotoweb/home-assistant-vacuum-viomise",
   "marq24/ha-bosch-ebike-flow",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/marl1w/reolink-stamina-ha/releases/tag/v1.2.10>
Link to successful HACS action (without the `ignore` key): <https://github.com/marl1w/reolink-stamina-ha/actions/runs/31246938324/job/93076992144>
Link to successful hassfest action (if integration): <https://github.com/marl1w/reolink-stamina-ha/actions/runs/31246938324/job/93076999133>
