### PR TITLE
Add maestrea76/Dreame-SF25-WIFI-HACS-Integration

### DIFF
--- a/integration
+++ b/integration
@@ -1750,6 +1750,7 @@
   "madpilot/hass-amber-electric",
   "madslundt/huligennem_ha",
   "maeek/ha-aux-cloud",
+  "maestrea76/Dreame-SF25-WIFI-HACS-Integration",
   "magicbear/schneider_selogic",
   "magiczoom2/HA-Leneda-Power",
   "magikh0e/ha-medication-reminder",


### PR DESCRIPTION
<!-- Integration -->

Repository: https://github.com/maestrea76/Dreame-SF25-WIFI-HACS-Integration

Unofficial integration for the **Dreame SF25 WiFi Food Waste Disposer** (`dreame.fwd.u2527`), a countertop food-waste composter/dehydrator with no public API. State and control go through the Dreame cloud (MIoT `sendCommand` RPC) with real-time updates over Dreame's MQTT broker.

Checklist:
- [x] Public repository, not archived, not a fork
- [x] Description, topics and issues enabled
- [x] HACS Action and Hassfest pass
- [x] Releases published (latest: v0.3.8)
- [x] `hacs.json` with `name`
- [x] Brand directory with `icon.png` (`custom_components/dreame_sf25/brand/`)
- [x] I am the owner of the repository
