### PR TITLE
Adds new integration [ajachierno/Akicon]

### DIFF
--- a/integration
+++ b/integration
@@ -62,6 +62,7 @@
   "agittins/bermuda",
   "airalab/altruist-homeassistant-integration",
   "airalab/homeassistant-robonomics-integration",
+  "ajachierno/Akicon",
   "ajachierno/Aromadd",
   "ajachierno/ha-airversa-diffuser-int",
   "AK-O/plant_care",


### PR DESCRIPTION
Adds the Akicon Bath Fan Speaker integration.

Repo: https://github.com/ajachierno/Akicon

A Home Assistant `media_player` for the Bluetooth speaker in the Akicon AK-SNP80-W bath fan (stream music + TTS). HACS + hassfest checks green, release v0.3.5 published, brand icon included.