### PR TITLE
Adds new plugin [mycrouch/weather-console-card]

### DIFF
--- a/plugin
+++ b/plugin
@@ -478,6 +478,7 @@
   "mtheli/toothbrush-card",
   "MUbeira0/lovelace-vigobus-card",
   "mutilator/homeassistant-solar-panel-preview",
+  "mycrouch/weather-console-card",
   "naked-head/lektrico-charger-card",
   "naked-head/puffer-card",
   "nathan-gs/ha-map-card",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/mycrouch/weather-console-card/releases/tag/v1.5.0>
Link to successful HACS action (without the `ignore` key): <https://github.com/mycrouch/weather-console-card/actions/runs/33251924880>

## Notes

This replaces #9210, per the review there.

`mycrouch/weather-station-card` collided with `chriguschneider/weather-station-card`, which is already in the store, so the repository has been renamed to `weather-console-card` — repository, filename, card type and editor tag all follow the new name.

The other points from that review are in as well: state values and units go through an escaping helper that coerces with `String()`, the card stub no longer ships my own entity ids, and the README no longer documents `show_moon` / `show_clock`, which this card never implemented.
