### PR TITLE
Adds new integration [stevekirtley/HomeAssistant-EDFEnergy]

### DIFF
--- a/integration
+++ b/integration
@@ -2810,6 +2810,7 @@
   "StephaneBranly/ha-enki",
   "StephanJoubert/home_assistant_solarman",
   "steveAbratt/VIGICam",
+  "stevekirtley/HomeAssistant-EDFEnergy",
   "stevesinchak/ha-weatherlink-live",
   "stickpin/homeassistant-meinvodafone",
   "stijn220/leisure-pools",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/stevekirtley/HomeAssistant-EDFEnergy/releases/tag/19.0.0>
Link to successful HACS action (without the `ignore` key): <https://github.com/stevekirtley/HomeAssistant-EDFEnergy/actions/runs/33312038949/job/99258732202>
Link to successful hassfest action (if integration): <https://github.com/stevekirtley/HomeAssistant-EDFEnergy/actions/runs/33312038949/job/99258732202>

## Additional context

This repository was originally a fork of [BottlecapDave/HomeAssistant-OctopusEnergy](https://github.com/BottlecapDave/HomeAssistant-OctopusEnergy) (MIT licensed), adapted for EDF Energy, which runs on the same Kraken platform. It has since diverged substantially, with its own release history, issue tracker and user base.

GitHub Support extracted it from the fork network in August 2026, so it is now a standalone repository and the root of its own network. As a result of the extraction the contributor graph shows the inherited upstream contributors alongside my own commits; I am the owner and sole maintainer of the EDF-specific work. Attribution to the original author is retained in both the LICENSE and the README.

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->