### PR TITLE
Add cnc-lasercraft/honda-wn7-wican

### DIFF
--- a/integration
+++ b/integration
@@ -562,6 +562,7 @@
   "CMGeorge/homeassistant_sabiana_smart_energy",
   "cmgrayb/hass-dyson",
   "cnc-lasercraft/device-saver",
+  "cnc-lasercraft/honda-wn7-wican",
   "cnecrea/cursbnr",
   "cnecrea/eonromania",
   "cnecrea/erovinieta",


### PR DESCRIPTION
https://github.com/cnc-lasercraft/honda-wn7-wican

Custom integration for the **Honda WN7** electric motorcycle. It consumes the
MQTT topics a [MeatPi WiCAN](https://github.com/meatpiHQ/wican-fw) OBD adapter
publishes from the bike's CAN bus and exposes one device with state of charge,
odometer, pack voltage/current/power, battery and ambient temperatures, SOH,
cell voltages, charge cable and charging state, plus a range estimate.

Local push, no cloud. The UDS/CAN decoding behind it is documented in the repo
and was cross-checked against a passive capture of Honda's official MCS
diagnostic tool.

- Category: `integration`
- Domain: `honda_wn7`
- Release: [v1.0.0](https://github.com/cnc-lasercraft/honda-wn7-wican/releases/tag/v1.0.0)
- HACS action and hassfest pass on `main`
- Brand assets ship in-repo under `custom_components/honda_wn7/brand/`
  (`icon.png`, `icon@2x.png`), per the
  [February 2026 brands announcement](https://developers.home-assistant.io/blog/2026/02/24/brands-proxy-api)