### PR TITLE
Add bitcoin stack tracker integration

### DIFF
--- a/integration
+++ b/integration
@@ -7,6 +7,7 @@
   "0xAlon/dolphin",
   "0xQuantumHome/bayrol-home-hassistant",
   "19DMO89/smartdome_heat_control",
+  "21Koblenz/bitcoin-stack-tracker",
   "38decibel/WILLO",
   "3dg1luk43/ha_creality_ws",
   "3dg1luk43/ha_washdata",


### PR DESCRIPTION
Adds **Bitcoin Stack Tracker** (`21Koblenz/bitcoin-stack-tracker`) — a Bitcoin-only portfolio and transaction tracker for Home Assistant.

It provides local portfolio tracking, multiple portfolios, purchases and sales, depot-based FIFO calculations, holding-period analysis, DCA and performance metrics, CSV imports for several Bitcoin exchanges and brokers, encrypted portable backups, privacy controls, and an optional separate Tor gateway for public market data.

Portfolio and transaction data remain local to Home Assistant. The integration supports UI-based configuration and is distributed as a standard HACS integration.

## Checklist

- [X] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [X] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [X] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [X] The actions are passing without any disabled checks in my repository.
- [X] I've added a link to the action run on my repository below in the links section.
- [X] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: [https://github.com/21Koblenz/bitcoin-stack-tracker/releases/tag/v0.21.0.7](https://github.com/21Koblenz/bitcoin-stack-tracker/releases/tag/v0.21.0.7)

Link to successful HACS action (without the `ignore` key): [https://github.com/21Koblenz/bitcoin-stack-tracker/actions/runs/31547990177/job/93964454033](https://github.com/21Koblenz/bitcoin-stack-tracker/actions/runs/31547990177/job/93964454033)

Link to successful hassfest action (if integration): [https://github.com/21Koblenz/bitcoin-stack-tracker/actions/runs/31547990177/job/93964453996](https://github.com/21Koblenz/bitcoin-stack-tracker/actions/runs/31547990177/job/93964453996)
