### PR TITLE
Adds new integration [bakroistvan/ha_veroval_ble]

### DIFF
--- a/integration
+++ b/integration
@@ -296,6 +296,7 @@
   "BAERnado/ha-samsungtv-encrypted",
   "bairnhard/fishing_assistant",
   "bairnhard/home-assistant-google-aqi",
+  "bakroistvan/ha_veroval_ble",
   "bangboomben/ha-nasa-firms",
   "banter240/hdg_bavaria_homeassistant",
   "banter240/tado_hijack",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: https://github.com/bakroistvan/ha_veroval_ble/releases/tag/0.2.0
Link to successful HACS action (without the `ignore` key): https://github.com/bakroistvan/ha_veroval_ble/actions/runs/33444900409/job/99661670264
Link to successful hassfest action (if integration): https://github.com/bakroistvan/ha_veroval_ble/actions/runs/33444900409/job/99661670559

## Notes

- Owner of `bakroistvan/ha_veroval_ble`
- Category: integration
- Brand assets: `custom_components/veroval_ble/brand/icon.png`
- Custom-repository install works; submitting for default store inclusion