### PR TITLE
Adds new integration [GImDX/kc761-ha]

### DIFF
--- a/integration
+++ b/integration
@@ -1137,6 +1137,7 @@
   "gieljnssns/kostalpiko-sensor-homeassistant",
   "gillesvs/librelink",
   "gilsonmandalogo/hacs-minerstat",
+  "GImDX/kc761-ha",
   "GimpArm/schellenberg_usb",
   "gjocys/ha-recom-modbus",
   "gjohansson-ST/attribute_as_sensor",


### PR DESCRIPTION
## Checklist

- [x] Read the [HACS publishing requirements](https://www.hacs.xyz/docs/publish/start/).
- [x] HACS validation is configured in the repository workflow.
- [x] Hassfest validation is configured for this integration.
- [x] Both validations pass; no checks are disabled or ignored.
- [x] Successful workflow links are provided below.
- [x] A complete Release was published after those successful validations.

## Links

- Latest release: [v0.2.0](https://github.com/GImDX/kc761-ha/releases/tag/v0.2.0)
- Successful HACS validation, without ignored checks: [main validation job](https://github.com/GImDX/kc761-ha/actions/runs/34298900644/job/102301415724)
- Successful Hassfest validation: [main validation job](https://github.com/GImDX/kc761-ha/actions/runs/34298900644/job/102301415724)

## Repository

Add `GImDX/kc761-ha` to the integration list. I am the repository owner.

KC761x integrates KC761-series radiation instruments with Home Assistant over TCP or Bluetooth LE. It provides readings, device status, and a bundled spectrum card with saved-spectrum selection and CSV export. Device writes are disabled by default. The README and release notes explicitly document the supported scope and remaining hardware limitations.

Release and validation commit: `500ffaa7168bff4664415374ff595837bf0d23e2`.
