### PR TITLE
Update integration

### DIFF
--- a/integration
+++ b/integration
@@ -1047,6 +1047,7 @@
   "fondberg/spotcast",
   "foureight84/CallAttendantNext_Monitor",
   "fourmajor/ha-whisker-ting",
+  "MrHC1983/FoxESS-Export-Control",
   "Foxi352/pollen_lu",
   "FoxXxHater/leasing-tracker",
   "fr33mang/homeassistant-elnur-gabarron",


### PR DESCRIPTION
## New default repository

This PR adds the following repository to the HACS default integration list:

- MrHC1983/FoxESS-Export-Control

The repository is a Home Assistant custom integration for controlling the FoxESS inverter export-limit setting through the FoxESS Cloud API.

### Validation

- HACS validation passes
- Hassfest passes
- Repository has a valid `hacs.json`
- Integration includes required brand assets
- Repository has a published release

The integration is independently developed and is not affiliated with or endorsed by FoxESS, Amber Electric, or Home Assistant.