### PR TITLE
Adds new integration [dasimon135/ha-bluesight]

### DIFF
--- a/integration
+++ b/integration
@@ -718,6 +718,7 @@
   "DarwinsBuddy/WienerNetzeSmartmeter",
   "DasBasti/SmartHashtag",
   "dasimon135/daikin_madoka",
+  "dasimon135/ha-bluesight",
   "dasshubham762/atomberg-integration",
   "dave-code-ruiz/elkbledom",
   "dave-code-ruiz/uhomeuponor",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

- Repository: https://github.com/dasimon135/ha-bluesight
- Validation run (HACS + hassfest, both passing, no `ignore` key): https://github.com/dasimon135/ha-bluesight/actions/runs/34064206152
- Latest release: https://github.com/dasimon135/ha-bluesight/releases/tag/v0.7.1

Read-only Home Assistant integration that surfaces the GATT connection-slot allocations of ESPHome Bluetooth proxies, and detects deadlocks, ghost slots and pairing storms.
