### PR TITLE
Add matuszeg/pumpspy-local

### DIFF
--- a/integration
+++ b/integration
@@ -1888,6 +1888,7 @@
   "MattieGit/qube_heatpump",
   "mattrayner/pod-point-home-assistant-component",
   "MattXcz/CEZ",
+  "matuszeg/pumpspy-local",
   "MauroDruwel/Weathercloud-HA",
   "mawinkler/astroweather",
   "maxbeizer/homeassistant-nes",


### PR DESCRIPTION
Adds https://github.com/matuszeg/pumpspy-local as an integration.

Local, cloud-free Home Assistant monitoring for PumpSpy and Richtech PitBoss+
sump pump battery backup systems. These monitors report telemetry to a vendor
cloud over unencrypted HTTP; this integration receives that traffic on the
user's own network, creates entities from it, and forwards the original requests
upstream unmodified so the vendor's own app keeps working. No vendor account, no
credentials handled, no polling.

I am the repository owner.

- Public, described, topics set, issues enabled, MIT licensed
- `hacs.json` present; `manifest.json` has version, documentation, issue_tracker
  and codeowners
- Released: [v0.1.0](https://github.com/matuszeg/pumpspy-local/releases/tag/v0.1.0)
- Brand images ship with the integration in `custom_components/pumpspy_local/brand/`,
  per the [2026.3 change](https://developers.home-assistant.io/blog/2026/02/24/brands-proxy-api)
  that retired custom integration icons from home-assistant/brands
- The HACS action and hassfest both run on every push and pass:
  https://github.com/matuszeg/pumpspy-local/actions/workflows/validate.yml

The entry is inserted in case-insensitive alphabetical order; the diff is a
single added line.