### PR TITLE
Adds new integration [DomCim/HA-Schoolday]

### DIFF
--- a/integration
+++ b/integration
@@ -804,6 +804,7 @@
   "dneprojects/habitron",
   "dneprojects/mypv",
   "dolezsa/thermal_comfort",
+  "DomCim/HA-Schoolday",
   "dominikamann/oekofen-pellematic-compact",
   "DominikStarke/becker_centralcontrol_has",
   "DominikWrobel/airmusic",


### PR DESCRIPTION
A Home Assistant integration for the family school week: timetable, routines, homework and days off, with Lovelace cards for a wall panel.

Inserted as a single line rather than through scripts/sort.py. The file carries a few pre-existing whitespace irregularities upstream — an unindented entry, a trailing space, an over-indented one — and running the sorter would sweep those into this diff. Both lint jobs read the file as JSON, so the one-line insertion is all that is needed: is_sorted.py and jq --raw-output both pass.

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [ ] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [ ] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [ ] The actions are passing without any disabled checks in my repository.
- [ ] I've added a link to the action run on my repository below in the links section.
- [ ] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <>
Link to successful HACS action (without the `ignore` key): <>
Link to successful hassfest action (if integration): <>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->