### PR TITLE
Add prestomation/ha-home-keeper

### DIFF
--- a/integration
+++ b/integration
@@ -2295,6 +2295,7 @@
   "prairiesnpr/hass-tdameritrade",
   "pranjal-joshi/moodlights",
   "PrayerZone/prayer-times-home-assistant",
+  "prestomation/ha-home-keeper",
   "prestomation/resmed_myair_sensors",
   "prezervos/goodwe-wallbox-sems-home-assistant",
   "PrimeAutomation/petnovations",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: https://github.com/prestomation/ha-home-keeper/releases/tag/v0.13.0
Link to successful HACS action (without the `ignore` key): https://github.com/prestomation/ha-home-keeper/actions/runs/32011236714
Link to successful hassfest action (if integration): https://github.com/prestomation/ha-home-keeper/actions/runs/32011236690