### PR TITLE
Adds new integration [Ghost-in-the-dark/ha-singbox]

### DIFF
--- a/integration
+++ b/integration
@@ -1123,6 +1123,7 @@
   "GertCauwenberg/methu",
   "getuhoo/uhooair-homeassistant",
   "ggiesen/ha-aprilaire-rs485",
+  "Ghost-in-the-dark/ha-singbox",
   "ghotso/HAS-pCloud-Backup",
   "giachello/beoplay",
   "giachello/mlgw",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: https://github.com/Ghost-in-the-dark/ha-singbox/releases/tag/v0.3.12
Link to successful HACS action (without the `ignore` key): https://github.com/Ghost-in-the-dark/ha-singbox/actions/runs/33550707812
Link to successful hassfest action (if integration): https://github.com/Ghost-in-the-dark/ha-singbox/actions

## Repository

https://github.com/Ghost-in-the-dark/ha-singbox

## Description

Home Assistant integration for monitoring and controlling sing-box: proxy groups with per-node latency, traffic totals, memory and connection stats, mode switching, outbound selection and URL tests. Supports both gRPC API and clash API backends (local push, config flow setup).