### PR TITLE
Add JellyEmu-HomeAssistant-Plugin to integration

### DIFF
--- a/integration
+++ b/integration
@@ -3260,5 +3260,6 @@
   "zubir2k/homeassistant-esolattakwim",
   "zulufoxtrot/ha-zyxel",
   "zupancicmarko/JellyHA",
-  "Zwer2k/ha-pca301"
+  "Zwer2k/ha-pca301",
+  "Jellyfin-PG/JellyEmu-HomeAssistant-Plugin"
 ]


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: https://github.com/Jellyfin-PG/JellyEmu-HomeAssistant-Plugin/releases/tag/v1.0.0
Link to successful HACS action (without the `ignore` key): https://github.com/Jellyfin-PG/JellyEmu-HomeAssistant-Plugin/actions/runs/33813406479/job/100840146866
Link to successful hassfest action (if integration): https://github.com/Jellyfin-PG/JellyEmu-HomeAssistant-Plugin/actions/runs/33813406479/job/100840146592
