### PR TITLE
Adds new plugin [mycrouch/weather-console-card]

### DIFF
--- a/plugin
+++ b/plugin
@@ -478,6 +478,7 @@
   "mtheli/toothbrush-card",
   "MUbeira0/lovelace-vigobus-card",
   "mutilator/homeassistant-solar-panel-preview",
+  "mycrouch/weather-console-card",
   "naked-head/lektrico-charger-card",
   "naked-head/puffer-card",
   "nathan-gs/ha-map-card",


### PR DESCRIPTION
This replaces #9210.

`mycrouch/weather-station-card` collided with `chriguschneider/weather-station-card`, already in the store, so the repository has been renamed to `weather-console-card` — repository, filename, card type and editor tag. Released as v1.5.0.

The other points from the review on #9210 are in as well: state values and units are escaped through a helper that coerces with `String()` (v1.4.2), the card stub no longer ships my own entity ids, and the README no longer documents `show_moon` / `show_clock`, which the card never implemented.

#9210 can be closed.