### PR TITLE
Add datetime picker card to plugin dependencies

### DIFF
--- a/plugin
+++ b/plugin
@@ -731,5 +731,6 @@
   "zanac/temperature-heatmap-card",
   "zanna-37/hass-swipe-navigation",
   "Zarvinx/statistics-table-card",
-  "zeronounours/lovelace-energy-entity-row"
+  "zeronounours/lovelace-energy-entity-row",
+  "akhtar-waseem/lovelace-datetime-picker-card"
 ]


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [ ] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [ ] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [ ] The actions are passing without any disabled checks in my repository.
- [ ] I've added a link to the action run on my repository below in the links section.
- [ ] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: https://github.com/akhtar-waseem/lovelace-datetime-picker-card/releases#release-v0.1.0
Link to successful HACS action (without the `ignore` key): https://github.com/akhtar-waseem/lovelace-datetime-picker-card/actions/runs/32004643445
Link to successful hassfest action (if integration): NA, lovelace card

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->