### PR TITLE
Adds new integration [dobrzynskim/ha-geneteka-monitor]

### DIFF
--- a/integration
+++ b/integration
@@ -822,6 +822,7 @@
   "dn5qMDW3/tzevaadom",
   "dneprojects/habitron",
   "dneprojects/mypv",
+  "dobrzynskim/ha-geneteka-monitor",
   "dolezsa/thermal_comfort",
   "dominikamann/oekofen-pellematic-compact",
   "DominikStarke/becker_centralcontrol_has",


### PR DESCRIPTION
Re-submission of #10253, which was closed by mistake and could not be reopened after the source fork was recreated. Same change as before.