### PR TITLE
Adds new integration [kubickasa/ecoservice_waste_collection]

### DIFF
--- a/integration
+++ b/integration
@@ -1622,6 +1622,7 @@
   "ksanislo/honda_generator",
   "ksanislo/senso4s_ble",
   "kubawolanin/ha-reaper",
+  "kubickasa/ecoservice_waste_collection",
   "kuchel77/diskspace",
   "kukulich/home-assistant-jablotron100",
   "kuvasz-uptime/ku-hass",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/kubickasa/ecoservice_waste_collection/releases/tag/1.0.0>
Link to successful HACS action (without the `ignore` key): <https://github.com/kubickasa/ecoservice_waste_collection/actions/runs/32273146004/job/96134164809>
Link to successful hassfest action (if integration): <https://github.com/kubickasa/ecoservice_waste_collection/actions/runs/32273146004/job/96134165341>

## Repository eligibility

- I am the repository owner and primary author.
- The repository is public and can be installed as a HACS custom repository.
- HACS validation passes without an `ignore` key, and Hassfest passes.
- A full public GitHub Release (`1.0.0`) is published.
- The released `hacs.json` contains `"country": "LT"`.
- This integration is not an alpha or beta replacement for an official Home Assistant integration.

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->