### PR TITLE
Adds new integration media-watch and companion plugin media-tracker-card

### DIFF
--- a/integration
+++ b/integration
@@ -753,6 +753,7 @@
   "demoklion/home-assistant-globaltrack",
   "demonio669/hidromotic",
   "Dennis90BW/ha-power-helper",
+  "dennisgranasen/home-assistant-media-tracker",
   "denov/home-assistant-apex-neptune",
   "denpamusic/homeassistant-plum-ecomax",
   "denysdovhan/ha-check-weather",

--- a/plugin
+++ b/plugin
@@ -137,6 +137,7 @@
   "deblockt/aria2-card",
   "decompil3d/lovelace-hourly-weather",
   "dennisbest85/energy-flow-price-card",
+  "dennisgranasen/media-tracker-card",
   "denysdovhan/purifier-card",
   "denysdovhan/vacuum-card",
   "derliebemarcus/homeassistant_custom_dishwasher_card",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

### Integration
Link to current release: [1.0](https://github.com/dennisgranasen/home-assistant-media-tracker/releases/tag/1.0)
Link to successful HACS action (without the `ignore` key): [validated](https://github.com/dennisgranasen/home-assistant-media-tracker/actions/runs/32952960050/job/98128319847)
Link to successful hassfest action (if integration): [validated](https://github.com/dennisgranasen/home-assistant-media-tracker/actions/runs/32952960050/job/98128319609)

### Card
Link to current release: [1.0](https://github.com/dennisgranasen/media-tracker-card/releases/tag/1.0)
Link to successful HACS action (without the `ignore` key): [validated](https://github.com/dennisgranasen/media-tracker-card/actions/runs/32954526722/job/98133148317)
Link to successful hassfest action (if integration): (not an integration)
<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->