### PR TITLE
Adds new plugin [BrainDeLook/healthsync-dashboard-card]

### DIFF
--- a/plugin
+++ b/plugin
@@ -63,6 +63,7 @@
   "Bobsilvio/calcio-live-card",
   "bokub/rgb-light-card",
   "bolkedebruin/erhv-lovelace",
+  "BrainDeLook/healthsync-dashboard-card",
   "bramkragten/swipe-card",
   "bramkragten/weather-card",
   "Brianfit/calvin-card-ha",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/BrainDeLook/healthsync-dashboard-card/releases/tag/v0.3.2>
Link to successful HACS action (without the `ignore` key): <https://github.com/BrainDeLook/healthsync-dashboard-card/actions/runs/31746821845>
Link to successful hassfest action (if integration): <N/A — plugin>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->
