### PR TITLE
Adds new integration [maestrea76/HA-Dreame-SF25-WiFi-Integration]

### DIFF
--- a/integration
+++ b/integration
@@ -1786,6 +1786,7 @@
   "madpilot/hass-amber-electric",
   "madslundt/huligennem_ha",
   "maeek/ha-aux-cloud",
+  "maestrea76/HA-Dreame-SF25-WiFi-Integration",
   "magicbear/schneider_selogic",
   "magiczoom2/HA-Leneda-Power",
   "magikh0e/ha-medication-reminder",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/maestrea76/HA-Dreame-SF25-WiFi-Integration/releases/tag/v0.4.2>
Link to successful HACS action (without the `ignore` key): <https://github.com/maestrea76/HA-Dreame-SF25-WiFi-Integration/actions/runs/32656463824/job/97235862014>
Link to successful hassfest action (if integration): <https://github.com/maestrea76/HA-Dreame-SF25-WiFi-Integration/actions/runs/32656463824/job/97235861921>

---

Repository: <https://github.com/maestrea76/HA-Dreame-SF25-WiFi-Integration>

Unofficial integration for the **Dreame SF25 WiFi Food Waste Disposer**
(`dreame.fwd.u2527`), a countertop food-waste composter/dehydrator with no public
API. State and control go through the Dreame cloud (MIoT `sendCommand` RPC), with
real-time updates over Dreame's MQTT broker.

Note: this supersedes #9863, which was closed by the bot. The repository has been
renamed to remove "HACS" from its name, the `ignore` key has been dropped from the
HACS action (it now passes on its own, since the integration ships its own
`brand/` directory), and a new release was cut after those runs succeeded.
