### PR TITLE
Adds new integration [Jackroyal/xiaodu-bridge]

### DIFF
--- a/integration
+++ b/integration
@@ -1367,6 +1367,7 @@
   "JaccoR/hass-entso-e",
   "JackDempsey9/homeassistant-emergencyapi",
   "JackJPowell/hass-unfoldedcircle",
+  "Jackroyal/xiaodu-bridge",
   "jacobbjerregaard/homeassistant-growatt-modbus",
   "jaidenlabelle/tuya-vacuum-maps",
   "jamesshannon/thermoworks-ha",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## What this integration does

`xiaodu bridge` exposes Home Assistant devices to Baidu Xiaodu (小度) smart-home
through the DuerOS smart-home protocol: HA is the skill backend, so devices and
entities already known to Home Assistant become controllable from Xiaodu speakers
and the Xiaodu app (turn on/off, dim, AC mode, plus state report back to DuerOS).

Note on naming: the integration domain is `xiaodu_bridge`. It is unrelated to
`RockJesus/ha-xiaodu` (domain `xiaodu`), which bridges in the opposite direction
(Xiaodu devices into HA) and uses BDUSS cookie polling. No shared code, and the
two can be installed side by side.

## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020-04-16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: https://github.com/Jackroyal/xiaodu-bridge/releases/tag/v0.9.3
Link to successful HACS action (without the `ignore` key): https://github.com/Jackroyal/xiaodu-bridge/actions/runs/33226158301
Link to successful hassfest action (if integration): https://github.com/Jackroyal/xiaodu-bridge/actions/runs/33226158305

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->
