### PR TITLE
Adds new integration [cnc-lasercraft/honda-wn7-wican]

### DIFF
--- a/integration
+++ b/integration
@@ -562,6 +562,7 @@
   "CMGeorge/homeassistant_sabiana_smart_energy",
   "cmgrayb/hass-dyson",
   "cnc-lasercraft/device-saver",
+  "cnc-lasercraft/honda-wn7-wican",
   "cnecrea/cursbnr",
   "cnecrea/eonromania",
   "cnecrea/erovinieta",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Repository: <https://github.com/cnc-lasercraft/honda-wn7-wican>
Link to current release: <https://github.com/cnc-lasercraft/honda-wn7-wican/releases/tag/v1.0.0>
Link to successful HACS action (without the `ignore` key): <https://github.com/cnc-lasercraft/honda-wn7-wican/actions/runs/33293763562/job/99209809379>
Link to successful hassfest action (if integration): <https://github.com/cnc-lasercraft/honda-wn7-wican/actions/runs/33293763562/job/99209809196>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->

---

Custom integration for the **Honda WN7** electric motorcycle (domain `honda_wn7`,
category `integration`). It consumes the MQTT topics a
[MeatPi WiCAN](https://github.com/meatpiHQ/wican-fw) OBD adapter publishes from
the bike's CAN bus and exposes one device with state of charge, odometer, pack
voltage/current/power, battery and ambient temperatures, SOH, cell voltages,
charge cable and charging state, plus a range estimate. Local push, no cloud.

Brand assets ship in-repo under `custom_components/honda_wn7/brand/`, per the
[February 2026 brands announcement](https://developers.home-assistant.io/blog/2026/02/24/brands-proxy-api).