### PR TITLE
Add paw2paw/balboa_robust

### DIFF
--- a/integration
+++ b/integration
@@ -2264,6 +2264,7 @@
   "PaulBiod/ha-esphome-smart-updater",
   "PaulVanSchayck/ha-nl-weather",
   "PavelD/ha-unban_ip",
+  "paw2paw/balboa_robust",
   "pawelhulek/kontomierz-sensor",
   "pawelhulek/pgnig-sensor",
   "pawkakol1/worlds-air-quality-index",


### PR DESCRIPTION
### Repository
https://github.com/paw2paw/balboa_robust

### What it does
Home Assistant integration for the aftermarket **Balboa BWA Wi-Fi Module (part 50350)** — a module that suffers from silent-socket disconnects (measured 33.85% effective uptime over a 14.75h soak on excellent Wi-Fi). Wraps `pybalboa` with a supervised connection manager: heartbeat, zombie-socket detection, exponential backoff, auto-reconnect. Not a replacement for the stock `balboa` integration — only earns its keep against this specific flaky hardware.

### Checks
- [x] `hacs.json` present with valid `name`, `homeassistant`, `render_readme`
- [x] `manifest.json` present with valid `domain`, `documentation`, `issue_tracker`, `codeowners`, `iot_class`, `requirements`, `version`
- [x] Public GitHub repo with description + topics
- [x] Repo is not archived
- [x] README documents install + usage
- [x] MIT license
- [x] Uses `pybalboa` from PyPI (declared in `requirements`)
- [x] Icons via `custom_components/balboa_robust/brand/`