### PR TITLE
Add Kaldanetus/HomeAssistant_NeoRe

### DIFF
--- a/integration
+++ b/integration
@@ -1509,6 +1509,7 @@
   "Kahera/HA_pollen_forecast",
   "Kajkac/ZTE-MC-Home-assistant-repo",
   "kalanda/homeassistant-aemet-sensor",
+  "Kaldanetus/HomeAssistant_NeoRe",
   "Kaluzaburza/Hoymiles_HIT_xxL_G3_ModBus",
   "kamaradclimber/datadog-integration-ha",
   "kamaradclimber/geovelo-homeassistant",


### PR DESCRIPTION
Adds the `HomeAssistant_NeoRe` integration (NeoRé heat pump for Home Assistant) by [@Kaldanetus](https://github.com/Kaldanetus): https://github.com/Kaldanetus/HomeAssistant_NeoRe

This repository meets the HACS default repository requirements:
- Public, not a fork, not archived
- Has a repository description
- Licensed under MIT
- Has GitHub topics set (`home-assistant`, `hacs-integration`, `home-assistant-integration`)
- Valid `hacs.json` (includes `name`) and valid `custom_components/neore/manifest.json`
- Has a published GitHub Release (tag `v0.4.3`)
- Passes hassfest and hacs/action validation (CI green)

---
_Generated by [Claude Code](https://claude.ai/code/session_018Bm9j854uas6MWtJKwSiRP)_