### PR TITLE
Add Ghost-in-the-dark/ha-singbox and Ghost-in-the-dark/ha-singbox-panel

### DIFF
--- a/integration
+++ b/integration
@@ -1123,6 +1123,7 @@
   "GertCauwenberg/methu",
   "getuhoo/uhooair-homeassistant",
   "ggiesen/ha-aprilaire-rs485",
+  "Ghost-in-the-dark/ha-singbox",
   "ghotso/HAS-pCloud-Backup",
   "giachello/beoplay",
   "giachello/mlgw",

--- a/plugin
+++ b/plugin
@@ -237,6 +237,7 @@
   "GeorgeSG/lovelace-time-picker-card",
   "georgezhao2010/lovelace-curtain-card",
   "Gh61/lovelace-hue-like-light-card",
+  "Ghost-in-the-dark/ha-singbox-panel",
   "Giorgio866/lumina-energy-card",
   "giovannilamarmora/lovelace-material-components",
   "go-hass/go-hass-cards",


### PR DESCRIPTION
## Summary

Add two repositories to the HACS default repository list:

- **Integration**: `Ghost-in-the-dark/ha-singbox` — Home Assistant integration for monitoring and controlling sing-box (supports gRPC API and clash API backends).
- **Plugin**: `Ghost-in-the-dark/ha-singbox-panel` — Lovelace frontend card for displaying sing-box status (groups, nodes, pings, traffic).

Both entries were inserted in the correct alphabetical position in `integration` and `plugin` respectively (verified against `scripts/is_sorted.py`).

## Checklist

- [x] The repositories are added to the correct category files
- [x] Entries are in alphabetical order (case-insensitive, per `scripts/sort.py`)
- [x] `scripts/is_sorted.py` passes
- [x] ha-singbox has a valid `manifest.json` (domain: singbox), HACS brand icon at `custom_components/singbox/brand/icon.png`, and passes the HACS validation workflow
- [x] ha-singbox-panel has `hacs.json` (category: plugin), a bundled JS file at repo root, and passes the HACS validation workflow