### PR TITLE
Deletes integration [lalexdotcom/ha-vacances-fr]

### DIFF
--- a/integration
+++ b/integration
@@ -1667,7 +1667,6 @@
   "lackas/ha-gridx",
   "LaggAt/ha-jokes",
   "LaggAt/hacs-govee",
-  "lalexdotcom/ha-vacances-fr",
   "Lamarqe/ha_openems",
   "lancer73/ha-weather-uploader",
   "larry-wong/bemfa",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

### This is a Delete action

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/lalexdotcom/ha-vacances-fr/releases/tag/1.1.5>
Link to successful HACS action (without the `ignore` key): <https://github.com/lalexdotcom/ha-vacances-fr/actions/runs/27110699755>
Link to successful hassfest action (if integration): <https://github.com/lalexdotcom/ha-vacances-fr/actions/runs/27110699755>

Removing my own integration `lalexdotcom/ha-vacances-fr` from the default catalog.

It is no longer maintained, and it is no longer needed: the same result can be obtained
with the built-in Remote Calendar integration subscribed to the official Education
nationale ICS feeds - one per zone, listed at
https://data.education.gouv.fr/explore/assets/fr-en-calendrier-scolaire/ - plus a few
template sensors.

This PR touches the `integration` file only, per the one-file rule. It first also carried
an entry in `removed` so that people who have it installed would get the repair issue
naming the replacement rather than seeing it vanish silently; that has been dropped to
keep the diff to a single file. Happy to open it as a separate PR, or to leave it to you.

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->