### PR TITLE
Adds new plugin [ADNPolymerase/ha-tenup-resa-card]

### DIFF
--- a/plugin
+++ b/plugin
@@ -18,6 +18,7 @@
   "ADNPolymerase/ha-dosing-tank-card",
   "ADNPolymerase/ha-gate-card",
   "ADNPolymerase/ha-pluviometer-card",
+  "ADNPolymerase/ha-tenup-resa-card",
   "ADNPolymerase/oklyn-card",
   "ADNPolymerase/poollab-card",
   "aex351/home-assistant-neerslag-card",


### PR DESCRIPTION
## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

Link to current release: https://github.com/ADNPolymerase/ha-tenup-resa-card/releases/tag/v0.7.0
Link to successful HACS action (without the `ignore` key): https://github.com/ADNPolymerase/ha-tenup-resa-card/actions/runs/34654992254
Link to successful hassfest action (if integration): N/A (Lovelace plugin, not an integration)

## Repository

https://github.com/ADNPolymerase/ha-tenup-resa-card

## Description

The reservation grid of a French tennis club, drawn from Ten'Up (Fédération Française de Tennis), as a Lovelace card. One tab per day, the club courts in columns, and four cell colours: free, free but needing a second player, taken by someone else, and yours. Tap a free slot to book it, tap your own to cancel it, both behind a confirmation, and the cell says so while Ten'Up is still answering.

Every day shares one time axis, so a cell keeps the same size whether the day is empty or fully booked. Courts that require two players are not bookable from the card yet, so they carry a badge and a direct link to the right day on Ten'Up instead of failing silently.

Follow a player and their bookings turn purple across the whole grid. Two ways in, both writing the same list held by the integration: tap someone's booking, or open the manager from the header. Matching ignores accents and case and only accepts whole words, and with names hidden they are never sent to the card at all, so following from the grid is disabled rather than leaking them.

Visual editor for every option, no build step and no dependency, 127 behaviour assertions run in CI. Companion to the [Ten'Up integration](https://github.com/ADNPolymerase/ha-tenup-resa).

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->
