### PR TITLE
Add new integration 'bkflatekvaal/ha-swetrack'

### DIFF
--- a/integration
+++ b/integration
@@ -375,6 +375,7 @@
   "bkbilly/Routario-ha",
   "bkbilly/seismoi",
   "bkbilly/tpms_ble",
+  "bkflatekvaal/ha-swetrack",
   "blaineventurine/simple_inventory",
   "blakeblackshear/frigate-hass-integration",
   "blear/hasslife",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/bkflatekvaal/ha-swetrack/releases/tag/v0.2.7>
Link to successful HACS action (without the `ignore` key): <https://github.com/bkflatekvaal/ha-swetrack/actions/runs/32100695096/job/95600473177>
Link to successful hassfest action (if integration): <https://github.com/bkflatekvaal/ha-swetrack/actions/runs/32100695096/job/95600473168>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->