### PR TITLE
Adds new plugin [Pacco24626/nexus_irrigation_card]

### DIFF
--- a/plugin
+++ b/plugin
@@ -522,6 +522,7 @@
   "openlamp/openlamp-beat-card",
   "othorg/rv-level-ha-lovelace-card",
   "ownbee/bootstrap-grid-card",
+  "Pacco24626/nexus_irrigation_card",
   "pacemaker82/Compact-Power-Card",
   "pacemaker82/Home-Climate-Card",
   "pacemaker82/Sections-Gauge-Card",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: https://github.com/Pacco24626/nexus_irrigation_card/releases/tag/v1.1.2
Link to successful HACS action (without the `ignore` key): https://github.com/Pacco24626/nexus_irrigation_card/actions/runs/33921865807
Link to successful hassfest action (if integration): N/A (Lovelace plugin, not an integration)

## Repository

https://github.com/Pacco24626/nexus_irrigation_card

## Description

Lovelace card for the Nexus Irrigation integration. It shows every zone of a watering
system with its duration slider, a manual start button and a live countdown with progress
bar for the zone currently running, plus the weekly schedule and the cycle controls.

The card is configured with a single entity: the group status sensor exposes the whole
map of the system in its attributes, so adding a zone in the integration makes it appear
in the card without touching the dashboard configuration. On systems with a master valve
or a pump, an extra indicator shows whether the line is pressurised.
