### PR TITLE
Adds new integration [Marker284/clatch-ha]

### DIFF
--- a/integration
+++ b/integration
@@ -1839,6 +1839,7 @@
   "markaggar/ha-media-index",
   "markaggar/Water-Monitor",
   "MarkAtwood/ha-mqtt-device-sync",
+  "Marker284/clatch-ha",
   "markfrancisonly/ha-cameralux",
   "markgdev/home-assistant_OctopusAgile",
   "markminnoye/HA-IPBuilding",


### PR DESCRIPTION
## Description

**Clatch Cycle Tracker** is a Home Assistant integration for [Clatch](https://clatch.app/), a menstrual cycle tracking app (backed by MTS ID). It exposes cycle day, current phase, days until period/ovulation, and diary entries as entities, using Clatch's private (unofficial, reverse-engineered) REST API — there is no public API for this app.

- Fully UI-configurable: the API token and profile ID are entered through a config flow, with a live validation request against the API before the entry is created (no YAML).
- `DataUpdateCoordinator`-based polling, interval configurable via the integration's Options (15–1440 min, default 60).
- 10 sensors + 1 binary_sensor (cycle day, phase, days until period/period end/ovulation, next period/ovulation/last period dates, average period length, last diary entry, period-active flag).
- Ships its own brand icon at `custom_components/clatch/brand/icon.png` (+ `icon@2x.png`), using HA's local brand-images mechanism (2026.3+), so this does not depend on a separate `home-assistant/brands` submission.

Repository: https://github.com/Marker284/clatch-ha

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/Marker284/clatch-ha/releases/tag/v1.0.0>
Link to successful HACS action (without the `ignore` key): <https://github.com/Marker284/clatch-ha/actions/runs/32856093602/job/97828323146>
Link to successful hassfest action (if integration): <https://github.com/Marker284/clatch-ha/actions/runs/32856093602/job/97828323379>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->
