### PR TITLE
Add hercozandwijk/wattwanneer-homeassistant

### DIFF
--- a/integration
+++ b/integration
@@ -1192,6 +1192,7 @@
   "HenkieThee/clash_royale",
   "henricm/ha-ferroamp",
   "hepter/ha-elegoo-spaghetti-detection",
+  "hercozandwijk/wattwanneer-homeassistant",
   "herikw/home-assistant-custom-components",
   "Hermesiss/itchio_homeassistant",
   "herruzo99/ista-calista",


### PR DESCRIPTION
Adds the WattWanneer integration for Dutch dynamic electricity prices.

**Repository:** https://github.com/hercozandwijk/wattwanneer-homeassistant

WattWanneer provides an hourly electricity price forecast for the Netherlands up to seven days ahead. Where day-ahead sources stop at tomorrow, this integration lets automations pick the cheapest block of the week, which matters for anything that does not need to run every day: EV charging, home batteries, heat pumps and boilers.

It creates seven sensors: current price, next hour price, average, lowest and highest of today, the cheapest consecutive window, and the week average with the full 168-hour series as an attribute.

**Checklist**

- Public repository, added successfully as a custom repository
- HACS action passes
- Hassfest passes
- Brand assets present at `custom_components/wattwanneer/brand/icon.png`
- Full GitHub release published: v0.1.0
- Topics and description set
- Issues enabled

Tested against Home Assistant 2026.8.2: config flow (valid key, invalid key, duplicate key), all sensors with live data, and a full restart. Sixteen unit tests cover error handling, including an unreachable API. CI also runs weekly against the latest Home Assistant release.