### PR TITLE
Add hercozandwijk/wattwanneer-homeassistant

### DIFF
--- a/integration
+++ b/integration
@@ -1192,6 +1192,7 @@
   "HenkieThee/clash_royale",
   "henricm/ha-ferroamp",
   "hepter/ha-elegoo-spaghetti-detection",
+  "hercozandwijk/wattwanneer-homeassistant",
   "herikw/home-assistant-custom-components",
   "Hermesiss/itchio_homeassistant",
   "herruzo99/ista-calista",


### PR DESCRIPTION
Adds the WattWanneer integration for Dutch dynamic electricity prices.

## Links

- Repository: https://github.com/hercozandwijk/wattwanneer-homeassistant
- Latest release: https://github.com/hercozandwijk/wattwanneer-homeassistant/releases/tag/v0.1.0
- CI action runs: https://github.com/hercozandwijk/wattwanneer-homeassistant/actions/runs/32350404843

## Checklist

- [x] The repository is public and hosted on GitHub
- [x] The repository can be added as a custom repository in HACS
- [x] The HACS action passes without errors
- [x] The hassfest action passes without errors
- [x] A full GitHub release has been published after the actions ran successfully
- [x] Brand assets are present at `custom_components/wattwanneer/brand/icon.png`
- [x] The repository has topics and a description
- [x] Issues are enabled on the repository
- [x] The entry is added to the correct file and sorted alphabetically

## About the integration

WattWanneer provides an hourly electricity price forecast for the Netherlands up to seven days ahead. Where day-ahead sources stop at tomorrow, this integration lets automations pick the cheapest block of the week, which matters for anything that does not have to run every day: EV charging, home batteries, heat pumps and boilers.

It creates seven sensors: current price, next hour price, average, lowest and highest of today, the cheapest consecutive window, and the week average with the full 168-hour series as an attribute.

Tested against Home Assistant 2026.8.2: config flow (valid key, invalid key, duplicate key), all sensors with live data, and a full restart. Sixteen unit tests cover error handling, including an unreachable API. CI also runs weekly against the latest Home Assistant release, so a breaking change upstream surfaces before users hit it.
