### PR TITLE
Adds new integration [jc22zhao/HA-Nuheat-Conductor]

### DIFF
--- a/integration
+++ b/integration
@@ -1367,6 +1367,7 @@
   "jazzz/ha-evocarshare",
   "jbergler/hass-ttlock",
   "jbouwh/ha-elro-connects",
+  "jc22zhao/HA-Nuheat-Conductor",
   "jcgoette/baby_buddy_homeassistant",
   "jcwillox/hass-auto-backup",
   "jdejaegh/irm-kmi-ha",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/jc22zhao/HA-Nuheat-Conductor/releases/tag/v1.0.1>
Link to successful HACS action (without the `ignore` key): <https://github.com/jc22zhao/HA-Nuheat-Conductor/actions/runs/32371927200>
Link to successful hassfest action (if integration): <https://github.com/jc22zhao/HA-Nuheat-Conductor/actions/runs/32371927200>

## About this integration

Home Assistant integration for nVent Nuheat thermostats on the **Conductor cloud platform**, covering both Conductor and Signature hardware.

Context for why this is worth listing: nVent retired the legacy `mynuheat.com` API (the hostname no longer resolves) and migrated Signature accounts onto the Conductor platform. Home Assistant core's built-in `nuheat` integration is pinned to the `nuheat` PyPI library, last released January 2023, which still targets that dead host — so it can no longer authenticate for any user. This integration talks to the current OAuth2/SignalR API and is currently the only working option for these thermostats.

This is a maintained fork of [SmilesGalore/HA-Nuheat-Conductor](https://github.com/SmilesGalore/HA-Nuheat-Conductor), whose author stepped back after losing access to Nuheat hardware and invited a handoff in their README. I maintain it against a live Signature thermostat, so changes can be tested on real hardware.
