### PR TITLE
Update Hoymiles repository slug

### DIFF
--- a/integration
+++ b/integration
@@ -1509,7 +1509,7 @@
   "Kahera/HA_pollen_forecast",
   "Kajkac/ZTE-MC-Home-assistant-repo",
   "kalanda/homeassistant-aemet-sensor",
-  "Kaluzaburza/Hoymiles_HIT_xxL_G3_ModBus",
+  "Kaluzaburza/hoymiles-hit-g3-ems",
   "kamaradclimber/datadog-integration-ha",
   "kamaradclimber/geovelo-homeassistant",
   "kamaradclimber/heishamon-homeassistant",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/Kaluzaburza/hoymiles-hit-g3-ems/releases/tag/v1.5.5>
Link to successful HACS action (without the `ignore` key): <https://github.com/Kaluzaburza/hoymiles-hit-g3-ems/actions/runs/31887713221/job/95019335605>
Link to successful hassfest action (if integration): <https://github.com/Kaluzaburza/hoymiles-hit-g3-ems/actions/runs/31887713221/job/95019335648>

## Change

The existing repository was renamed from `Kaluzaburza/Hoymiles_HIT_xxL_G3_ModBus` to `Kaluzaburza/hoymiles-hit-g3-ems` without changing its GitHub repository ID. GitHub retains the old URL as a permanent redirect. This PR changes only the single HACS default registry entry to the canonical new slug.

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->
