### PR TITLE
Add S1 Ergani integration

### DIFF
--- a/integration
+++ b/integration
@@ -2935,6 +2935,7 @@
   "v1ack/lelight",
   "v1k70rk4/HASS.Agent.NET10-Integration",
   "V4n1X/ha_stromgedacht",
+  "vagelisdermos/s1_ergani",
   "vaind/ha-shmu",
   "vakio-ru/vakio_atmosphere",
   "vakio-ru/vakio_base_smart",


### PR DESCRIPTION
Adds the S1 Ergani Home Assistant integration to HACS.

Repository:
https://github.com/vagelisdermos/s1_ergani

The integration has passed:
- HACS validation
- Hassfest validation
- GitHub release v0.1.0