### PR TITLE
Adds new plugin [DennisdeBest/HaTodoKanbanCard]

### DIFF
--- a/plugin
+++ b/plugin
@@ -137,6 +137,7 @@
   "deblockt/aria2-card",
   "decompil3d/lovelace-hourly-weather",
   "dennisbest85/energy-flow-price-card",
+  "DennisdeBest/HaTodoKanbanCard",
   "denysdovhan/purifier-card",
   "denysdovhan/vacuum-card",
   "derliebemarcus/homeassistant_custom_dishwasher_card",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/DennisdeBest/HaTodoKanbanCard/releases/tag/v1.2.1>
Link to successful HACS action (without the `ignore` key): <https://github.com/DennisdeBest/HaTodoKanbanCard/actions/runs/33179069715>
Link to successful hassfest action (if integration): <n/a — this is a dashboard plugin, not an integration>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->