### PR TITLE
Adds new plugin [mrwogu/xiaomi-smart-fan-card]

### DIFF
--- a/plugin
+++ b/plugin
@@ -450,6 +450,7 @@
   "MrSjodin/HomeAssistant_Trafiklab_DynamicTravelSearch_Card",
   "MrSjodin/HomeAssistant_Trafiklab_Timetable_Card",
   "MrSjodin/HomeAssistant_Trafiklab_TravelSearch_Card",
+  "mrwogu/xiaomi-smart-fan-card",
   "msztolcman/yrno-weather-card",
   "mtheli/gardena-smart-system-card",
   "mtheli/toothbrush-card",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/mrwogu/xiaomi-smart-fan-card/releases/tag/v1.1.0>
Link to successful HACS action (without the `ignore` key): <https://github.com/mrwogu/xiaomi-smart-fan-card/actions/runs/31890391139>
Link to successful hassfest action (if integration): Not applicable - this repository is a plugin.
