### PR TITLE
Adds new plugin [badboiaustria/dynamic-radiocard]

### DIFF
--- a/plugin
+++ b/plugin
@@ -41,6 +41,7 @@
   "axelfair/seasonclock",
   "azuwis/zigbee2mqtt-networkmap",
   "badbadtrip/aqara-feeder-card",
+  "badboiaustria/dynamic-radiocard",
   "badguy99/PlantPictureCard",
   "Barma-lej/landroid-card",
   "bbbenji/synthwave-hass-extras",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: https://github.com/badboiaustria/dynamic-radiocard/releases/tag/v3.0.1
Link to successful HACS action (without the `ignore` key): https://github.com/badboiaustria/dynamic-radiocard/actions/runs/32189753651
Link to successful hassfest action (if integration): N/A (Lovelace plugin, not an integration)

## Repository

https://github.com/badboiaustria/dynamic-radiocard

## Description

3D cover-flow media browser for Music Assistant: radio stations, podcasts, tracks, albums and artists in a single Lovelace card. Per-category provider filter (Spotify, TuneIn, RadioBrowser, Apple Music, local files and more), grid view, automatic player discovery with a player picker, transport bar with volume, and a direct WebSocket connection to Music Assistant (ingress-compatible, works over HTTPS/Nabu Casa) with a browse_media fallback. English and German UI, auto-detected from the HA user profile. No dependencies - a single vanilla web component; runs well on wall displays including the smallest Shelly Wall Displays.
