### PR TITLE
Adds new plugin [ADNPolymerase/ha-printer-card]

### DIFF
--- a/plugin
+++ b/plugin
@@ -18,6 +18,7 @@
   "ADNPolymerase/ha-dosing-tank-card",
   "ADNPolymerase/ha-gate-card",
   "ADNPolymerase/ha-pluviometer-card",
+  "ADNPolymerase/ha-printer-card",
   "ADNPolymerase/oklyn-card",
   "ADNPolymerase/poollab-card",
   "aex351/home-assistant-neerslag-card",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: https://github.com/ADNPolymerase/ha-printer-card/releases/tag/v0.2.0
Link to successful HACS action (without the `ignore` key): https://github.com/ADNPolymerase/ha-printer-card/actions/runs/33634562178
Link to successful hassfest action (if integration): N/A (Lovelace plugin, not an integration)

## Repository

https://github.com/ADNPolymerase/ha-printer-card

## Description

Lovelace card for printers. A sheet slides out of the machine on a loop while it prints and fades as if taken, a paper jam leaves it stuck half-way with a warning triangle, and an empty tray is drawn empty. Four classic silhouettes, each ejecting the page where it really does: all-in-one, inkjet, laser and office multifunction.

Supplies are discovered from the printer's own device rather than from a naming convention, so it works beyond the `ipp` integration it started on: Brother drums, belts, fusers and feed kits, Samsung SyncThru toners, Epson inks and maintenance box, HP consumables, SNMP receptacles and Dell's bare colour sensors. Inks are drawn in their own colour, wear parts get a compact chip row, and each has its own low alert with a threshold that fires at 20 % rather than at the 3 % printers advertise. Mono printers are handled: a lone cartridge with no colour in its name is black. Page counters (total, black and white, colour) are shown in the card's language, with scans, copies and faxes deliberately left out.

Six states normalized across brands and thirteen languages, including a warning state so that a printer reporting "toner low" is not shown as stopped. Optional socket entity that makes a printer without mains read as offline, an optional wattmeter that catches the short jobs falling between two 60 second polls, a paper tray entity, a test print button and a link to the printer's own web interface derived from what it advertises.

Visual editor for every option, compact mode, three cartridge layouts including one drawn inside the machine, `prefers-reduced-motion` honoured, and a language option to pin the card. EN, FR, DE, ES, IT, NL, PT, SV, NO, DA, PL, RU, ZH. No build step and no dependency, with 206 behaviour assertions run in CI.

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->
