### PR TITLE
Adds new integration [moryoav/ha-gwm-ev]

### DIFF
--- a/integration
+++ b/integration
@@ -2058,6 +2058,7 @@
   "moryoav/ha-addons",
   "moryoav/ha-anylist",
   "moryoav/ha-gwm-ev",
+  "moryoav/ha-gwm_ora",
   "moryoav/ha-knob-navigation",
   "moryoav/ha-panda",
   "moryoav/home-assistant-codex",

--- a/integration
+++ b/integration
@@ -2057,7 +2057,7 @@
   "MortUK/Aferiy-PS240-Local-",
   "moryoav/ha-addons",
   "moryoav/ha-anylist",
-  "moryoav/ha-gwm_ora",
+  "moryoav/ha-gwm-ev",
   "moryoav/ha-knob-navigation",
   "moryoav/ha-panda",
   "moryoav/home-assistant-codex",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/moryoav/ha-gwm-ev/releases/tag/v0.17.2>
Link to successful HACS action (without the `ignore` key): <https://github.com/moryoav/ha-gwm-ev/actions/runs/34122653340>
Link to successful hassfest action (if integration): <https://github.com/moryoav/ha-gwm-ev/actions/runs/34122653341>

## Description

I maintain both repositories and would like to add `moryoav/ha-gwm-ev` as the maintained successor to `moryoav/ha-gwm_ora`.

My original integration was accepted in #8714. Its listed URL now redirects to `moryoav/ha-gwm`, which I have archived. I continue development in `moryoav/ha-gwm-ev`, a separate repository for the current GWM integration.

I kept the `gwm_ora` Home Assistant domain. The current integration connects directly to GWM cloud services and requires a fresh sign-in with a dedicated account. This listing change does not migrate existing credentials or configuration entries.

I included the required country metadata and local brand assets in v0.17.2. All nine HACS checks and Hassfest passed before I published that release. The full Python suite also passed 1,356 tests: <https://github.com/moryoav/ha-gwm-ev/actions/runs/34122372172>.

I added only the new repository entry and kept the list sorted. I requested removal of the archived listing separately in https://github.com/hacs/integration/issues/5528.

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->