### PR TITLE
Adds new integration [aarikmudgal/ha-speedport-smart]

### DIFF
--- a/integration
+++ b/integration
@@ -23,6 +23,7 @@
   "9a4gl/hass-centrometal-boiler",
   "a-mavrides/roomba_v4",
   "aaamoeder/ha-goboony",
+  "aarikmudgal/ha-speedport-smart",
   "AaronDavidSchneider/SonosAlarm",
   "aaronmayeux/ha-hurricane-tracker",
   "Aasikki/daily-fingerpori",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/aarikmudgal/ha-speedport-smart/releases/tag/v0.3.0>
Link to successful HACS action (without the `ignore` key): <https://github.com/aarikmudgal/ha-speedport-smart/actions/runs/33787971078/job/100757274711>
Link to successful hassfest action (if integration): <https://github.com/aarikmudgal/ha-speedport-smart/actions/runs/33787971078/job/100757275032>

## Integration identity

This repository installs as `custom_components/speedport_smart` and uses `speedport_smart.zip`. Its display name is `Telekom Speedport Smart`, so it remains separate from the existing `speedport` catalog entry.

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->
