### PR TITLE
Adds new integration [henriquekraemer/udiconnect-plus-ha]

### DIFF
--- a/integration
+++ b/integration
@@ -1212,6 +1212,7 @@
   "helv-io/ha-gif",
   "HenkieThee/clash_royale",
   "henricm/ha-ferroamp",
+  "henriquekraemer/udiconnect-plus-ha",
   "hepter/ha-elegoo-spaghetti-detection",
   "herikw/home-assistant-custom-components",
   "Hermesiss/itchio_homeassistant",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: https://github.com/henriquekraemer/udiconnect-plus-ha/releases/tag/v1.0.2
Link to successful HACS action (without the `ignore` key): https://github.com/henriquekraemer/udiconnect-plus-ha/actions/runs/32614741730/job/97133466555
Link to successful hassfest action (if integration): https://github.com/henriquekraemer/udiconnect-plus-ha/actions/runs/32614741730/job/97133466422