### PR TITLE
Adds new integration [javaDevJT/home-assistant-openai-codex]

### DIFF
--- a/integration
+++ b/integration
@@ -1415,6 +1415,7 @@
   "jasperslits/haithowifi",
   "javaDevJT/DTE-Rates-for-Home-Assistant",
   "javaDevJT/ha-rccl",
+  "javaDevJT/home-assistant-openai-codex",
   "Javisen/proxmox_sensors",
   "JaviSoto/homeassistant-quilt",
   "JayBlackedOut/hass-nhlapi",


### PR DESCRIPTION
Adds OpenAI Codex Conversation, an independent Home Assistant conversation integration using ChatGPT device-code sign-in instead of an API key. It supports Assist conversations, follow-up history, and optional control through Home Assistant's exposed tools. The integration uses its own `openai_codex` domain and does not override a Home Assistant core integration.

## Checklist

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions run successfully.

## Links

Link to current release: https://github.com/javaDevJT/home-assistant-openai-codex/releases/tag/v0.1.2

Link to successful HACS action (without the `ignore` key): https://github.com/javaDevJT/home-assistant-openai-codex/actions/runs/34758408402/job/103726737050

Link to successful hassfest action (if integration): https://github.com/javaDevJT/home-assistant-openai-codex/actions/runs/34758408402/job/103726737043

<!-- tid:73253df5-5376-4e68-8c16-b234da6a2de3 -->
