### PR TITLE
Adds new integration [Ducatel/UrbanSolarEnergyHomeAssistant]

### DIFF
--- a/integration
+++ b/integration
@@ -838,6 +838,7 @@
   "DTekNO/mspa-homeassistant",
   "DTekNO/norway_alerts",
   "DTekNO/norway_seaforecast",
+  "Ducatel/UrbanSolarEnergyHomeAssistant",
   "dudanov/hassio-ftms",
   "duhow/hass-aigues-barcelona",
   "duhow/hass-cover-time-based",


### PR DESCRIPTION
# Urban Solar Energy integration

Hi, I wanted to publish my integration of Urban Solar Energy.
This integration allow to track your photovoltaic production and surplus injection data from Urban Solar Energy

## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

[Link to current release](https://github.com/Ducatel/UrbanSolarEnergyHomeAssistant/releases/tag/v1.0.0)
[Link to successful HACS action (without the `ignore` key):](https://github.com/Ducatel/UrbanSolarEnergyHomeAssistant/actions/runs/31508176543/job/93834979049)
[Link to successful hassfest action (if integration):](https://github.com/Ducatel/UrbanSolarEnergyHomeAssistant/actions/runs/31508176543/job/93834978772)

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->