### PR TITLE
Add JayLo1401/ha_midea_local

### DIFF
--- a/integration
+++ b/integration
@@ -1389,6 +1389,7 @@
   "JayDeeCo-Limited/homekit-climate-plus",
   "jaydeethree/Home-Assistant-weatherdotcom",
   "jayjojayson/hass-victron-vrm-api",
+  "JayLo1401/ha_midea_local",
   "jayzuccarelli/ha-memory",
   "jazzz/ha-evocarshare",
   "jbergler/hass-ttlock",


### PR DESCRIPTION
## Repository

https://github.com/JayLo1401/ha_midea_local

## Description

Adds "Midea AC (Local LAN)" — a Home Assistant integration for controlling
Midea-based air conditioners purely over the local network (fixed IP/hostname),
with no cloud round-trip during normal operation.

Beyond the standard `climate` entity found in most existing Midea integrations,
this one also exposes:

- `switch`: Ionizer (anion) on/off
- `switch`: Self clean on/off
- `binary_sensor`: Clean filter reminder (dust filter full)
- `sensor`: Raw error code

The local LAN protocol (AES encryption, discovery, attribute encoding) is
handled by the actively maintained
[`midea-local`](https://pypi.org/project/midea-local/) library; this
repository adds the Home Assistant config flow and entity layer on top of it.

## Checklist

- [x] `hacs/action` validation passing
- [x] `hassfest` validation passing
- [x] MIT licensed, with a self-hosted brand icon fallback
  (`custom_components/midea_ac_local/brand/icon.png`)
- [x] README in English (+ German translation, `README.de.md`)
