### PR TITLE
Adds new integration [BackupBaTTerY/energypriceforecast-home-assistant]

### DIFF
--- a/integration
+++ b/integration
@@ -279,6 +279,7 @@
   "Babel-Innovations/ha-lucarne",
   "bacco007/sensor.opennem",
   "bacco007/sensor.waternsw",
+  "BackupBaTTerY/energypriceforecast-home-assistant",
   "BAERnado/ha-samsungtv-encrypted",
   "bairnhard/fishing_assistant",
   "bairnhard/home-assistant-google-aqi",


### PR DESCRIPTION
- [x] I've read the publishing documentation.
- [x] I've added the HACS action to my repository.
- [x] (For integrations only) I've added the hassfest action to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: https://github.com/BackupBaTTerY/energypriceforecast-home-assistant/releases/tag/0.2.0
Link to successful HACS action (without the `ignore` key): https://github.com/BackupBaTTerY/energypriceforecast-home-assistant/actions/runs/31255503670/job/93098158230
Link to successful hassfest action (if integration): https://github.com/BackupBaTTerY/energypriceforecast-home-assistant/actions/runs/31255503670/job/93098158247