### PR TITLE
Adds new integration [tabascoz/hass-neakasa]

### DIFF
--- a/integration
+++ b/integration
@@ -2825,6 +2825,7 @@
   "t0mer/matterbridge-custom-notifier",
   "t4bias/ha-sizzapp",
   "taarskog/home-assistant-component-somweb",
+  "tabascoz/hass-neakasa",
   "tadasdanielius/daikin_altherma",
   "Tadiern/climaveneta",
   "taduo/ha-pluxee-pt",


### PR DESCRIPTION
The original maintainer''s repository (`timniklas/hass-neakasa`) has vanished. This replaces it with the maintained fork at `tabascoz/hass-neakasa`, which is the same codebase with ongoing bug fixes and active support.

## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [ ] I've added a link to the action run on my repository below in the links section.
- [ ] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: <https://github.com/tabascoz/hass-neakasa/releases/tag/v1.3.1>
Link to successful HACS action (without the `ignore` key): <https://github.com/tabascoz/hass-neakasa/actions/runs/32992544442>
Link to successful hassfest action (if integration): <https://github.com/tabascoz/hass-neakasa/actions/runs/32992566490>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->

