### PR TITLE
Add benji2k2/ha_smart_and_green

### DIFF
--- a/integration
+++ b/integration
@@ -338,6 +338,7 @@
   "bendikrb/ha-politikontroller",
   "BenJamesAndo/ha-propresenter",
   "benjamin-dcs/file-plusplus",
+  "benji2k2/ha_smart_and_green",
   "benjycov/exo_pool",
   "benleb/sureha",
   "Bennett-Wendorf/hass-uplift-desk",


### PR DESCRIPTION
Adds `benji2k2/ha_smart_and_green`.

Local control of Smart & Green "Cube" BLE RGBW lamps from Home Assistant, over
the proprietary Linkio LMP protocol — no cloud and no vendor gateway. The mesh
keys are read from the vendor app's encrypted `.lap` export during the config
flow, so there is no manual key entry.

- One `light` per lamp (on/off, brightness, HS colour, colour temperature) plus
  an optional group entity that reaches every lamp through one connection
- Diagnostic sensors: signal strength, last seen, and which Bluetooth proxy is
  in use — all read from advertisements, without ever opening a connection
- Commands are acknowledged by the device, so a lost one is detected and
  retried rather than failing silently
- Works through ESPHome Bluetooth proxies; state survives restarts

Validation: the HACS action, hassfest and the test suite (50 tests) run on
every push and weekly, and all pass on the current release.
