### PR TITLE
Adds new plugin [kkilchrist/ha-color-ext-card]

### DIFF
--- a/plugin
+++ b/plugin
@@ -346,6 +346,7 @@
   "KipK/openevse-card",
   "kirbo/ha-lovelace-elapsed-time-card",
   "kizza/magic-home-party-card",
+  "kkilchrist/ha-color-ext-card",
   "konnectedvn/lovelace-vertical-slider-cover-card",
   "Korkuttum/xiaomi_air_purifier_card",
   "kratochj/hassio-irrigation-card",


### PR DESCRIPTION
A Lovelace card for the `color` helper integration ([kkilchrist/ha-color-ext](https://github.com/kkilchrist/ha-color-ext), submitted separately in #10139): color swatch + picker with a chromatic/white toggle and kelvin slider.

## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: https://github.com/kkilchrist/ha-color-ext-card/releases/tag/v0.1.1
Link to successful HACS action (without the `ignore` key): https://github.com/kkilchrist/ha-color-ext-card/actions/runs/32312378721/job/96257817548
Link to successful hassfest action (if integration): n/a (plugin)
