### PR TITLE
Add Jo-Highness/media_time_guard

### DIFF
--- a/integration
+++ b/integration
@@ -1446,6 +1446,7 @@
   "jnbp/t-skylt",
   "jnctech/hinen-solar-homeassistant",
   "jnxxx/homeassistant-dabblerdk_powermeterreader",
+  "Jo-Highness/media_time_guard",
   "JoaoPedroBelo/bmw-wallbox-ha",
   "JoaoPedroBelo/curgasnatural-ha",
   "jobvk/Home-Assistant-Windcentrale",


### PR DESCRIPTION
Adds https://github.com/Jo-Highness/media_time_guard

Media Time Guard — enforces a per-child daily media-time budget on the assigned media players.

UI config flow, hassfest + HACS Validate green, MIT licensed, published release.