### PR TITLE
Adds new integration [willbeeching/ha-jlr-incontrol]

### DIFF
--- a/integration
+++ b/integration
@@ -3160,6 +3160,7 @@
   "WickedGhost/avinor_flight_data",
   "widewing/ha-toyota-na",
   "wielorzeczownik/ha-toya-decoder",
+  "willbeeching/ha-jlr-incontrol",
   "willbeeching/ha-unifiplay",
   "WillCodeForCats/solaredge-modbus-multi",
   "WillCodeForCats/tekmar-482",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/willbeeching/ha-jlr-incontrol/releases/tag/v1.6.1>
Link to successful HACS action (without the `ignore` key): <https://github.com/willbeeching/ha-jlr-incontrol/actions/runs/33874265152/job/101027343530>
Link to successful hassfest action (if integration): <https://github.com/willbeeching/ha-jlr-incontrol/actions/runs/33874265152/job/101027343756>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->