### PR TITLE
Adds new integration [luguina/arozen_eon_hass]

### DIFF
--- a/integration
+++ b/integration
@@ -1792,6 +1792,7 @@
   "Ludy87/ecotrend-ista",
   "Ludy87/ipv64",
   "lufton/ha_telegram_client",
+  "luguina/arozen_eon_hass",
   "luis-garza/movistar_rft8115vw",
   "lukaszsobala/ld2410_serial",
   "lukegackle/Home-Assistant-User-Info-Integration",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/luguina/arozen_eon_hass/releases/tag/v0.1.2>
Link to successful HACS action (without the `ignore` key): <https://github.com/luguina/arozen_eon_hass/actions/runs/33243719634/job/99077379435>
Link to successful hassfest action (if integration): <https://github.com/luguina/arozen_eon_hass/actions/runs/33243719634/job/99077379512>

## About

A local-LAN integration for the **Arozen EON Pro 2** cold-air scent diffuser — power, intensity,
timer, battery and charging, over the Tuya local protocol with no cloud in the runtime path.

It exists because the official Tuya integration gives this device **zero entities**: the OEM
registered an empty datapoint schema, so every schema-driven integration reads nothing and creates
nothing. The datapoints were mapped by hand from packet captures and the printed manual.

Brand assets are carried in the repository at `custom_components/arozen_eon/brand/` rather than in
`home-assistant/brands`, which the `brands` validator accepts — it is included in the 9/9 above
rather than ignored.
