### PR TITLE
Add qian2023qian/ha-volcengine-asr

### DIFF
--- a/integration
+++ b/integration
@@ -2371,6 +2371,7 @@
   "QNimbus/haefele-connect-mesh",
   "QuadNL/Vattenfall-InCharge-integration",
   "QuickMadeSimulation/QmdevHA",
+  "qian2023qian/ha-volcengine-asr",
   "qwqqq6/tclplus-ac",
   "r-renato/ha-climacell-weather",
   "rabits/ha-ef-ble",  


### PR DESCRIPTION
Add [qian2023qian/ha-volcengine-asr](https://github.com/qian2023qian/ha-volcengine-asr) - 豆包语音识别 (Volcengine ASR): Doubao speech-to-text for Home Assistant with config flow UI and API-key auth.