### PR TITLE
Fix hassfest integration discovery

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -218,7 +218,7 @@ jobs:
           integration=$(python3 -m scripts.helpers.integration_path)
           domain=$(python3 -m scripts.helpers.domain)
           docker run --rm \
-            -v "$integration":"/github/workspace/$domain" \
+            -v "$integration":"/github/workspace/custom_components/$domain" \
             ghcr.io/home-assistant/hassfest:latest
 
   hacs:


### PR DESCRIPTION
The current hassfest container now limits custom-integration discovery to `manifest.json` at the workspace root or under `custom_components/<domain>`. The default-catalog check still mounts each integration at `/github/workspace/<domain>`, so hassfest reports `Error: No integrations found!` before validation. This currently affects new integration submissions, including #10018 and #10019.

Mounting at the documented `custom_components/<domain>` location restores discovery while preserving the domain directory name. I reproduced the current failure with `ghcr.io/home-assistant/hassfest:latest`, then verified this destination runs all validators successfully against `eman/tariffkit`.

The workflow passes `actionlint` with this change.