### PR TITLE
Adds new plugin [Ghost-in-the-dark/ha-singbox-panel]

### DIFF
--- a/plugin
+++ b/plugin
@@ -237,6 +237,7 @@
   "GeorgeSG/lovelace-time-picker-card",
   "georgezhao2010/lovelace-curtain-card",
   "Gh61/lovelace-hue-like-light-card",
+  "Ghost-in-the-dark/ha-singbox-panel",
   "Giorgio866/lumina-energy-card",
   "giovannilamarmora/lovelace-material-components",
   "go-hass/go-hass-cards",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: https://github.com/Ghost-in-the-dark/ha-singbox-panel/releases/tag/v0.1.12
Link to successful HACS action (without the `ignore` key): https://github.com/Ghost-in-the-dark/ha-singbox-panel/actions/runs/33537166513
Link to successful hassfest action (if integration): N/A (Lovelace plugin, not an integration)

## Repository

https://github.com/Ghost-in-the-dark/ha-singbox-panel

## Description

Lovelace frontend card for displaying sing-box status: proxy groups with node chips (latency badge, color-coded), traffic totals, memory, connections, version and mode, plus a radar button for node URL tests.