### PR TITLE
Mount candidate integration under custom_components for hassfest

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -218,7 +218,7 @@ jobs:
           integration=$(python3 -m scripts.helpers.integration_path)
           domain=$(python3 -m scripts.helpers.domain)
           docker run --rm \
-            -v "$integration":"/github/workspace/$domain" \
+            -v "$integration":"/github/workspace/custom_components/$domain" \
             ghcr.io/home-assistant/hassfest:latest
 
   hacs:


### PR DESCRIPTION
## The problem

Every integration PR is currently failing the `Hassfest` job:

```
Status: Downloaded newer image for ghcr.io/home-assistant/hassfest:latest
Error: No integrations found!
##[error]Process completed with exit code 1.
```

Plugin, theme and other categories are unaffected, because `Hassfest` only runs for integrations. The clearest illustration is one author with both kinds open on 2026-08-19: their integration PR failed at 23:09 and their plugin PR passed at 23:15.

Affected runs seen so far, all `Adds new integration`, earliest 2026-08-19T22:32:

- `eman/ha_nwp500` (run 32342278516)
- `vagelisdermos/s1_ergani` (twice)
- `warden-nz/warden-ha` (run 32333785774)
- `eigger/hass-sip`
- `yosef-chai/needle-assist-he`
- `kkilchrist/ha-color-ext`
- `HerrHaseGermany/HA-Wallpanel`

Nothing is wrong with any of those repositories.

## The cause

`ghcr.io/home-assistant/hassfest:latest` is unpinned, and its entrypoint changed. Up to and including 2026.8.0, `script/hassfest/docker/entrypoint.sh` discovered manifests with an unrestricted search:

```sh
# Enable recursive globbing using find
for manifest in $(find . -name "manifest.json"); do
```

Current `dev` narrows that to the two documented custom integration locations:

```sh
# Manifest discovery is limited to the two documented custom-integration
# locations rather than anywhere in the repo, to avoid misvalidating
# unrelated files that happen to share the filename.
manifests=$(
    { [ -d custom_components ] && find custom_components -mindepth 2 -maxdepth 2 -name "manifest.json"
      find . -maxdepth 1 -name "manifest.json"; } 2>/dev/null
)
```

We mount the cloned integration at `/github/workspace/$domain`, so inside the container the manifest sits at `/github/workspace/<domain>/manifest.json`. That is neither `custom_components/*/manifest.json` nor `./manifest.json`, so discovery returns nothing and the entrypoint exits 1.

## The fix

Mount one level deeper, under `custom_components`, which is the first documented location and also mirrors how the integration actually ships to users.

Running the entrypoint's own discovery logic against both layouts:

| Layout | Old entrypoint | New entrypoint |
|---|---|---|
| `/github/workspace/$domain` (today) | found | **No integrations found!** |
| `/github/workspace/custom_components/$domain` (this PR) | found | found |

The `$domain` directory name is preserved, so hassfest still validates that the folder name matches the manifest domain.

## Note on pinning

Leaving `:latest` unpinned is what allowed an upstream entrypoint change to break this repository's CI without any change on our side. Pinning to a released tag would be worth considering separately, but this PR keeps the change minimal and restores the check to working order.

../Frenck  
<p>
  <a href="https://www.linkedin.com/in/frenck/"><img src="https://github.com/frenck/frenck/raw/main/images/linkedin.svg" width="18" height="18"></a>
  &nbsp;&nbsp;
  <a href="https://youtube.com/@frenck"><img src="https://github.com/frenck/frenck/raw/main/images/youtube.svg" width="18" height="18"></a>
  &nbsp;&nbsp;
  <a href="https://bsky.app/profile/frenck.social"><img src="https://github.com/frenck/frenck/raw/main/images/bluesky.svg" width="18" height="18"></a>
  &nbsp;&nbsp;
  <a href="https://fosstodon.org/@frenck"><img src="https://github.com/frenck/frenck/raw/main/images/mastodon.svg" width="18" height="18"></a>
  &nbsp;&nbsp;
  <a href="https://www.instagram.com/frenck/"><img src="https://github.com/frenck/frenck/raw/main/images/instagram.svg" width="18" height="18"></a>
  &nbsp;&nbsp;
  <a href="https://www.threads.net/@frenck"><img src="https://github.com/frenck/frenck/raw/main/images/threads.svg" width="18" height="18"></a>
  &nbsp;&nbsp;
  <a href="https://www.facebook.com/frenck.dev/"><img src="https://github.com/frenck/frenck/raw/main/images/facebook.svg" width="18" height="18"></a>
  &nbsp;&nbsp;
  <a href="https://x.com/frenck"><img src="https://github.com/frenck/frenck/raw/main/images/x.svg" width="18" height="18"></a>
  &nbsp;&nbsp;
  <a href="https://www.tiktok.com/@frenck.nl"><img src="https://github.com/frenck/frenck/raw/main/images/tiktok.svg" width="18" height="18"></a>
</p>
Blogging my personal ramblings at <a href="https://frenck.dev">frenck.dev</a>