### PR TITLE
Adds new integration [Jackroyal/xiaodu-bridge]

### DIFF
--- a/integration
+++ b/integration
@@ -1370,6 +1370,7 @@
   "JaccoR/hass-entso-e",
   "JackDempsey9/homeassistant-emergencyapi",
   "JackJPowell/hass-unfoldedcircle",
+  "Jackroyal/xiaodu-bridge",
   "jacobbjerregaard/homeassistant-growatt-modbus",
   "jaidenlabelle/tuya-vacuum-maps",
   "jamesshannon/thermoworks-ha",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Summary

Adds `xiaodu bridge`, which exposes Home Assistant entities to Baidu Xiaodu (小度) speakers and the Xiaodu app through the DuerOS smart-home protocol: Home Assistant acts as the DuerOS skill backend (OAuth token endpoint, discovery, control, query and state report back to DuerOS).

The integration domain is `xiaodu_bridge`, so it does not collide with the `xiaodu` domain used by other, unrelated Xiaodu integrations (those bridge in the opposite direction). No shared code, and they can be installed side by side.

## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020-04-16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: https://github.com/Jackroyal/xiaodu-bridge/releases/tag/v0.9.3
Link to successful HACS action (without the `ignore` key): https://github.com/Jackroyal/xiaodu-bridge/actions/runs/33226158301
Link to successful hassfest action (if integration): https://github.com/Jackroyal/xiaodu-bridge/actions/runs/33226158305

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->
