### PR TITLE
Adds new plugin [lawnmowerwoman/auri-ager]

### DIFF
--- a/plugin
+++ b/plugin
@@ -362,6 +362,7 @@
   "KTibow/fullscreen-card",
   "kverqus/lovelace-hassam-card",
   "laurence-syree/universal-battery-card",
+  "lawnmowerwoman/auri-ager",
   "ldoench/lovelace-beautiful-weather-card",
   "leonidostrovski/groups-visualizer",
   "leshniak/hass-auth-cookie",


### PR DESCRIPTION
## Proposed change

Adds `lawnmowerwoman/auri-ager` as a default HACS plugin repository.

## Repository

- Repository: https://github.com/lawnmowerwoman/auri-ager
- Category: plugin
- Latest release: https://github.com/lawnmowerwoman/auri-ager/releases/tag/v1.2.0
- HACS metadata: `hacs.json` with `filename: auri-ager.js`

## Validation

- `plugin` remains valid JSON.
- `scripts/is_sorted.py` passes.
- The repository has a stable release with the `auri-ager.js` release asset.
