### PR TITLE
Add pallemannen/hass-scrape-att-gateway

### DIFF
--- a/integration
+++ b/integration
@@ -2210,6 +2210,7 @@
   "pail23/stiebel_eltron_isg_component",
   "pajeronda/xai_conversation",
   "pajew-ski/ha-speedport",
+  "pallemannen/hass-scrape-att-gateway",
   "PalmManiac/battery-smartflow-ai",
   "PanSzelescik/home-assistant-enea",
   "pant3ras/ha-apavital",


### PR DESCRIPTION
Config-flow integration for AT&T Internet Gateways, built on Home Assistant Core's built-in scrape/rest integrations.

- `manifest.json`: valid, `config_flow: true`
- Branding: `custom_components/att_gateway/brand/{icon,logo}.png` present
- Releases: v1.0.0, tagged
- I am the repo owner.