### PR TITLE
Adds new plugin [Pacco24626/nexus_tablet_charge_card]

### DIFF
--- a/plugin
+++ b/plugin
@@ -522,6 +522,7 @@
   "openlamp/openlamp-beat-card",
   "othorg/rv-level-ha-lovelace-card",
   "ownbee/bootstrap-grid-card",
+  "Pacco24626/nexus_tablet_charge_card",
   "pacemaker82/Compact-Power-Card",
   "pacemaker82/Home-Climate-Card",
   "pacemaker82/Sections-Gauge-Card",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: https://github.com/Pacco24626/nexus_tablet_charge_card/releases/tag/v1.0.2
Link to successful HACS action (without the `ignore` key): https://github.com/Pacco24626/nexus_tablet_charge_card/actions/runs/33921867296
Link to successful hassfest action (if integration): N/A (Lovelace plugin, not an integration)

## Repository

https://github.com/Pacco24626/nexus_tablet_charge_card

## Description

Lovelace card for the Nexus Tablet Charge integration, which keeps wall-mounted tablets
inside a charge band instead of leaving them plugged in permanently.

For each tablet the card draws the battery level on a bar that also shows the chosen
charge band, so you can see at a glance where the device sits relative to its thresholds.
Next to it: the cycle state, a charge-now button and a switch to suspend management. Both
thresholds are adjustable from sliders on the card itself.

It is configured with a single entity: the group status sensor carries the whole map in
its attributes, so a tablet added in the integration appears on its own.
