### PR TITLE
Adds new integration [Xygen/EcoFlow-PowerPulse-2-for-Home-Assistant]

### DIFF
--- a/integration
+++ b/integration
@@ -1,4 +1,5 @@
 [
+  
   "007hacky007/car_maintenance",
   "0jety0/emaux_spv150",
   "0xAHA/airtouch4_advanced",
@@ -3204,6 +3205,7 @@
   "xraver/mercedes_me_api",
   "xtimmy86x/ha-s7plc",
   "Xunil99/ha-bosch-ebike",
+  "Xygen/EcoFlow-PowerPulse-2-for-Home-Assistant",
   "yandex/pogoda-home-assistant",
   "yangqian/hass-hk_air_quality",
   "yashijoe/ha-cameconnect",

--- a/integration
+++ b/integration
@@ -1,5 +1,4 @@
 [
-  
   "007hacky007/car_maintenance",
   "0jety0/emaux_spv150",
   "0xAHA/airtouch4_advanced",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/Xygen/EcoFlow-PowerPulse-2-for-Home-Assistant/releases/tag/v1.0.1>
Link to successful HACS action (without the `ignore` key): <https://github.com/Xygen/EcoFlow-PowerPulse-2-for-Home-Assistant/actions/runs/33959934348>
Link to successful hassfest action (if integration): <https://github.com/Xygen/EcoFlow-PowerPulse-2-for-Home-Assistant/actions/runs/33959934348>