### PR TITLE
Adds new integration [cnc-lasercraft/ha_udk-0410-dimmer]

### DIFF
--- a/integration
+++ b/integration
@@ -562,6 +562,7 @@
   "CMGeorge/homeassistant_sabiana_smart_energy",
   "cmgrayb/hass-dyson",
   "cnc-lasercraft/device-saver",
+  "cnc-lasercraft/ha_udk-0410-dimmer",
   "cnecrea/cursbnr",
   "cnecrea/eonromania",
   "cnecrea/erovinieta",


### PR DESCRIPTION
Home Assistant integration for UDK-0410 RS-485 dimmer modules (4 dimmer channels per module, all modules on one shared RS-485 bus).

- One light entity per channel, brightness and transitions
- UI setup via config flow, no YAML
- ACK-based protocol with retry, plus a watchdog that recovers a silent bus (port reopen / USB reset)
- Custom Lovelace cards for module management and a technician view

Repository: https://github.com/cnc-lasercraft/ha_udk-0410-dimmer
Latest release: v1.2.0
hassfest and HACS validation workflows pass on main.