### PR TITLE
Adds new integration [which-newton/ha-rpi5-fan]

### DIFF
--- a/integration
+++ b/integration
@@ -3003,6 +3003,7 @@
   "werthdavid/homeassistant-pulsatrix-local-mqtt",
   "wez/govee-lan-hass",
   "wheeller123/Tineco-Integration",
+  "which-newton/ha-rpi5-fan",
   "WHISTLER-Arc/Greg",
   "Wibias/hass-variables",
   "WickedGhost/avinor_flight_data",


### PR DESCRIPTION
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/which-newton/ha-rpi5-fan/releases/tag/v1.0.1>
Link to successful HACS action (without the `ignore` key): <https://github.com/which-newton/ha-rpi5-fan/actions/runs/31544833954/job/93954978693>
Link to successful hassfest action (if integration): <https://github.com/which-newton/ha-rpi5-fan/actions/runs/31544833954/job/93954978832>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->

---

## About this integration

Live fan-curve control for the **Raspberry Pi 5's 4-pin fan header** — the Active Cooler, the official case fan, or the fan on an M.2 HAT+.

Every existing Home Assistant Pi fan integration drives a **GPIO-wired fan with software PWM**. None can control the Pi 5's dedicated header, because that fan is owned by the kernel's `pwm-fan` driver and steered by the thermal governor. That matters on an M.2 HAT+, where the same airflow cools the **NVMe** and the stock curve does not start the fan until 50 °C.

**The kernel stays the safety net.** Control works by retuning the governor's trip points rather than driving raw PWM, so the user's curve keeps being enforced even if Home Assistant stops running. Raw fixed-speed control exists but is off by default and is guarded by a watchdog that hands the fan back to the kernel after 90 s without a new value, and on unload/reload/removal. The `type=critical` trip (110 °C thermal shutdown) is never read or written.

Verified against real hardware on Home Assistant OS 16.2 / core 2026.8.1 on a Pi 5 with an M.2 HAT+. Degrades to read-only reporting where `/sys` is read-only, which is common on Home Assistant Container.
