### PR TITLE
Adds new integration [chriguschneider/hass-meteoswiss-radar]

### DIFF
--- a/integration
+++ b/integration
@@ -508,6 +508,7 @@
   "choucheyu/panasonic_ems2",
   "Chouffy/home_assistant_libratone_zipp",
   "Chouffy/home_assistant_tgtg",
+  "chriguschneider/hass-meteoswiss-radar",
   "chriphil/homeassistant-binformed",
   "chris-mc1/homeconnect_local_hass",
   "chris-mc1/unraid_api",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/chriguschneider/hass-meteoswiss-radar/releases/tag/v0.12.0>
Link to successful HACS action (without the `ignore` key): <https://github.com/chriguschneider/hass-meteoswiss-radar/actions/runs/32813799434/job/97698060478>
Link to successful hassfest action (if integration): <https://github.com/chriguschneider/hass-meteoswiss-radar/actions/runs/32813799434/job/97698060647>

Both jobs live in the same `CI` workflow, so the two links point at the same run — [runs/32813799434](https://github.com/chriguschneider/hass-meteoswiss-radar/actions/runs/32813799434), on the `v0.12.0` release commit.

## About

MeteoSwiss precipitation radar for Home Assistant — the animation from the official MeteoSwiss app (~12 h of measured radar flowing into ~28 h of INCA forecast) as a Lovelace card on a swisstopo basemap.

The MeteoSwiss endpoints send no CORS headers, so the browser cannot reach them directly. The integration is an authenticated server-side proxy with a strict upstream path allowlist (`fullmatch` against a fixed base URL); the card is the frontend it serves.

Brand images ship inside the integration at `custom_components/meteoswiss_radar/brand/`, via the [brands proxy API](https://developers.home-assistant.io/blog/2026/02/24/brands-proxy-api) rather than a `home-assistant/brands` PR.
