### PR TITLE
Adds new plugin [shogun301/climate-history-card]

### DIFF
--- a/plugin
+++ b/plugin
@@ -620,6 +620,7 @@
   "ShadowAya/anchor-card",
   "shadowsight00/aio-light-controller-card",
   "shashanktomar/zen-ui",
+  "shogun301/climate-history-card",
   "shouldbecommitted/arlo-camera-card",
   "shpongledsummer/atmospheric-weather-card",
   "Sian-Lee-SA/honeycomb-menu",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/shogun301/climate-history-card/releases/tag/v0.1.2>
Link to successful HACS action (without the `ignore` key): <https://github.com/shogun301/climate-history-card/actions/runs/33407155943/job/99537442768>
Link to successful hassfest action (if integration): <>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->