### PR TITLE
Adds new integration [morelinks-iot/ml-home-assistant]

### DIFF
--- a/integration
+++ b/integration
@@ -1951,6 +1951,7 @@
   "monty68/uniled",
   "moox-it/hass-moox-track",
   "moralmunky/Home-Assistant-Mail-And-Packages",
+  "morelinks-iot/ml-home-assistant",
   "morosanmihail/HA-LondonTfL",
   "morotsgurka/garo-gctrl-homeassistant",
   "MortUK/Aferiy-PS240-Local-",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/morelinks-iot/ml-home-assistant/releases/tag/v0.1.0>
Link to successful HACS action (without the `ignore` key): <https://github.com/morelinks-iot/ml-home-assistant/actions/runs/31998465077/job/95294278936>
Link to successful hassfest action (if integration): <https://github.com/morelinks-iot/ml-home-assistant/actions/runs/31998465077/job/95294278869>

The change adds `morelinks-iot/ml-home-assistant` to `integration` in alphabetical order. The repository is public, the release is a full non-prerelease release, and the integration was installed and reconnected successfully from HACS Custom Repository before release creation.