### PR TITLE
Add rovocz/ha-vschrudim

### DIFF
--- a/integration
+++ b/integration
@@ -2502,6 +2502,7 @@
   "roslovets/SP110E-HASS",
   "rospogrigio/localtuya",
   "ross-w/emerald-hws-ha",
+  "rovocz/ha-vschrudim".
   "RowanRamasray/Ratio_Ev_Charger",
   "rroller/dahua",
   "rroller/netgear",


### PR DESCRIPTION
Add VS Chrudim Home Assistant integration to the HACS default repository.