### PR TITLE
Adds new integration [which-newton/ha-rpi5-fan]

### DIFF
--- a/integration
+++ b/integration
@@ -3003,6 +3003,7 @@
   "werthdavid/homeassistant-pulsatrix-local-mqtt",
   "wez/govee-lan-hass",
   "wheeller123/Tineco-Integration",
+  "which-newton/ha-rpi5-fan",
   "WHISTLER-Arc/Greg",
   "Wibias/hass-variables",
   "WickedGhost/avinor_flight_data",


### PR DESCRIPTION
Live fan-curve control for the **Raspberry Pi 5's 4-pin fan header** — the Active Cooler, the official case fan, or the fan on an M.2 HAT+.

### What gap this fills

Every existing Home Assistant Pi fan integration drives a **GPIO-wired fan with software PWM**. None of them can control the Pi 5's dedicated fan header, because that fan is owned by the kernel's `pwm-fan` driver and steered by the thermal governor.

That matters when a HAT is involved: on an M.2 HAT+ the same airflow cools the **NVMe**, and the stock curve does not start the fan until 50 °C.

### Design — the kernel stays the safety net

Control works by **retuning the governor's trip points**, not by driving raw PWM, so the user's curve keeps being enforced even if Home Assistant stops running. Raw fixed-speed control exists but is **off by default** and guarded by a watchdog that returns the fan to the kernel after 90 s without a new value, and on unload/reload/removal. The `type=critical` trip (110 °C thermal shutdown) is never read or written — trip discovery filters on `type == "active"` so it cannot be included.

### Entities

`fan` (curve profiles + measured duty cycle), `select` (profile), four `number` entities (the live curve editor, one per fan level), `sensor` × 4 (RPM, duty cycle, CPU temperature, governor), and a problem-class `binary_sensor` for when manual control has the governor disabled.

### Validation

- `hacs/action@22.5.0` and `hassfest` both pass on CI
- Brand assets included in-repo at `custom_components/rpi5_fan/brand/`
- Config flow, single instance, no YAML, translations present
- Released as `v1.0.0`

### Testing

Verified against real hardware on Home Assistant OS 16.2 / core 2026.8.1, on a Pi 5 with an M.2 HAT+: all entities set up cleanly, and switching profiles provably moved the kernel trip points from 40/47/54/61 °C to 45/53/60/68 °C with the governor still enabled.

Degrades gracefully rather than failing where `/sys` is read-only (common on Home Assistant Container): temperature, RPM and duty cycle still report, controls show unavailable, and a warning is logged.
