### PR TITLE
Adds new plugin [hoizi89/power-origin-card]

### DIFF
--- a/plugin
+++ b/plugin
@@ -260,6 +260,7 @@
   "hasl-sensor/lovelace-hasl-traffic-status-card",
   "hatools93/climate-timer",
   "hepter/ha-tplink-router-card",
+  "hoizi89/power-origin-card",
   "homeassistant-extras/adguard-card",
   "homeassistant-extras/device-card",
   "homeassistant-extras/ohm-assistant",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: <https://github.com/hoizi89/power-origin-card/releases/tag/v0.2.1>
Link to successful HACS action (without the `ignore` key): <https://github.com/hoizi89/power-origin-card/actions/runs/34163744940/job/101870602084>
Link to successful hassfest action (if integration): <n/a, this is a plugin>

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->
