### PR TITLE
Add new integration for HGSmart

### DIFF
--- a/integration
+++ b/integration
@@ -709,6 +709,7 @@
   "ddanssaert/home-assistant-ipcamlive",
   "ddebaets/belgium-energy-costs",
   "ddrimus/ha-tper-tracker",
+  "Dead96/hgsmart-ha-integration",
   "deadbeef3137/ha-cloudflare-tunnel-monitor",
   "DeadmaroZ-TLOTL/ha-renault-zoe-smart-charger",
   "deanlongstaff/home-assistant-moodo-integration",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/Dead96/hgsmart-ha-integration/releases/tag/v0.2.1>
Link to successful HACS action (without the `ignore` key): <https://github.com/Dead96/hgsmart-ha-integration/actions/runs/32114675914>
Link to successful hassfest action (if integration): <https://github.com/Dead96/hgsmart-ha-integration/actions/runs/32114675931>