### PR TITLE
Add Jo-Highness/balcony_battery_manager

### DIFF
--- a/integration
+++ b/integration
@@ -1446,6 +1446,7 @@
   "jnbp/t-skylt",
   "jnctech/hinen-solar-homeassistant",
   "jnxxx/homeassistant-dabblerdk_powermeterreader",
+  "Jo-Highness/balcony_battery_manager",
   "JoaoPedroBelo/bmw-wallbox-ha",
   "JoaoPedroBelo/curgasnatural-ha",
   "jobvk/Home-Assistant-Windcentrale",


### PR DESCRIPTION
Adds https://github.com/Jo-Highness/balcony_battery_manager

Balcony Battery Manager — controls an Anker SOLIX Solarbank 4 balcony battery from local Home Assistant signals (discharge staircase, predictive PV-surplus charging, grid support).

UI config flow, hassfest + HACS Validate green, MIT licensed, published release.