### PR TITLE
Add off-grid-protection integration

### DIFF
--- a/integration
+++ b/integration
@@ -1308,6 +1308,7 @@
   "iluvdata/august_access_codes",
   "iluvdata/liebherr",
   "iluvdata/pdf_scrape",
+  "imehun/off-grid-protection",
   "imhotep/hass-unifi-access",
   "iMicknl/ha-nest-protect",
   "iml885203/trash_tracking",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: https://github.com/imehun/off-grid-protection/releases/tag/v1.1.2
Link to successful HACS action (without the `ignore` key): https://github.com/imehun/off-grid-protection/actions/runs/33127325766
Link to successful hassfest action (if integration): https://github.com/imehun/off-grid-protection/actions/runs/33127325766

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->