### PR TITLE
Adds new integration [cnc-lasercraft/ha_udk-0410-dimmer]

### DIFF
--- a/integration
+++ b/integration
@@ -562,6 +562,7 @@
   "CMGeorge/homeassistant_sabiana_smart_energy",
   "cmgrayb/hass-dyson",
   "cnc-lasercraft/device-saver",
+  "cnc-lasercraft/ha_udk-0410-dimmer",
   "cnecrea/cursbnr",
   "cnecrea/eonromania",
   "cnecrea/erovinieta",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/cnc-lasercraft/ha_udk-0410-dimmer/releases/tag/v1.2.0>
Link to successful HACS action (without the `ignore` key): <https://github.com/cnc-lasercraft/ha_udk-0410-dimmer/actions/runs/33276135201/job/99163086424>
Link to successful hassfest action (if integration): <https://github.com/cnc-lasercraft/ha_udk-0410-dimmer/actions/runs/33276135201/job/99163086515>

## About

Home Assistant integration for UDK-0410 RS-485 dimmer modules (4 dimmer channels per module, all modules sharing one RS-485 bus).

- One light entity per channel, brightness and transitions
- UI setup via config flow, no YAML
- ACK-based protocol with retry, plus a watchdog that recovers a silent bus (port reopen / USB reset)
- Custom Lovelace cards for module management and a technician view
