### PR TITLE
Add ALArvi019/mercadona-cart-bridge

### DIFF
--- a/integration
+++ b/integration
@@ -76,6 +76,7 @@
   "aLAN-LDZ/ThesslaGreen_HA",
   "alandtse/alexa_media_player",
   "alandtse/tesla",
+  "ALArvi019/mercadona-cart-bridge",
   "ALArvi019/moderntides",
   "albaintor/homeassistant_electrolux_status",
   "albertogeniola/meross-homeassistant",


### PR DESCRIPTION
## Repository

https://github.com/ALArvi019/mercadona-cart-bridge

## What does it do

Connects a Mercadona shopping cart to Home Assistant. Mercadona is the largest supermarket chain in Spain, and many households use its cart as a shared shopping list.

The integration exposes the cart as a to-do list entity, lets you add and remove items by voice, and adds a touch panel showing the cart alongside your usual products.

It never places an order. Adding to the cart does not buy anything, checkout is still done by hand in the app.

## Checklist

* [x] The repository is public and works as a custom repository
* [x] HACS Action passes
* [x] Hassfest passes
* [x] There is a published release
* [x] Brand images are provided inside the integration (`custom_components/mercadona/brand/`)
* [x] Added in alphabetical order