### PR TITLE
Adds a removed entry for [lalexdotcom/ha-vacances-fr]

### DIFF
--- a/removed
+++ b/removed
@@ -202,6 +202,11 @@
     "repository": "kethoth/green_slate_theme"
   },
   {
+    "reason": "it is no longer maintained, and the same result can be had with the built-in Remote Calendar integration subscribed to the official Éducation nationale ICS feeds — one per zone, listed at https://data.education.gouv.fr/explore/assets/fr-en-calendrier-scolaire/ — plus a few template sensors",
+    "removal_type": "remove",
+    "repository": "lalexdotcom/ha-vacances-fr"
+  },
+  {
     "removal_type": "blacklist",
     "repository": "ljmerza/waze-card"
   },


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

### This is a Delete action

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/lalexdotcom/ha-vacances-fr/releases/tag/1.1.5>
Link to successful HACS action (without the `ignore` key): <https://github.com/lalexdotcom/ha-vacances-fr/actions/runs/27110699755>
Link to successful hassfest action (if integration): <https://github.com/lalexdotcom/ha-vacances-fr/actions/runs/27110699755>

Companion to #10236, which removes my own integration `lalexdotcom/ha-vacances-fr`
from the `integration` file. Kept as a separate pull request so that each one
touches a single file.

This adds the matching `removed` entry, with `removal_type: remove` rather than
`blacklist`: the repository is not being removed for cause, I am withdrawing it.
The point of the entry is the repair issue HACS raises for people who still have
it installed - without it the integration simply disappears from the store and
they are told nothing. The reason text is written to read as the clause it
becomes: "Because <reason>, `lalexdotcom/ha-vacances-fr` has been removed from
HACS.", and it names the replacement - the built-in Remote Calendar integration
subscribed to the official Education nationale ICS feeds, plus a few template
sensors.

I am aware this file looks maintainer-owned; close this if contributors are not
meant to touch it, and I will not take it badly. In that case #10236 alone still
does the removal, only silently.

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->