### PR TITLE
Adds new integration [JonBasse/ha-klereo]

### DIFF
--- a/integration
+++ b/integration
@@ -1478,6 +1478,7 @@
   "JonasJoKuJonas/homeassistant-WebUntis",
   "JonasPed/homeassistant-eloverblik",
   "jonathan-gtd/scribe",
+  "JonBasse/ha-klereo",
   "jonkristian/wasteplan_trv",
   "jonnybergdahl/HomeAssistant_NewsbinPro_Integration",
   "jonnynch/ha-jemenaoutlook",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/JonBasse/ha-klereo/releases/tag/v1.6.0>
Link to successful HACS action (without the `ignore` key): <https://github.com/JonBasse/ha-klereo/actions/runs/32645476940/job/97208972996>
Link to successful hassfest action (if integration): <https://github.com/JonBasse/ha-klereo/actions/runs/32645476940/job/97208973101>

## Note

This replaces #6025, which was closed as stale on 2026-08-01 with an invitation to reopen. GitHub
refuses to reopen it — its branch had to be rebased (it was 1287 commits behind and the alphabetical
neighbourhood had shifted, so the original one-line patch no longer applied), and a force-pushed
branch makes a closed PR permanently un-reopenable. Hence a new pull request rather than a reopen.

Two things changed on the integration since that submission, both worth stating plainly:

- The `hacs` and `hassfest` workflows were **removed from the repository on 2026-07-15** by an
  unrelated CI migration. So for the last six weeks of #6025's wait, the "actions must pass"
  requirement was silently not met. They have been restored and both pass on `master`; the links
  above are from that run.
- `v1.6.0` was released **after** those actions ran green, in the order the documentation requires.

No `ignore` key is set on the HACS action — all 9 checks pass, brands included (the integration
ships its own `custom_components/klereo/brand/icon.png`).

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->
