### PR TITLE
Adds new plugin [YaddyVirus/ha-device-default-dashboard]

### DIFF
--- a/plugin
+++ b/plugin
@@ -747,6 +747,7 @@
   "xBourner/header-position-card",
   "xBourner/status-card",
   "xplanes/ha-plant-diary-card",
+  "YaddyVirus/ha-device-default-dashboard",
   "Yeelight/ha_yeelight_dashboard",
   "yohaybn/lovelace-aliexpress-package-card",
   "yosef-chai/ha-checklist-card",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: https://github.com/YaddyVirus/ha-device-default-dashboard/releases/tag/v1.0.1
Link to successful HACS action (without the `ignore` key): https://github.com/YaddyVirus/ha-device-default-dashboard/actions/runs/33068589740
Link to successful hassfest action (if integration): N/A (plugin, not an integration)
