### PR TITLE
Adds new integration [cyclope205/changelog-traduction]

### DIFF
--- a/integration
+++ b/integration
@@ -644,6 +644,7 @@
   "cyberjunky/home-assistant-toon_climate",
   "cyberjunky/home-assistant-toon_smartmeter",
   "cyberjunky/home-assistant-ttn_gateway",
+  "cyclope205/changelog-traduction",
   "cygnusb/ha-netze-bw",
   "Cyr-ius/hass-heatzy",
   "Cyr-ius/hass-livebox-component",


### PR DESCRIPTION
New integration submission: Changelog Traduction (cyclope205/changelog-traduction). AI-translated release notes for update entities. HACS action and hassfest both pass. Release v2.0.1 published.

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/cyclope205/changelog-traduction/releases/tag/v2.0.1>
Link to successful HACS action (without the `ignore` key): <https://github.com/cyclope205/changelog-traduction/actions/runs/32577041301>
Link to successful hassfest action (if integration): <https://github.com/cyclope205/changelog-traduction/actions/runs/32577041295>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->