### PR TITLE
Adds new integration [espruino/homeassistant-espruino]

### DIFF
--- a/integration
+++ b/integration
@@ -964,6 +964,7 @@
   "esbenwiberg/easyiq",
   "eseglem/hass-wattbox",
   "eseverson/hass-balena",
+  "espruino/homeassistant-espruino",
   "etiennec78/ha-artemis-rgb",
   "etiennec78/ha-celcat",
   "Eunanibus/ha-emporia-ev",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
This allows devices with the Espuino (espruino.com) JS interpreter installed to be programmed through Home Assistant via Bluetooth using the Espruino IDE at espruino.com/ide/

## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: https://github.com/espruino/homeassistant-espruino/releases/tag/1.0.2
Link to successful HACS action (without the `ignore` key): https://github.com/espruino/homeassistant-espruino/actions/runs/33408830416
Link to successful hassfest action (if integration): https://github.com/espruino/homeassistant-espruino/actions/runs/33408830507

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->