### PR TITLE
Adds new integration [Marker284/ha-minecraft-realms]

### DIFF
--- a/integration
+++ b/integration
@@ -1839,6 +1839,7 @@
   "markaggar/ha-media-index",
   "markaggar/Water-Monitor",
   "MarkAtwood/ha-mqtt-device-sync",
+  "Marker284/ha-minecraft-realms",
   "markfrancisonly/ha-cameralux",
   "markgdev/home-assistant_OctopusAgile",
   "markminnoye/HA-IPBuilding",


### PR DESCRIPTION
## Description

Home Assistant integration for Minecraft: Java Edition Realms. Adds sensors for a Realm's status (open/closed), online players (with the full invited-player list as an attribute), and world version. Authenticates via the standard Microsoft device-code -> Xbox Live -> Minecraft Java login chain in the config flow (no manual token entry required).

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/Marker284/ha-minecraft-realms/releases/tag/v0.1.1>
Link to successful HACS action (without the `ignore` key): <https://github.com/Marker284/ha-minecraft-realms/actions/runs/32839521825/job/97775710878>
Link to successful hassfest action (if integration): <https://github.com/Marker284/ha-minecraft-realms/actions/runs/32839521825/job/97775711160>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->