### PR TITLE
Adds new integration [Wattuneed-com/battery_up_ha]

### DIFF
--- a/integration
+++ b/integration
@@ -3065,6 +3065,7 @@
   "wachino/orkli_wifi_thermostat",
   "warfuric/ha-sinilink-udp",
   "waszkowski/homeassistant-sharp-cocoro-air",
+  "Wattuneed-com/battery_up_ha",
   "wbyoung/lampie",
   "wbyoung/movement",
   "wbyoung/smartcar",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/Wattuneed-com/battery_up_ha/releases/tag/v0.2.1>
Link to successful HACS action (without the `ignore` key): <https://github.com/Wattuneed-com/battery_up_ha/actions/runs/32955066477/job/98134830821>
Link to successful hassfest action (if integration): <https://github.com/Wattuneed-com/battery_up_ha/actions/runs/32955066477/job/98134830666>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->