### PR TITLE
Add Kaldanetus/HomeAssistant_NeoRe integration

### DIFF
--- a/integration
+++ b/integration
@@ -1509,6 +1509,7 @@
   "Kahera/HA_pollen_forecast",
   "Kajkac/ZTE-MC-Home-assistant-repo",
   "kalanda/homeassistant-aemet-sensor",
+  "Kaldanetus/HomeAssistant_NeoRe",
   "Kaluzaburza/Hoymiles_HIT_xxL_G3_ModBus",
   "kamaradclimber/datadog-integration-ha",
   "kamaradclimber/geovelo-homeassistant",


### PR DESCRIPTION
Adds `Kaldanetus/HomeAssistant_NeoRe` to the HACS default integration list.

HomeAssistant_NeoRe is a custom integration for Home Assistant for the NeoRé heat pump.
GitHub: https://github.com/Kaldanetus/HomeAssistant_NeoRe
Current release: v0.4.4

The repository meets the HACS default repository requirements:
- Public, not a fork, not archived
- Has a repository description
- MIT license
- GitHub topics set: `home-assistant`, `hacs-integration`, `home-assistant-integration`
- Valid `hacs.json` (contains `name`) and valid `custom_components/neore/manifest.json`
- Published GitHub Release with tag `v0.4.4`
- Passes hassfest and hacs/action validation (CI green on main, commit `c58699d`)

## Checklist

- [x] I've read the publishing documentation (https://hacs.xyz/docs/publish/start).
- [x] I've added the HACS action (https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the hassfest action (https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: https://github.com/Kaldanetus/HomeAssistant_NeoRe/releases/tag/v0.4.4
Link to successful HACS action (without the ignore key): https://github.com/Kaldanetus/HomeAssistant_NeoRe/actions/runs/31924660972
Link to successful hassfest action (if integration): https://github.com/Kaldanetus/HomeAssistant_NeoRe/actions/runs/31924660972