### PR TITLE
Adds new integration [rellerton/noaa-nhc-sensor-suite]

### DIFF
--- a/integration
+++ b/integration
@@ -2448,6 +2448,7 @@
   "Refoss/refoss_rpc",
   "ReikanYsora/Helios-Forecast",
   "reinos/solar-daytopper-ha",
+  "rellerton/noaa-nhc-sensor-suite",
   "remialban/ipx800v3",
   "remimikalsen/ollama_vision",
   "remimikalsen/sparebank1_pengerobot",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/rellerton/noaa-nhc-sensor-suite/releases/tag/v0.3.5>
Link to successful HACS action (without the `ignore` key): <https://github.com/rellerton/noaa-nhc-sensor-suite/actions/runs/33258604634>
Link to successful hassfest action (if integration): <https://github.com/rellerton/noaa-nhc-sensor-suite/actions/runs/33258604633>