### PR TITLE
Add pallemannen/hass-calendar-admin

### DIFF
--- a/integration
+++ b/integration
@@ -2210,6 +2210,7 @@
   "pail23/stiebel_eltron_isg_component",
   "pajeronda/xai_conversation",
   "pajew-ski/ha-speedport",
+  "pallemannen/hass-calendar-admin",
   "PalmManiac/battery-smartflow-ai",
   "PanSzelescik/home-assistant-enea",
   "pant3ras/ha-apavital",


### PR DESCRIPTION
Admin sidebar panel merging all calendar.* entities into one FullCalendar view, with live per-calendar checkboxes and sort order - features the built-in HA Calendar panel lacks.

- `manifest.json`: valid, `config_flow: true`
- Branding: `custom_components/ha_calendar_admin/brand/{icon,logo}.png` present
- Releases: v0.2.2 through v0.2.5, tagged
- I am the repo owner.