### PR TITLE
Adds new plugin [GpsM2/flightradar24-splitflap-card]

### DIFF
--- a/plugin
+++ b/plugin
@@ -229,6 +229,7 @@
   "giovannilamarmora/lovelace-material-components",
   "go-hass/go-hass-cards",
   "goggybox/compact-light-card",
+  "GpsM2/flightradar24-splitflap-card",
   "grinstantin/todoist-card",
   "guiohm79/custom-gauge-card",
   "guiohm79/dual_gauge",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: https://github.com/GpsM2/flightradar24-splitflap-card/releases/tag/0.6.0
Link to successful HACS action (without the `ignore` key): https://github.com/GpsM2/flightradar24-splitflap-card/actions/runs/31958482024
Link to successful hassfest action (if integration): N/A (Lovelace plugin, not an integration)

## Repository

https://github.com/GpsM2/flightradar24-splitflap-card

## Description

Split-flap airport board for Home Assistant, driven by the FlightRadar24 integration's arrivals/departures sensors. Authentic per-character flip animation (optionally a scramble/roll-through style), delay indicator with colour-coded status, light and dark mode following the Home Assistant theme, customisable accent colour and edge bars, and a bundled (non-network) monospace typeface. Visual configuration editor, no YAML required, with a live preview in Home Assistant's card picker. Multilingual: EN, DE, ES, FR, auto-detected from Home Assistant.
