### PR TITLE
Adds new integration [paw2paw/balboa_robust]

### DIFF
--- a/integration
+++ b/integration
@@ -2264,6 +2264,7 @@
   "PaulBiod/ha-esphome-smart-updater",
   "PaulVanSchayck/ha-nl-weather",
   "PavelD/ha-unban_ip",
+  "paw2paw/balboa_robust",
   "pawelhulek/kontomierz-sensor",
   "pawelhulek/pgnig-sensor",
   "pawkakol1/worlds-air-quality-index",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: https://github.com/paw2paw/balboa_robust/releases/tag/v0.2.9
Link to successful HACS action (without the `ignore` key): https://github.com/paw2paw/balboa_robust/actions/runs/33163858398
Link to successful hassfest action (if integration): https://github.com/paw2paw/balboa_robust/actions/runs/33163858493

## Repository

https://github.com/paw2paw/balboa_robust

## Description

Home Assistant integration for the aftermarket **Balboa BWA Wi-Fi Module (part 50350)** — a module that suffers from silent-socket disconnects (measured 33.85% effective uptime over a 14.75h soak on excellent Wi-Fi). Wraps `pybalboa` with a supervised connection manager: heartbeat, zombie-socket detection, exponential backoff, auto-reconnect. Not a replacement for the stock `balboa` integration — only earns its keep against this specific flaky hardware.
