### PR TITLE
Adds new integration [xagon0/ha-gemstone-lights]

### DIFF
--- a/integration
+++ b/integration
@@ -3189,6 +3189,7 @@
   "WulfgarW/homeassistant-pycupra",
   "wuwentao/midea_ac_lan",
   "x1marc/homeassistant-judo-idos",
+  "xagon0/ha-gemstone-lights",
   "xannor/ha_reolink_discovery",
   "xathon/Allianz-BonusDrive-HomeAssistant",
   "Xerolux/idm-heatpump-hass",


### PR DESCRIPTION
Home Assistant integration for Gemstone Lights permanent outdoor lighting (Hub2). Domain: `gemstone_lights`.

Repository: https://github.com/xagon0/ha-gemstone-lights

Latest release: https://github.com/xagon0/ha-gemstone-lights/releases/tag/v1.4.3

CI action run (HACS action and hassfest, both passing with no ignores): https://github.com/xagon0/ha-gemstone-lights/actions/runs/33978608582

Checklist:

- [x] The repository can be added to HACS as a custom repository.
- [x] The repository is public and hosted on GitHub.
- [x] The HACS action and hassfest both pass, with no `ignore` entries.
- [x] A full release was created after the actions passed.
- [x] The entry was added alphabetically rather than at the end.
- [x] Submitted from a personal account, so the PR is editable.

The integration ships its own brand icon under `custom_components/gemstone_lights/brand/`, per the 2026.3 change to brand handling.