### PR TITLE
Adds new plugin [LuckyTriple7/ha-beach-weather-card]

### DIFF
--- a/plugin
+++ b/plugin
@@ -393,6 +393,7 @@
   "Ltek/bypass-manager-card",
   "lubomir-moric/ha-zigbee-mesh-map",
   "LuckyG3000/old-style-utility-meter-card",
+  "LuckyTriple7/ha-beach-weather-card",
   "luisanllo/ecowitt-hud-card",
   "luixal/lovelace-media-source-image-card",
   "lukevink/lovelace-buien-rain-card",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: https://github.com/LuckyTriple7/ha-beach-weather-card/releases/tag/v0.1.1
Link to successful HACS action (without the `ignore` key): https://github.com/LuckyTriple7/ha-beach-weather-card/actions/runs/33271048251
Link to successful hassfest action (if integration): n/a — this is a dashboard plugin, not an integration

## Context

This is the Lovelace card that used to ship inside `LuckyTriple7/ha-beach-weather` (#9475). It was split out on review feedback there: an integration should not write the user's shared `lovelace_resources` store, so the card is submitted here as a plugin instead, and the integration's 1.0.0 release removes the resource it used to register.