### PR TITLE
Add EZ-card to plugin list

### DIFF
--- a/plugin
+++ b/plugin
@@ -637,6 +637,7 @@
   "tcarlsen/lovelace-light-with-profiles",
   "tdvtdv/ha-tdv-bar",
   "tempus2016/tabdeck-card",
+  "terrizzza/EZ-card",
   "teuchezh/dynamic-weather-card",
   "thanhn062/ha-dyson-card",
   "TheLuXoR/calendar-week-card",


### PR DESCRIPTION
Add EZ-card to plugin list

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: https://github.com/terrizzza/EZ-Card/releases/tag/1.0.0
Link to successful HACS action (without the `ignore` key): https://github.com/terrizzza/EZ-Card/actions/runs/31600537178
Link to successful hassfest action (if integration): N/A

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->