### PR TITLE
Adds new plugin [kmich/ha-aiper-card]

### DIFF
--- a/plugin
+++ b/plugin
@@ -362,6 +362,7 @@
   "KipK/openevse-card",
   "kirbo/ha-lovelace-elapsed-time-card",
   "kizza/magic-home-party-card",
+  "kmich/ha-aiper-card",
   "konnectedvn/lovelace-vertical-slider-cover-card",
   "Korkuttum/xiaomi_air_purifier_card",
   "kratochj/hassio-irrigation-card",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: https://github.com/kmich/ha-aiper-card/releases/tag/v0.1.1
Link to successful HACS action (without the `ignore` key): https://github.com/kmich/ha-aiper-card/actions/runs/33719389078
Link to successful hassfest action (if integration): N/A (Lovelace plugin, not an integration)

## Repository

https://github.com/kmich/ha-aiper-card

## Description

Two Lovelace cards for the ha-aiper integration. The Aiper Cleaner Card shows a pool cleaner's status and battery, online / in-water / solar / wifi pills, a warning banner, cleaning-mode and clean-path selectors as chips, a start/stop switch for models that support it, consumable wear bars, and force-sync buttons. The Aiper Water Quality Card shows a HydroComm monitor's overall water-quality score plus pH, ORP, free chlorine, TDS and EC gauges with healthy/warning bands, water temperature and sample age. Both cards are device-driven (point them at an Aiper device and they resolve the entities themselves, including renamed ones), are theme-aware for light and dark, and ship a visual editor.