### PR TITLE
Adds new integration [qian2023qian/ha-volcengine-asr]

### DIFF
--- a/integration
+++ b/integration
@@ -2366,6 +2366,7 @@
   "pyrech/homewizard_cloud_watermeter",
   "pytoyoda/ha_toyota",
   "qcgzxw/hass-lierda-iot",
+  "qian2023qian/ha-volcengine-asr",
   "qlerup/chores4kids",
   "qlerup/thermostat-pro-timeline",
   "QNimbus/haefele-connect-mesh",


### PR DESCRIPTION
﻿Add [qian2023qian/ha-volcengine-asr](https://github.com/qian2023qian/ha-volcengine-asr) - 豆包语音识别 (Volcengine ASR): Doubao speech-to-text for Home Assistant with config flow UI and API-key auth.

## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/qian2023qian/ha-volcengine-asr/releases/tag/v1.0.4>
Link to successful HACS action (without the `ignore` key): <https://github.com/qian2023qian/ha-volcengine-asr/actions/runs/32659226826>
Link to successful hassfest action (if integration): <https://github.com/qian2023qian/ha-volcengine-asr/actions/runs/32659226930>


