### PR TITLE
Adds new integration [jrx-code/hassio-integration-aquilo]

### DIFF
--- a/integration
+++ b/integration
@@ -1506,6 +1506,7 @@
   "jrgim/Zaragoza_tram",
   "jrhubott/adaptive-cover-pro",
   "jrmattila/ha-elenia",
+  "jrx-code/hassio-integration-aquilo",
   "jschroeter/HomeAssistant-Limodor-AirOdor",
   "jscruz/sensor.carbon_intensity_uk",
   "jseidl/magic-areas",


### PR DESCRIPTION
## Repository

https://github.com/jrx-code/hassio-integration-aquilo

## Description

Custom integration for Aquilo (aquilo.pl) local liquid-level sensors (septic tank, rainwater tank, well). Config-flow based, auto-discovers every tank a gateway reports from its unauthenticated local `/state` endpoint, one HA device per tank. Adds two derived diagnostics the raw API doesn't compute: a stale-data watchdog and a configurable overflow-risk binary sensor.

## Checklist

- [x] I have read the [documentation](https://hacs.xyz/docs/publish/start)
- [x] The repository is licensed (MIT)
- [x] `hacsfest`/hassfest validation passes: https://github.com/jrx-code/hassio-integration-aquilo/actions
- [x] HACS validation action passes (9/9): https://github.com/jrx-code/hassio-integration-aquilo/actions
- [x] Latest release (v0.1.4) manifest version matches the release tag
- [x] Repository topics include `home-assistant`