### PR TITLE
Adds new integration [marek9336/ha-rsh-socket]

### DIFF
--- a/integration
+++ b/integration
@@ -1796,6 +1796,7 @@
   "marcovolt/homeassistant-binance",
   "marcschmiedchen/home-assistant-wolf_ism8",
   "MarcusTaz/ha_kia_hyundai_USA",
+  "marek9336/ha-rsh-socket",
   "Mariusthvdb/custom_local_icons",
   "mariusz-ostoja-swierczynski/tech-controllers",
   "markaggar/ha-media-index",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/has>
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/marek9336/ha-rsh-socket/releases/tag/v0.1.1>
Link to successful HACS action (without the `ignore` key): <https://github.com/marek9336/ha-rsh-socket/actions/runs/31618714079/job/94187856092>
Link to successful hassfest action (if integration): <https://github.com/marek9336/ha-rsh-socket/actions/runs/31618714079/job/94187855784>

## About

Local control for cheap cloud-only Wi-Fi sockets (RSH Smart Home / Rising Sun
and unbranded clones) that listen on no port, are not Tuya, and can only be
reflashed over serial.

Instead of opening the case, the integration proxies the socket's single
outbound cloud connection. Traffic is relayed unchanged, so the vendor app and
Google Home keep working, while Home Assistant can inject its own commands and
observe those sent by the cloud.

Verified end to end against real hardware.

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->