### PR TITLE
Adds new integration [Nicolai96dk/kaisai-khx-modbus-tcp]

### DIFF
--- a/integration
+++ b/integration
@@ -2068,6 +2068,7 @@
   "nickneos/HA_harmony_climate_component",
   "NicoIIT/ha-ble-adv",
   "nicois/foxess-control",
+  "Nicolai96dk/kaisai-khx-modbus-tcp",
   "NicolasBonduel/hass-vibbo-feed",
   "nicole-ashley/homeassistant-goldair-climate",
   "nicx17/unstats",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/Nicolai96dk/kaisai-khx-modbus-tcp/releases/tag/v0.1.0>
Link to successful HACS action (without the `ignore` key): <https://github.com/Nicolai96dk/kaisai-khx-modbus-tcp/actions/runs/31674276119/job/94365307522>
Link to successful hassfest action (if integration): <https://github.com/Nicolai96dk/kaisai-khx-modbus-tcp/actions/runs/31674276119/job/94365307523>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->
