### PR TITLE
Adds new integration [eigger/hass-ws-bridge]

### DIFF
--- a/integration
+++ b/integration
@@ -874,6 +874,7 @@
   "EHylands/ha-qolsys-panel",
   "eifinger/hass-foldingathomecontrol",
   "eifinger/hass-weenect",
+  "eigger/hass-ws-bridge",
   "einFreak/ha-regensburg-transport",
   "einToast/openai_stt_ha",
   "EiS94/db_info",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: https://github.com/eigger/hass-ws-bridge/releases/tag/1.4.6
Link to successful HACS action (without the `ignore` key): https://github.com/eigger/hass-ws-bridge/actions/runs/31986472916/job/95262256292
Link to successful hassfest action (if integration): https://github.com/eigger/hass-ws-bridge/actions/runs/31986472916/job/95262256340

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->