### PR TITLE
Add Jaguaza/Neon-Cards to plugin list

### DIFF
--- a/plugin
+++ b/plugin
@@ -290,6 +290,7 @@
   "itsbrianburton/slide-confirm",
   "itsteddyyo/strategy-pack",
   "j-a-n/lovelace-wallpanel",
+  "Jaguaza/Neon-Cards",
   "jampez77/multiline-entity-card",
   "jansendejong/JJs-Birthday-Card",
   "Jarauvi/elisa_kotiakku_cards",


### PR DESCRIPTION
## Checklist
- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.
## Links
Link to current release: <https://github.com/Jaguaza/Neon-Cards/releases/tag/v0.1.0>
Link to successful HACS action (without the `ignore` key): <https://github.com/Jaguaza/Neon-Cards/actions/runs/31918864706>
Link to successful hassfest action (if integration): <N/A — this is a plugin (Lovelace frontend card), not an integration>
<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->