### PR TITLE
Add Ghost-in-the-dark/ha-singbox-panel plugin

### DIFF
--- a/plugin
+++ b/plugin
@@ -237,6 +237,7 @@
   "GeorgeSG/lovelace-time-picker-card",
   "georgezhao2010/lovelace-curtain-card",
   "Gh61/lovelace-hue-like-light-card",
+  "Ghost-in-the-dark/ha-singbox-panel",
   "Giorgio866/lumina-energy-card",
   "giovannilamarmora/lovelace-material-components",
   "go-hass/go-hass-cards",


### PR DESCRIPTION
## Summary

Add the `Ghost-in-the-dark/ha-singbox-panel` repository to the HACS default **plugin** list.

ha-singbox-panel is a Lovelace frontend card for displaying sing-box status (groups, nodes, pings, traffic).

The entry was inserted in the correct alphabetical position (case-insensitive, per `scripts/sort.py`) and verified with `scripts/is_sorted.py`.

## Checklist

- [x] Added to the correct category file (`plugin`)
- [x] Single file change only
- [x] Alphabetical order maintained (`scripts/is_sorted.py` passes)
- [x] ha-singbox-panel has `hacs.json` (category: plugin)
- [x] Bundled JS file present at repo root (per `hacs.json` filename)
- [x] HACS validation workflow passes