### PR TITLE
Adds new plugin [lalexdotcom/picture-studio-card]

### DIFF
--- a/plugin
+++ b/plugin
@@ -362,6 +362,7 @@
   "krissen/sixdegrees-card",
   "KTibow/fullscreen-card",
   "kverqus/lovelace-hassam-card",
+  "lalexdotcom/picture-studio-card",
   "laurence-syree/universal-battery-card",
   "ldoench/lovelace-beautiful-weather-card",
   "leonidostrovski/groups-visualizer",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/lalexdotcom/picture-studio-card/releases/tag/v1.5.3>
Link to successful HACS action (without the `ignore` key): <https://github.com/lalexdotcom/picture-studio-card/actions/runs/33465582727>

This is a dashboard plugin, so the hassfest line is left out and its checkbox unticked.

Sorry for the noise: #10234 and #10235 were opened with a malformed Links section and
closed automatically. Same branch, same one-line change, correct body this time.

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->