### PR TITLE
Adds new plugin [Xerolux/heatpump-flow-card]

### DIFF
--- a/plugin
+++ b/plugin
@@ -723,6 +723,7 @@
   "xBourner/calendar-card-plus",
   "xBourner/header-position-card",
   "xBourner/status-card",
+  "Xerolux/heatpump-flow-card",
   "xplanes/ha-plant-diary-card",
   "Yeelight/ha_yeelight_dashboard",
   "yohaybn/lovelace-aliexpress-package-card",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the hassfest action to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: https://github.com/Xerolux/heatpump-flow-card/releases/tag/v1.6.1
Link to successful HACS action (without the `ignore` key): https://github.com/Xerolux/heatpump-flow-card/actions/runs/32344245043/job/96349482098
Link to successful hassfest action (if integration): n/a — this is a dashboard plugin, not an integration