### PR TITLE
Adds new integration [johan71gent/ha-capacity-tariff]

### DIFF
--- a/integration
+++ b/integration
@@ -1453,6 +1453,7 @@
   "jobvk/Home-Assistant-Windcentrale",
   "joemcc-90/leeds-bins-hass",
   "joggs/home_assistant_ebeco",
+  "johan71gent/ha-capacity-tariff",
   "JohanAlvedal/PumpSteer",
   "Johann11T/ha-tplink-deco-panel",
   "johannesWen/KEBA-Heat-Pump-Modbus-Integration",

--- a/integration
+++ b/integration
@@ -1421,6 +1421,7 @@
   "jobvk/Home-Assistant-Windcentrale",
   "joemcc-90/leeds-bins-hass",
   "joggs/home_assistant_ebeco",
+  "johan71gent/ha-capacity-tariff",
   "JohanAlvedal/PumpSteer",
   "Johann11T/ha-tplink-deco-panel",
   "johannesWen/KEBA-Heat-Pump-Modbus-Integration",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/johan71gent/ha-capacity-tariff/releases/tag/v0.2.0>
Link to successful HACS action (without the `ignore` key): <https://github.com/johan71gent/ha-capacity-tariff/actions/runs/32261131965/job/96094404985>
Link to successful hassfest action (if integration): <https://github.com/johan71gent/ha-capacity-tariff/actions/runs/32261131965/job/96094404417>

## Description

Capacity tariff (capaciteitstarief) guard for Flanders, Belgium: monitors the monthly quarter-hour peak from any P1 integration (DSMR, HomeWizard, ESPHome...), forecasts the running quarter, exposes the remaining power margin and "peak at risk" / "peak will be exceeded" binary sensors for load shedding, cost sensors with the official per-area tariff table, history import services, blueprints, NL/EN, local brand images, diagnostics and tests.