### PR TITLE
Adds new plugin [LuckyTriple7/ha-entity-watchguard-card]

### DIFF
--- a/plugin
+++ b/plugin
@@ -393,6 +393,7 @@
   "Ltek/bypass-manager-card",
   "lubomir-moric/ha-zigbee-mesh-map",
   "LuckyG3000/old-style-utility-meter-card",
+  "LuckyTriple7/ha-entity-watchguard-card",
   "luisanllo/ecowitt-hud-card",
   "luixal/lovelace-media-source-image-card",
   "lukevink/lovelace-buien-rain-card",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: https://github.com/LuckyTriple7/ha-entity-watchguard-card/releases/tag/v0.1.0
Link to successful HACS action (without the `ignore` key): https://github.com/LuckyTriple7/ha-entity-watchguard-card/actions/runs/33273557068
Link to successful hassfest action (if integration): N/A (this is a plugin, not an integration)

## Repository

https://github.com/LuckyTriple7/ha-entity-watchguard-card

## Description

Dashboard card for the Entity Watchguard integration: one row per watched domain with a counter, expandable into the entities that are actually unavailable — each with how long it has been gone, how many recovery attempts ran, and a one-click action to label it as ignored. Check now / Recover now buttons, a visual editor, EN/DE.

It used to ship inside `LuckyTriple7/ha-entity-watchguard` (#10008) and was split out for the same reason as `ha-beach-weather-card` (#10451): an integration should not write the user's shared `lovelace_resources` store, so the card is submitted here as a plugin and the integration's 1.0.0 release removes the resource it used to register.

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->