### PR TITLE
Adds new integration [mkappsch/ha-precipitation-watch]

### DIFF
--- a/integration
+++ b/integration
@@ -1931,6 +1931,7 @@
   "MislavMandaric/home-assistant-vaillant-vsmart",
   "miyosmart/miyocube-homeassistant-custom-component",
   "mjcumming/wiim",
+  "mkappsch/ha-precipitation-watch",
   "mkirsten/lydbro-hass",
   "MKSG-MugunthKumar/ha-chameleon",
   "MKsys1337/MiWiFi-CB0401V2",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: https://github.com/mkappsch/ha-precipitation-watch/releases/tag/v0.2.0
Link to successful HACS action (without the `ignore` key): https://github.com/mkappsch/ha-precipitation-watch/actions/runs/31972186223/job/95226199492
Link to successful hassfest action (if integration): https://github.com/mkappsch/ha-precipitation-watch/actions/runs/31972186223/job/95226199517