### PR TITLE
Adds new integration [jeburks2/wallecube-bt-ha]

### DIFF
--- a/integration
+++ b/integration
@@ -1399,6 +1399,7 @@
   "jdrozdnovak/ha_pagerduty",
   "jdu-acit/ACIT_HA_Integration",
   "jebeke65/room-power-aggregator",
+  "jeburks2/wallecube-bt-ha",
   "JeffSteinbok/hass-dreo",
   "jekalmin/extended_openai_conversation",
   "jellespijker/home-assistant-ultimaker",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/jeburks2/wallecube-bt-ha/releases/tag/v1.0.1>
Link to successful HACS action (without the `ignore` key): <https://github.com/jeburks2/wallecube-bt-ha/actions/runs/32869036038>
Link to successful hassfest action (if integration): <https://github.com/jeburks2/wallecube-bt-ha/actions/runs/32869035245>

---

A local Bluetooth LE integration for WalleCube DC UPS units (W150 and
similar), which otherwise only work through the vendor's app or their
cloud MQTT broker. No cloud, no app, no broker.

Provides telemetry (input/output voltage, current and power, per-cell
battery voltages, state of charge, temperature, energy), AC-present and
on-battery binary sensors for shutdown automations, and read/write access
to device settings.
