### PR TITLE
Adds new plugin [tverweij92/House-Powerflow-Card]

### DIFF
--- a/plugin
+++ b/plugin
@@ -677,6 +677,7 @@
   "trollix/ha-tsmoon-card",
   "tungmeister/hass-blind-card",
   "turbulator/pandora-cas-card",
+  "tverweij92/House-Powerflow-Card",
   "twrecked/lovelace-hass-aarlo",
   "ulic75/power-flow-card",
   "unbekannt3/room-card-minimalist",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository. Not applicable: this is a plugin/custom card.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/tverweij92/House-Powerflow-Card/releases/tag/V5.0.0>
Link to successful HACS action (without the `ignore` key): <https://github.com/tverweij92/House-Powerflow-Card/actions/runs/31586932744>
Link to successful hassfest action (if integration): <Not applicable - plugin/custom card>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->