### PR TITLE
Add volanddemoor/cozylife_relay_light

### DIFF
--- a/integration
+++ b/integration
@@ -2976,6 +2976,7 @@
   "vmarkovtsev/sistena_onix_ha",
   "vmvelev/home-assistant-toshiba_ac",
   "VoidElle/hass-open-tecnosystemi",
+  "volanddemoor/cozylife_relay_light",
   "VolantisDev/ha-aquanta",
   "voldemarpanso/ha_hailolibero",
   "volschin/Danfoss-TLX-2-HA",


### PR DESCRIPTION
Adds a new integration: CozyLife Relay Light — a minimal Home Assistant integration for controlling lighting through a CozyLife WiFi mini relay installed in a flush-mount/wall box, over its local TCP/JSON protocol (no cloud).

Repo: https://github.com/volanddemoor/cozylife_relay_light