### PR TITLE
Adds new integration [XAV59213/freebox_homexa]

### DIFF
--- a/integration
+++ b/integration
@@ -3170,6 +3170,7 @@
   "x1marc/homeassistant-judo-idos",
   "xannor/ha_reolink_discovery",
   "xathon/Allianz-BonusDrive-HomeAssistant",
+  "XAV59213/freebox_homexa",
   "Xerolux/idm-heatpump-hass",
   "xiaodong-lx/tplink-ipc-control",
   "XiaoMi/ha_xiaomi_home",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: https://github.com/XAV59213/freebox_homexa/releases/tag/28.8.3
Link to successful HACS action (without the `ignore` key): https://github.com/XAV59213/freebox_homexa/actions/runs/33384610729
Link to successful hassfest action (if integration): https://github.com/XAV59213/freebox_homexa/actions/runs/33384610694

## Notes

- Repository: https://github.com/XAV59213/freebox_homexa
- Domain: `freebox_homexa`
- I am the owner of the repository.
- Entry added alphabetically in `integration` after `xathon/Allianz-BonusDrive-HomeAssistant`.
- This replaces the invalid placeholder change in https://github.com/hacs/default/pull/10470.
