### PR TITLE
Adds new integration [Cebbas/cal_activity_sensors]

### DIFF
--- a/integration
+++ b/integration
@@ -497,6 +497,7 @@
   "cbetz/ratebook-homeassistant",
   "ccsliinc/ha-smart-sprinkler-control",
   "cdnninja/yoto_ha",
+  "Cebbas/cal_activity_sensors",
   "Cebbas/smart_pump_scheduler",
   "cedricziel/ha-matter-binding-helper",
   "cedricziel/ha-sunlit",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: https://github.com/Cebbas/cal_activity_sensors/releases/tag/v0.0.7
Link to successful HACS action (without the `ignore` key): https://github.com/Cebbas/cal_activity_sensors/actions/runs/34400080061/job/102629499801
Link to successful hassfest action (if integration): https://github.com/Cebbas/cal_activity_sensors/actions/runs/34400080061/job/102629500104