### PR TITLE
Adds new plugin [gurroz/ha-media-gallery]

### DIFF
--- a/plugin
+++ b/plugin
@@ -242,6 +242,7 @@
   "guiohm79/jaugeLineaire",
   "guiohm79/psychrometric-chart-advanced",
   "gurbyz/power-wheel-card",
+  "gurroz/ha-media-gallery",
   "GyroGearl00se/lovelace-froeling-card",
   "hacf-fr/EcoleDirecteHACards",
   "halfbuilthq/solar-battery-card",


### PR DESCRIPTION
Adds new plugin [gurroz/ha-media-gallery]

## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: https://github.com/gurroz/ha-media-gallery/releases/tag/v1.0.0
Link to successful HACS action (without the `ignore` key): https://github.com/gurroz/ha-media-gallery/actions/runs/32608201574
Link to successful hassfest action (if integration): N/A — this is a plugin (dashboard card), not an integration

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->