### PR TITLE
Add Jo-Highness/hausarbeit

### DIFF
--- a/integration
+++ b/integration
@@ -1446,6 +1446,7 @@
   "jnbp/t-skylt",
   "jnctech/hinen-solar-homeassistant",
   "jnxxx/homeassistant-dabblerdk_powermeterreader",
+  "Jo-Highness/hausarbeit",
   "JoaoPedroBelo/bmw-wallbox-ha",
   "JoaoPedroBelo/curgasnatural-ha",
   "jobvk/Home-Assistant-Windcentrale",


### PR DESCRIPTION
Adds https://github.com/Jo-Highness/hausarbeit

Hausarbeit-Tracker — tracks who did which household chore and when: per-person statistics, target-vs-actual, and three bundled Lovelace cards.

UI config flow, hassfest + HACS Validate green, MIT licensed, published release.