### PR TITLE
Adds new plugin [doccodyblue/ha-pvstrings-dash]

### DIFF
--- a/plugin
+++ b/plugin
@@ -158,6 +158,7 @@
   "dmulcahey/zha-network-card",
   "dnguyen800/air-visual-card",
   "DocBig/Energy-Waterfall-Card",
+  "doccodyblue/ha-pvstrings-dash",
   "domodom30/mealie-card",
   "dooz127/swipe-glance-card",
   "DorjeDorf/HA-Desk-Card",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/doccodyblue/ha-pvstrings-dash/releases/tag/v0.10.3>
Link to successful HACS action (without the `ignore` key): <https://github.com/doccodyblue/ha-pvstrings-dash/actions/runs/33601134444>
Link to successful hassfest action (if integration): not applicable — this is a dashboard plugin, not an integration.
