### PR TITLE
Adds new plugin [j0sp0r/m3-cards]

### DIFF
--- a/plugin
+++ b/plugin
@@ -290,6 +290,7 @@
   "itsbrianburton/slide-confirm",
   "itsteddyyo/strategy-pack",
   "j-a-n/lovelace-wallpanel",
+  "j0sp0r/m3-cards",
   "jampez77/multiline-entity-card",
   "jansendejong/JJs-Birthday-Card",
   "Jarauvi/elisa_kotiakku_cards",


### PR DESCRIPTION
## Repository
https://github.com/j0sp0r/m3-cards

Material 3–inspired Lovelace cards for Home Assistant — 17 cards (climate, energy, weather, presence, media, and more), built natively with Lit, no `button-card`/`card-mod` dependency.

## Checklist
- [x] Public repository
- [x] `hacs.json` present and valid
- [x] At least one release (`v1.0.0`) with the built plugin file attached as an asset
- [x] `hacs/action` validation passing (all 8 checks) — https://github.com/j0sp0r/m3-cards/actions/workflows/hacs-validate.yml
- [x] README documents installation and configuration for every card