### PR TITLE
Adds new integration [amcchord/home-assistant-busybar]

### DIFF
--- a/integration
+++ b/integration
@@ -144,6 +144,7 @@
   "amaximus/radioactivity_hu",
   "amaximus/water_quality_fvm",
   "ambientika/HomeAssistant-integration-for-Ambientika",
+  "amcchord/home-assistant-busybar",
   "amg0/ha_ipx800v3",
   "amitfin/daily_schedule",
   "amitfin/oref_alert",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/amcchord/home-assistant-busybar/releases/tag/v0.2.0>

Link to successful HACS action (without the `ignore` key): <https://github.com/amcchord/home-assistant-busybar/actions/runs/31628738438>

Link to successful hassfest action (if integration): <https://github.com/amcchord/home-assistant-busybar/actions/runs/31628738438>

## About

BUSY Bar for Home Assistant is a playful, local-first integration for the BUSY Bar display and focus device. It provides streamed physical-control and timer events, native entities, priority-aware screen composition, local media, widgets, animations, mini-apps, a dashboard card, and automation blueprints. Everyday operation remains on the LAN and the integration has been verified against real hardware.

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->
