### PR TITLE
Adds new integration [DjangoToni/home-assistant-portfolio-tracker]

### DIFF
--- a/integration
+++ b/integration
@@ -778,6 +778,7 @@
   "DiUS/homeassistant-powersensor",
   "Dixet/homeassistant_geopulse",
   "Dixet/homeassistant_hetzner",
+  "DjangoToni/home-assistant-portfolio-tracker",
   "djansen1987/SAJeSolar",
   "djbios/home-assistant-cat-scale",
   "djbulsink/panasonic_ac",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/DjangoToni/home-assistant-portfolio-tracker/releases/tag/v1.4.2>
Link to successful HACS action (without the `ignore` key): <https://github.com/DjangoToni/home-assistant-portfolio-tracker/actions/runs/32374830575/job/96443597774>
Link to successful hassfest action (if integration): <https://github.com/DjangoToni/home-assistant-portfolio-tracker/actions/runs/32374830575/job/96443597444>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->