### PR TITLE
Adds new plugin [mbrande/animated-sky-weather-card]

### DIFF
--- a/plugin
+++ b/plugin
@@ -429,6 +429,7 @@
   "maxwroc/battery-state-card",
   "maxwroc/github-flexi-card",
   "maybetaken/ha-makeskyblue-mppt-card",
+  "mbrande/animated-sky-weather-card",
   "MelleD/lovelace-expander-card",
   "memphi2/ha-unifi-drive-card",
   "mentalilll/ha-vpd-chart",


### PR DESCRIPTION
- [x] I've read the publishing documentation.
- [x] I've added the HACS action to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: https://github.com/mbrande/animated-sky-weather-card/releases/tag/v1.0.1
Link to successful HACS action (without the `ignore` key): https://github.com/mbrande/animated-sky-weather-card/actions/runs/31649132720
Link to successful hassfest action (if integration): n/a — this is a plugin, not an integration