### PR TITLE
Adds new integration [simon1916sh/simon_zha_quirks]

### DIFF
--- a/integration
+++ b/integration
@@ -2659,6 +2659,7 @@
   "sillyfrog/Automate-Pulse-v2",
   "sillymoi/homeassistant-infometric",
   "silvanfischer/tuya_sensors",
+  "simon1916sh/simon_zha_quirks",
   "simonjgreen/sageha",
   "simonkowallik/ha-mikrotik-netwatch",
   "simplytoast1/ha-ring-smoke-detectors",


### PR DESCRIPTION
## Summary

- Add `simon1916sh/simon_zha_quirks` to the default HACS integration catalog.
- The integration provides custom ZHA quirks and device support for SIMON and compatible Zigbee devices.

## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/simon1916sh/simon_zha_quirks/releases/tag/v1.4.1>
Link to successful HACS action (without the `ignore` key): <https://github.com/simon1916sh/simon_zha_quirks/actions/runs/32942133653>
Link to successful hassfest action (if integration): <https://github.com/simon1916sh/simon_zha_quirks/actions/runs/32942133653>

## Test plan

- [x] Verified the repository installs through HACS as a custom integration.
- [x] Verified the integration on a Home Assistant instance with ZHA devices.
- [x] Confirmed HACS and hassfest validation pass.

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->