### PR TITLE
Adds new integration [dobrzynskim/ha-geneteka-monitor]

### DIFF
--- a/integration
+++ b/integration
@@ -822,6 +822,7 @@
   "dn5qMDW3/tzevaadom",
   "dneprojects/habitron",
   "dneprojects/mypv",
+  "dobrzynskim/ha-geneteka-monitor",
   "dolezsa/thermal_comfort",
   "dominikamann/oekofen-pellematic-compact",
   "DominikStarke/becker_centralcontrol_has",


### PR DESCRIPTION
Re-submission of #10253 / #10279 (both closed by mistake / missing links, not due to any issue with the integration itself).

## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: https://github.com/dobrzynskim/ha-geneteka-monitor/releases/tag/v0.8.2
Link to successful HACS action (without the `ignore` key): https://github.com/dobrzynskim/ha-geneteka-monitor/actions/runs/32615911631
Link to successful hassfest action (if integration): https://github.com/dobrzynskim/ha-geneteka-monitor/actions/runs/32615911634