### PR TITLE
Adds new integration [Cebbas/family-planner-card]

### DIFF
--- a/integration
+++ b/integration
@@ -497,6 +497,7 @@
   "cbetz/ratebook-homeassistant",
   "ccsliinc/ha-smart-sprinkler-control",
   "cdnninja/yoto_ha",
+  "Cebbas/family-planner-card",
   "Cebbas/smart_pump_scheduler",
   "cedricziel/ha-matter-binding-helper",
   "cedricziel/ha-sunlit",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: https://github.com/Cebbas/family-planner-card/releases/tag/0.4.40
Link to successful HACS action (without the `ignore` key): https://github.com/Cebbas/family-planner-card/actions/runs/34400305609/job/102630261466
Link to successful hassfest action (if integration): https://github.com/Cebbas/family-planner-card/actions/runs/34400305609/job/102630261803