### PR TITLE
Adds new integration [hercozandwijk/wattwanneer-homeassistant]

### DIFF
--- a/integration
+++ b/integration
@@ -1192,6 +1192,7 @@
   "HenkieThee/clash_royale",
   "henricm/ha-ferroamp",
   "hepter/ha-elegoo-spaghetti-detection",
+  "hercozandwijk/wattwanneer-homeassistant",
   "herikw/home-assistant-custom-components",
   "Hermesiss/itchio_homeassistant",
   "herruzo99/ista-calista",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/hercozandwijk/wattwanneer-homeassistant/releases/tag/v0.1.0>
Link to successful HACS action (without the `ignore` key): <https://github.com/hercozandwijk/wattwanneer-homeassistant/actions/runs/32350404843/job/96368129063>
Link to successful hassfest action (if integration): <https://github.com/hercozandwijk/wattwanneer-homeassistant/actions/runs/32350404843/job/96368129083>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->

## About

[WattWanneer](https://github.com/hercozandwijk/wattwanneer-homeassistant) provides an hourly electricity price forecast for the Netherlands up to seven days ahead. Where day-ahead sources stop at tomorrow, this lets automations pick the cheapest block of the week, which matters for anything that does not have to run every day: EV charging, home batteries, heat pumps and boilers.

Seven sensors: current price, next hour price, average, lowest and highest of today, the cheapest consecutive window, and the week average with the full 168-hour series as an attribute.
