### PR TITLE
Add jurgenmahn/ha_tuya_doorbell

### DIFF
--- a/integration
+++ b/integration
@@ -1541,6 +1541,7 @@
   "JurajNyiri/HomeAssistant-qBitTorrentAlternativeSpeed",
   "JurajNyiri/HomeAssistant-Tapo-Control",
   "JurajNyiri/HomeAssistant-Tavos",
+  "jurgenmahn/ha_tuya_doorbell",
   "JustChr/BavarianData",
   "jvitkauskas/homeassistant_blauberg_s21",
   "jwillemsen/daikin_onecta",


### PR DESCRIPTION
Local integration for LSC Smart Connect and other Tuya video doorbells, talking to the device over the LAN with the Tuya local protocol.

Repository: https://github.com/jurgenmahn/ha_tuya_doorbell
Release: v3.0.0

Checks:

- `hacs.json` present, name set, `content_in_root: false`, minimum Home Assistant version matches the manifest (2025.3.0)
- `manifest.json` has codeowners, documentation, domain, issue_tracker, name and version
- Repository description and topics set, issues enabled, not archived
- Readme contains images
- Brand assets shipped in `custom_components/lsc_tuya_doorbell/brand/` rather than the brands repository