### PR TITLE
Add Marker284/ha-minecraft-realms

### DIFF
--- a/integration
+++ b/integration
@@ -1839,6 +1839,7 @@
   "markaggar/ha-media-index",
   "markaggar/Water-Monitor",
   "MarkAtwood/ha-mqtt-device-sync",
+  "Marker284/ha-minecraft-realms",
   "markfrancisonly/ha-cameralux",
   "markgdev/home-assistant_OctopusAgile",
   "markminnoye/HA-IPBuilding",


### PR DESCRIPTION
## Repository
https://github.com/Marker284/ha-minecraft-realms

## Description
Home Assistant integration for Minecraft: Java Edition Realms. Tracks a Realm's status (open/closed), online players, and world version as sensors, authenticating through the standard Microsoft device-code -> Xbox Live -> Minecraft Java login chain (no manual token entry).

## Checklist
- [x] Repository is public
- [x] HACS Action passes
- [x] Hassfest passes
- [x] A GitHub release has been published (not just a tag)
- [x] Brand icon included (`custom_components/minecraft_realms/brand/icon.png`)