### PR TITLE
Adds new plugin [anym001/ha-mos-card]

### DIFF
--- a/plugin
+++ b/plugin
@@ -32,6 +32,7 @@
   "andyblac/Orbit-Cards",
   "Anonym-tsk/lovelace-starline-card",
   "Anrolosia/Shopping-List-with-Grocy-Card",
+  "anym001/ha-mos-card",
   "arallsopp/hass-hue-icons",
   "argaar/comfortable-environment-card",
   "artem-sedykh/mini-climate-card",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after die validation actions were run successfully.

## Links

Link to current release: <https://github.com/anym001/ha-mos-card/releases/tag/v0.2.0>
Link to successful HACS action (without the `ignore` key): <https://github.com/anym001/ha-mos-card/actions/runs/32202761543>
Link to successful hassfest action (if integration): not applicable, this is a plugin

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->
