### PR TITLE
Adds new plugin [semichcsc-byte/ha-countdown-card]

### DIFF
--- a/plugin
+++ b/plugin
@@ -589,6 +589,7 @@
   "seevee/weather_alerts_card",
   "selvalt7/badge-horizontal-container-card",
   "selvalt7/modern-circular-gauge",
+  "semichcsc-byte/ha-countdown-card",
   "Sese-Schneider/ha-energy-overview-card",
   "ShadowAya/anchor-card",
   "shadowsight00/aio-light-controller-card",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/semichcsc-byte/ha-countdown-card/releases/tag/v1.9.5>
Link to successful HACS action (without the `ignore` key): <https://github.com/semichcsc-byte/ha-countdown-card/actions/runs/32359533428/job/96395939667>
Link to successful hassfest action (if integration): n/a, this is a plugin
