### PR TITLE
Adds new integration [SoftwareSchmied/ha-ambientika-ventilation]

### DIFF
--- a/integration
+++ b/integration
@@ -2702,6 +2702,7 @@
   "sockless-coding/ha-eaton-ups-companion",
   "sockless-coding/panasonic_cc",
   "sockless-coding/senz-wifi",
+  "SoftwareSchmied/ha-ambientika-ventilation",
   "SoftXperience/home-assistant-foxess-api",
   "sokolovs/wda-sensor",
   "solarcube-io/solar-cube-integration",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/SoftwareSchmied/ha-ambientika-ventilation/releases/tag/v0.9.0>
Link to successful HACS action (without the `ignore` key): <https://github.com/SoftwareSchmied/ha-ambientika-ventilation/actions/runs/32542983085/job/96956383170>
Link to successful hassfest action (if integration): <https://github.com/SoftwareSchmied/ha-ambientika-ventilation/actions/runs/32542983085/job/96956383196>

## Additional context

This independent integration uses the distinct `ambientika_ventilation` domain. It does not override Home Assistant Core or the existing `ambientika` custom integration, so both catalog entries can coexist. The repository and release clearly identify this project as unofficial.