### PR TITLE
Add Jo-Highness/dishwasher_duty

### DIFF
--- a/integration
+++ b/integration
@@ -1446,6 +1446,7 @@
   "jnbp/t-skylt",
   "jnctech/hinen-solar-homeassistant",
   "jnxxx/homeassistant-dabblerdk_powermeterreader",
+  "Jo-Highness/dishwasher_duty",
   "JoaoPedroBelo/bmw-wallbox-ha",
   "JoaoPedroBelo/curgasnatural-ha",
   "jobvk/Home-Assistant-Windcentrale",


### PR DESCRIPTION
Adds https://github.com/Jo-Highness/dishwasher_duty

Dishwasher Duty — tracks who unloads the dishwasher: per-person credits and statistics, optional shared claims.

UI config flow, hassfest + HACS Validate green, MIT licensed, published release.