### PR TITLE
Add Jo-Highness/school_holidays

### DIFF
--- a/integration
+++ b/integration
@@ -1446,6 +1446,7 @@
   "jnbp/t-skylt",
   "jnctech/hinen-solar-homeassistant",
   "jnxxx/homeassistant-dabblerdk_powermeterreader",
+  "Jo-Highness/school_holidays",
   "JoaoPedroBelo/bmw-wallbox-ha",
   "JoaoPedroBelo/curgasnatural-ha",
   "jobvk/Home-Assistant-Windcentrale",


### PR DESCRIPTION
Adds https://github.com/Jo-Highness/school_holidays

School Holidays — today / tomorrow / next school-holiday sensors per country and region, using the open openholidaysapi.org data source (no API key).

UI config flow, hassfest + HACS Validate green, MIT licensed, published release.