### PR TITLE
Adds new integration [matuszeg/pumpspy-local]

### DIFF
--- a/integration
+++ b/integration
@@ -1888,6 +1888,7 @@
   "MattieGit/qube_heatpump",
   "mattrayner/pod-point-home-assistant-component",
   "MattXcz/CEZ",
+  "matuszeg/pumpspy-local",
   "MauroDruwel/Weathercloud-HA",
   "mawinkler/astroweather",
   "maxbeizer/homeassistant-nes",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/matuszeg/pumpspy-local/releases/tag/v0.1.0>
Link to successful HACS action (without the `ignore` key): <https://github.com/matuszeg/pumpspy-local/actions/runs/32486906209/job/96785373824>
Link to successful hassfest action (if integration): <https://github.com/matuszeg/pumpspy-local/actions/runs/32486906209/job/96785373561>

## About

Local, cloud-free Home Assistant monitoring for PumpSpy and Richtech PitBoss+
sump pump battery backup systems. These monitors report telemetry to a vendor
cloud over unencrypted HTTP; this integration receives that traffic on the
user's own network, creates entities from it, and forwards the original requests
upstream unmodified so the vendor's own app keeps working. No vendor account, no
credentials handled, no polling.

I am the repository owner. The entry is inserted in case-insensitive
alphabetical order and the diff is a single added line.

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->