### PR TITLE
Add sourcesoldier/Abfallkalender-RTK

### DIFF
--- a/integration
+++ b/integration
@@ -2693,6 +2693,7 @@
   "soulripper13/speedtest_rt_ru",
   "soundstorm/aha_trash",
   "SourceLabOrg/HomeAssistant-PVOutputPublisher",
+  "sourcesoldier/Abfallkalender-RTK",
   "spagonic/ha-hi3510",
   "SpanPanel/span",
   "spatecon/orcommconnect",


### PR DESCRIPTION
Adds the [Abfallkalender RTK](https://github.com/sourcesoldier/Abfallkalender-RTK) integration.

Reads the yearly Eltville / Rheingau-Taunus-Kreis (RTK) waste-collection PDF and exposes it as a Home Assistant calendar plus per-bin sensors, with automatic year rollover and failure alerting.

- Category: integration
- Config flow: yes
- Release: v0.1.0
- HACS + hassfest validation passing
- Brand assets: home-assistant/brands#11016 (plus local brand/ fallback)