### PR TITLE
Adds new integration [zoic21/ha_alert_manager]

### DIFF
--- a/integration
+++ b/integration
@@ -3220,6 +3220,7 @@
   "zigul/HomeAssistant-CEZdistribuce",
   "zimm3rmann/ha-cyberpower-pdu",
   "ziogref/TAS-Fuel-HA-Intergration",
+  "zoic21/ha_alert_manager",
   "zollak/homeassistant-mikrotik_swos",
   "zollak/homeassistant-syslog-receiver",
   "zqs1qiwan/ha-mihomo-ctrl",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/zoic21/ha_alert_manager/releases/tag/v2.0.1-dev2>
Link to successful HACS action (without the `ignore` key): <https://github.com/zoic21/ha_alert_manager/actions/runs/33265195590/job/99133923230>
Link to successful hassfest action (if integration): <https://github.com/zoic21/ha_alert_manager/actions/runs/33265195590/job/99133923085>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->