### PR TITLE
Adds new plugin [rellerton/lovelace-noaa-nhc-card]

### DIFF
--- a/plugin
+++ b/plugin
@@ -574,6 +574,7 @@
   "redstone99/hass-alert2-ui",
   "ReikanYsora/Helios",
   "rejuvenate/lovelace-horizon-card",
+  "rellerton/lovelace-noaa-nhc-card",
   "renespeaker/ha-family-board-card",
   "reptilex/tesla-style-solar-power-card",
   "RF1705/fritzbox-calllist-card",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/rellerton/lovelace-noaa-nhc-card/releases/tag/v0.3.4>
Link to successful HACS action (without the `ignore` key): <https://github.com/rellerton/lovelace-noaa-nhc-card/actions/runs/33258604652>
Link to successful hassfest action (if integration): <not applicable — plugin submission>