### PR TITLE
Replace timniklas/hass-neakasa with tabascoz/hass-neakasa

### DIFF
--- a/integration
+++ b/integration
@@ -2910,7 +2910,7 @@
   "timniklas/hass-blitzerde",
   "timniklas/hass-fitnesspark",
   "timniklas/hass-fitx",
-  "timniklas/hass-neakasa",
+  "tabascoz/hass-neakasa",
   "timniklas/hass-smartme",
   "timniklas/hass-wellyou",
   "timoa/ha-remi",


### PR DESCRIPTION
The original maintainer's repository `timniklas/hass-neakasa` has vanished. This replaces it with the maintained fork at `tabascoz/hass-neakasa`, which is the same codebase with ongoing bug fixes and active support.

## Changes

- Removed: `timniklas/hass-neakasa` (repo no longer exists)
- Added: `tabascoz/hass-neakasa` (maintained fork)

## Repo validation

The replacement repository passes all HACS validation checks:
- ✅ License (MIT)
- ✅ Topics: `home-assistant`, `hacs`, `hacs-integration`, `neakasa`
- ✅ Releases: v1.3.1 with `neakasa.zip` asset
- ✅ HACS Action CI: passing