### PR TITLE
Adds new integration [Pacco24626/nexus_tecnoalarm]

### DIFF
--- a/integration
+++ b/integration
@@ -2275,6 +2275,7 @@
   "oyvindwe/connectlife-ha",
   "p0l0/hapetwalk",
   "pa-martin/ha-pandascore",
+  "Pacco24626/nexus_tecnoalarm",
   "pacorola/Atmoce_battery_HA",
   "pail23/stiebel_eltron_isg_component",
   "pajeronda/xai_conversation",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/Pacco24626/nexus_tecnoalarm/releases/tag/v2.1.1>
Link to successful HACS action (without the `ignore` key): <https://github.com/Pacco24626/nexus_tecnoalarm/actions/runs/33921850536/job/101181717907>
Link to successful hassfest action (if integration): <https://github.com/Pacco24626/nexus_tecnoalarm/actions/runs/33921850536/job/101181717535>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->
