### PR TITLE
Adds new integration [MadMatt34/ha-freebox-caller-id]

### DIFF
--- a/integration
+++ b/integration
@@ -1778,6 +1778,7 @@
   "MacSiem/ha-network-map",
   "MacSiem/ha-vacuum-water-monitor",
   "macxq/foxess-ha",
+  "MadMatt34/ha-freebox-caller-id",
   "MadOne/hass_gira_iot_api",
   "madpilot/hass-amber-electric",
   "madslundt/huligennem_ha",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/MadMatt34/ha-freebox-caller-id/releases/tag/1.5.2>
Link to successful HACS action (without the `ignore` key): <https://github.com/MadMatt34/ha-freebox-caller-id/actions/runs/32490761892>
Link to successful hassfest action (if integration): <https://github.com/MadMatt34/ha-freebox-caller-id/actions/runs/32491005472>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->