### PR TITLE
Add strickdd/ImmichRandomImage to integration

### DIFF
--- a/integration
+++ b/integration
@@ -2729,6 +2729,7 @@
   "strepto42/foobar2k_custom_component",
   "strepto42/homeassistant-esptimecast",
   "strepto42/TeslaBluetoothSolarCharger",
+  "strickdd/ImmichRandomImage",
   "Strixx76/mold_risk_index",
   "Strixx76/samsungwam",
   "strongbugman/ha-octopusenergy-oejp",


### PR DESCRIPTION
## Adding a new default repository

### Repository
[strickdd/ImmichRandomImage](https://github.com/strickdd/ImmichRandomImage)

### Category
Integration

### Description
Custom Home Assistant integration that displays random images from an Immich v3+ instance on dashboards. Uses the current `/api/search/random` endpoint. Created as a fresh implementation after the previous `outadoc/immich-home-assistant` integration broke when Immich changed their API in v3.

### Checklist

- [x] I am the owner of the repository
- [x] The repository is public on GitHub
- [x] The repository has a description
- [x] The repository has topics defined
- [x] The repository has issues enabled
- [x] HACS Action passes (category: integration)
- [x] Hassfest passes
- [x] The repository has at least one GitHub release (not just a tag)
- [x] The entry is added alphabetically (not at the end)
- [x] This PR is submitted from a personal fork, not an organization account
- [x] This PR is submitted from a new branch (not master)

### Verification

- HACS Action: [passing](https://github.com/strickdd/ImmichRandomImage/actions/workflows/hacs.yml)
- Hassfest: [passing](https://github.com/strickdd/ImmichRandomImage/actions/workflows/hassfest.yml)
- Latest release: [v1.2.3](https://github.com/strickdd/ImmichRandomImage/releases/tag/v1.2.3)
- Brand assets: `custom_components/immich_random/brand/icon.png`
- hacs.json: present with name + render_readme