### PR TITLE
Adds new plugin [djdevil/AlertTicker-Card]

### DIFF
--- a/plugin
+++ b/plugin
@@ -148,6 +148,7 @@
   "dimagoltsman/generic-remote-control-card",
   "dimagoltsman/refreshable-picture-card",
   "displaced/ha-segmented-button-card",
+  "djdevil/AlertTicker-Card",
   "dmatik/switcher-boiler-card",
   "dmoo500/ha-swissweather-card",
   "dmulcahey/zha-network-card",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: https://github.com/djdevil/AlertTicker-Card/releases/tag/v1.3.9.9.1
Link to successful HACS action (without the `ignore` key): https://github.com/djdevil/AlertTicker-Card/actions/runs/32526922292
Link to successful hassfest action (if integration): N/A (this is a plugin, not an integration)