### PR TITLE
Adds new integration [IonCojucari/homeassistant-xmrig]

### DIFF
--- a/integration
+++ b/integration
@@ -1307,6 +1307,7 @@
   "insihi/kraftplug",
   "insound/iohouse_climate",
   "InTheDaylight14/nginx-proxy-manager-switches",
+  "IonCojucari/homeassistant-xmrig",
   "IoTFenster/MySmartWindow",
   "iPeel/HA-Eleven-Energy",
   "iprak/sensi",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: https://github.com/IonCojucari/homeassistant-xmrig/releases/tag/v0.8.1
Link to successful HACS action (without the `ignore` key): https://github.com/IonCojucari/homeassistant-xmrig/actions/runs/32712545908/job/97386870351
Link to successful hassfest action (if integration): https://github.com/IonCojucari/homeassistant-xmrig/actions/runs/32712545908/job/97386870470
