### PR TITLE
Add pallemannen/hass-sharp-aquos

### DIFF
--- a/integration
+++ b/integration
@@ -2210,6 +2210,7 @@
   "pail23/stiebel_eltron_isg_component",
   "pajeronda/xai_conversation",
   "pajew-ski/ha-speedport",
+  "pallemannen/hass-sharp-aquos",
   "PalmManiac/battery-smartflow-ai",
   "PanSzelescik/home-assistant-enea",
   "pant3ras/ha-apavital",


### PR DESCRIPTION
Config-flow integration for Sharp Aquos TVs. Replaces the abandoned core `aquostv` integration and its dead `sharp_aquos_rc` dependency with an inline async TCP client.

- `manifest.json`: valid, `config_flow: true`
- Branding: `custom_components/aquostv/brand/{icon,logo}.png` present
- Releases: v0.1.0 through v0.1.3, tagged
- I am the repo owner.