### PR TITLE
Adds new plugin [htpchome/FrigateViewCard]

### DIFF
--- a/plugin
+++ b/plugin
@@ -269,6 +269,7 @@
   "homeassistant-extras/whisker",
   "homeassistant-extras/zwave-card-set",
   "hsolgaard/zha-bindings-manager",
+  "htpchome/FrigateViewCard",
   "hudsonbrendon/nintendo-switch-card",
   "Hugo0485/DoubleCurtainCard",
   "hulkhaugen/hass-bha-icons",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/htpchome/FrigateViewCard/releases/tag/v1.1.2>
Link to successful HACS action (without the `ignore` key): <https://github.com/htpchome/FrigateViewCard/actions/runs/33713808006>
Link to successful hassfest action (if integration): <> (not an integration)