### PR TITLE
Add yakattack77/ha-buildinglink

### DIFF
--- a/integration
+++ b/integration
@@ -3050,6 +3050,7 @@
   "xraver/mercedes_me_api",
   "xtimmy86x/ha-s7plc",
   "Xunil99/ha-bosch-ebike",
+  "yakattack77/ha-buildinglink",
   "yandex/pogoda-home-assistant",
   "yangqian/hass-hk_air_quality",
   "yashijoe/ha-cameconnect",


### PR DESCRIPTION
Adds the **BuildingLink** integration to the HACS default store.

- Repository: https://github.com/yakattack77/ha-buildinglink
- Category: integration
- Domain: `buildinglink`

BuildingLink is a residential building management platform. This integration
surfaces a resident's mail-room package deliveries as a Home Assistant sensor
(`sensor.buildinglink_packages`), with per-delivery attributes (carrier,
location, tracking number, timestamp). UI config flow, cloud polling.

Validation (hassfest + HACS action) passes on the repository, and it ships its
own brand images in `custom_components/buildinglink/brand/` per the HA 2026.3
local-brands mechanism.