### PR TITLE
Add energy-event-explorer-card

### DIFF
--- a/plugin
+++ b/plugin
@@ -620,6 +620,7 @@
   "ShadowAya/anchor-card",
   "shadowsight00/aio-light-controller-card",
   "shashanktomar/zen-ui",
+  "shogun301/energy-event-explorer-card",
   "shouldbecommitted/arlo-camera-card",
   "shpongledsummer/atmospheric-weather-card",
   "Sian-Lee-SA/honeycomb-menu",


### PR DESCRIPTION
## Proposed change

Add `shogun301/energy-event-explorer-card` as a HACS dashboard plugin.

## Checklist

- [x] The repository is compatible with HACS.
- [x] The repository has a full release.
- [x] The repository has a successful HACS action run.
- [x] The repository has a successful Hassfest action run.
- [x] The repository is not a fork.
- [x] The repository was not previously rejected.

Link to successful HACS action: <https://github.com/shogun301/energy-event-explorer-card/actions/runs/33364415007>
Link to successful hassfest action (if integration): <https://github.com/shogun301/energy-event-explorer-card/actions/runs/33364415007>
Link to full release: <https://github.com/shogun301/energy-event-explorer-card/releases/tag/v0.1.0>