### PR TITLE
Add 'wiesi12/windhager-tools' to integration list

### DIFF
--- a/integration
+++ b/integration
@@ -3008,6 +3008,7 @@
   "WickedGhost/avinor_flight_data",
   "widewing/ha-toyota-na",
   "wielorzeczownik/ha-toya-decoder",
+  "wiesi12/windhager-tools",
   "willbeeching/ha-unifiplay",
   "WillCodeForCats/solaredge-modbus-multi",
   "WillCodeForCats/tekmar-482",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: https://github.com/wiesi12/windhager-tools/releases/tag/v0.10.13
Link to successful HACS action (without the `ignore` key): https://github.com/wiesi12/windhager-tools/actions/runs/31626921393
Link to successful hassfest action (if integration): https://github.com/wiesi12/windhager-tools/actions/runs/31626921683

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->