### PR TITLE
Adds new plugin [fapgomes/ha-leapmotor-card]

### DIFF
--- a/plugin
+++ b/plugin
@@ -191,6 +191,7 @@
   "faeibson/lovelace-multiline-text-input-card",
   "FamousWolf/multitodo",
   "FamousWolf/week-planner-card",
+  "fapgomes/ha-leapmotor-card",
   "figorr/meteocat-card",
   "fineemb/lovelace-air-filter-card",
   "fineemb/lovelace-car-card",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/fapgomes/ha-leapmotor-card/releases/tag/v0.3.4>
Link to successful HACS action (without the `ignore` key): <https://github.com/fapgomes/ha-leapmotor-card/actions/runs/33173775991>
Link to successful hassfest action (if integration): <n/a — this is a dashboard plugin, not an integration>
