### PR TITLE
Adds new integration [neoge/vestel_vr_remote]

### DIFF
--- a/integration
+++ b/integration
@@ -2051,6 +2051,7 @@
   "nemiro-TECH/correios_tracker_ha",
   "NemoN/ha-chuango-ov300",
   "NemoN/ha-intex-swg",
+  "neoge/vestel_vr_remote",
   "NeoHuncho/vikunja-voice-assistant",
   "neon9809/cuk-wifi-ha",
   "neon9809/FiberHome-CPE-HA",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: https://github.com/neoge/vestel_vr_remote/releases/tag/v1.0.0
Link to successful HACS action (without the `ignore` key): https://github.com/neoge/vestel_vr_remote/actions/runs/31318322408
Link to successful hassfest action (if integration): https://github.com/neoge/vestel_vr_remote/actions/runs/31318322412

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->
