### PR TITLE
Adds new integration [Kraken-Labz/octopus-media-card]

### DIFF
--- a/integration
+++ b/integration
@@ -1609,6 +1609,7 @@
   "kpoppel/homeassistant-eforsyning",
   "kpoppel/homeassistant-novafos",
   "krahabb/meross_lan",
+  "Kraken-Labz/octopus-media-card",
   "kramttocs/ha-blueiris",
   "kramttocs/ha-gluetun",
   "krasnoukhov/homeassistant-nova-poshta",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/Kraken-Labz/octopus-media-card/releases/tag/v0.1.0>
Link to successful HACS action (without the `ignore` key): <https://github.com/Kraken-Labz/octopus-media-card/actions/runs/32213360613/job/95950196811>
Link to successful hassfest action (if integration): <https://github.com/Kraken-Labz/octopus-media-card/actions/runs/32213360613/job/95950196811>

## Repository

- Repository: https://github.com/Kraken-Labz/octopus-media-card
- Release: v0.1.0
- Submitter: @phgsbr, owner and major contributor of the project.
- The repository is public and the release is not a draft or prerelease.
- The integration uses local Home Assistant branding under `custom_components/octopus_media/brand/`; no separate `home-assistant/brands` submission is included.

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->
