### PR TITLE
Adds new integration [shogun301/solaredge-monitoring-bridge]

### DIFF
--- a/integration
+++ b/integration
@@ -2695,6 +2695,7 @@
   "Sheep26/huawei_hg659",
   "shhhrodingercat/ecobot-ha",
   "shivan/homeassistant-liquidcheck",
+  "shogun301/solaredge-monitoring-bridge",
   "shogunxam/Home-Assistant-custom-components-cfr-toscana",
   "Sholofly/lghorizon",
   "shuette42/ecoflow-energy-ha",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/shogun301/solaredge-monitoring-bridge/releases/tag/v0.1.2>
Link to successful HACS action (without the `ignore` key): <https://github.com/shogun301/solaredge-monitoring-bridge/actions/runs/33405501580/job/99531958205>
Link to successful hassfest action (if integration): <https://github.com/shogun301/solaredge-monitoring-bridge/actions/runs/33405501580/job/99531958193>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->