### PR TITLE
Adds new integration [kkilchrist/ha-color-ext]

### DIFF
--- a/integration
+++ b/integration
@@ -1563,6 +1563,7 @@
   "KiraPC/ha-switchbot-remote",
   "kirei/hass-chargeamps",
   "kirill-k2/hass-guk-krasnodar",
+  "kkilchrist/ha-color-ext",
   "klacol/homeassistant-clage_homeserver",
   "klaptafel/ha-previous-state-tracker",
   "klatka/nc-talk-bot-component",


### PR DESCRIPTION
A reusable color value as a Home Assistant helper entity — like `input_number` or `input_boolean`, but the value is a color.

## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: https://github.com/kkilchrist/ha-color-ext/releases/tag/v0.2.0
Link to successful HACS action (without the `ignore` key): https://github.com/kkilchrist/ha-color-ext/actions/runs/32204957332/job/95926270089
Link to successful hassfest action (if integration): https://github.com/kkilchrist/ha-color-ext/actions/runs/32204957332/job/95926270073
