### PR TITLE
Adds new integration [CrilleBaba/ha-podcast-feed]

### DIFF
--- a/integration
+++ b/integration
@@ -604,6 +604,7 @@
   "crankynetman/ha-cumtd",
   "Crazy-Duck/home-assistant-fiftyfive",
   "CreasolTech/home-assistant-creasol-dombus",
+  "CrilleBaba/ha-podcast-feed",
   "cryptotomte/ev-charging-manager",
   "cryptotomte/ev-load-balancer",
   "CRZTFR/bindicator",


### PR DESCRIPTION

## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: https://github.com/CrilleBaba/ha-podcast-feed/releases/tag/v1.0.2
Link to successful HACS action (without the `ignore` key): https://github.com/CrilleBaba/ha-podcast-feed/actions/runs/33726909937/job/100557867643
Link to successful hassfest action (if integration): https://github.com/CrilleBaba/ha-podcast-feed/actions/runs/33726909937/job/100557867688

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->