### PR TITLE
Add Ghost-in-the-dark/ha-singbox integration

### DIFF
--- a/integration
+++ b/integration
@@ -1123,6 +1123,7 @@
   "GertCauwenberg/methu",
   "getuhoo/uhooair-homeassistant",
   "ggiesen/ha-aprilaire-rs485",
+  "Ghost-in-the-dark/ha-singbox",
   "ghotso/HAS-pCloud-Backup",
   "giachello/beoplay",
   "giachello/mlgw",


### PR DESCRIPTION
## Summary

Add the `Ghost-in-the-dark/ha-singbox` repository to the HACS default **integration** list.

ha-singbox is a Home Assistant integration for monitoring and controlling sing-box (supports gRPC API and clash API backends).

The entry was inserted in the correct alphabetical position (case-insensitive, per `scripts/sort.py`) and verified with `scripts/is_sorted.py`.

## Checklist

- [x] Added to the correct category file (`integration`)
- [x] Single file change only
- [x] Alphabetical order maintained (`scripts/is_sorted.py` passes)
- [x] ha-singbox has a valid `manifest.json` (domain: singbox)
- [x] HACS brand icon present at `custom_components/singbox/brand/icon.png`
- [x] HACS validation workflow passes