### PR TITLE
Add Mahoniz/ha-ft0360

### DIFF
--- a/integration
+++ b/integration
@@ -1841,6 +1841,7 @@
   "magikh0e/ha-medication-reminder",
   "maginawin/ha-azoula-smart",
   "maginawin/ha-dali-center",
+  "Mahoniz/ha-ft0360",
   "majorfrog/qvantum_modbus",
   "make-all/infrared-light",
   "make-all/metlink-nz",


### PR DESCRIPTION
Adds the public `Mahoniz/ha-ft0360` local Home Assistant integration for LANDI / FT0360 weather stations.

The repository has a GitHub release, repository topics, a local brand icon, and passing HACS and Hassfest checks.